### PR TITLE
Make arrows disappear on blob hit

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -436,6 +436,10 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 			{
 				ArrowHitMap(this, worldPoint, velocity, damage, Hitters::arrow);
 			}
+			else
+			{
+				this.server_Die();
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, arrows are not removed on blob hit.
As a result they're stuck at `Vec2f_zero` (for 20 seconds).