### PR TITLE
Slight modability improvement for custom blocks

### DIFF
--- a/Entities/Materials/MaterialCommon.as
+++ b/Entities/Materials/MaterialCommon.as
@@ -7,6 +7,8 @@
 // the server-side. An example can
 // be found in Log.as
 
+#include "CustomBlocks.as";
+
 namespace Material
 {
   const float MERGE_RADIUS = 20.0f;
@@ -224,6 +226,10 @@ namespace Material
     else if (map.isTileGold(type))
     {
       createFor(this, 'mat_gold', 4 * damage);
+    }
+    else
+    {
+      MaterialFromCustomTile(this, type, damage);
     }
   }
 }

--- a/Scripts/MapLoaders/CustomBlocks.as
+++ b/Scripts/MapLoaders/CustomBlocks.as
@@ -9,6 +9,8 @@
  *		Note: don't modify this file directly, do it in a mod!
  */
 
+//#include MaterialCommon.as;
+
 namespace CMap
 {
 	enum CustomTiles
@@ -18,7 +20,17 @@ namespace CMap
 	};
 };
 
+//Map loading
 void HandleCustomTile(CMap@ map, int offset, SColor pixel)
 {
 	//change this in your mod
+}
+
+//Harvesting
+void MaterialFromCustomTile(CBlob@ this, uint16 &in type, float &in damage)
+{
+  if (type == CMap::tile_whatever)
+  {
+    //Material::createFor(this, 'mat_whatever', damage);
+  }
 }


### PR DESCRIPTION
Just a very small modability improvement, that lets modders not just create custom blocks that serve no purpose, but can be harvested by a builder's pickaxe or drill. Without messing with vanilla scripts needlessly.