### PR TITLE
[modified] pickup priority tweaks

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -176,46 +176,51 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b, f32 scale)
 {
 	u32 gameTime = getGameTime();
 
-	// 0
-	// exploding stuff + crates unpacking
-	{
-		u32 unpackTime = b.get_u32("unpack time");
-		if (b.hasTag("exploding") || unpackTime > gameTime)
-		{
-			scale *= 0.1f;
-		}
-
-		//special stuff - flags etc
-		if (b.hasTag("special"))
-		{
-			scale *= 0.01f;
-		}
-	}
-
-	// 1
-	// combat items, important
 	const string name = b.getName();
+	u32 unpackTime = b.get_u32("unpack time");
+
+	//special stuff - flags etc
+	if (b.hasTag("special"))
 	{
-		if (name == "boulder" || name == "drill" || name == "keg" ||
-		        name == "mine" || name == "satchel" || name == "crate")
-		{
-			scale *= 0.41f;
-		}
+		scale *= 0.01f;
 	}
 
+	// exploding stuff + crates unpacking
+	if (b.hasTag("exploding") || unpackTime > gameTime)
+	{
+		scale *= 0.1f;
+	}
+
+	// combat items, important
+	if (name == "boulder" || name == "drill" || name == "keg" ||
+	    name == "mine" || name == "satchel" || name == "crate")
+	{
+		scale *= 0.41f;
+	}
+	
+	// builder materials
+	{
+		if (name == "mat_gold")
+		{
+			scale *= 0.7f;
+		}
+		if (name == "mat_stone")
+		{
+			scale *= 0.9f;
+		}
+	}
+	
 	//low priority
 	if (name == "log" || b.hasTag("player"))
 	{
 		scale *= 5.0f;
 	}
 
-	// super low priority
-	// dead stuff, sick of picking up corpses
+	// super low priority, dead stuff - sick of picking up corpses
+	if (b.hasTag("dead"))
 	{
-		if (b.hasTag("dead"))
-		{
-			scale *= 10.0f;
-		}
+		scale *= 10.0f;
+		scale += 20.0f;
 	}
 
 	const string thisname = this.getName();

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -192,7 +192,7 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b, f32 scale)
 	}
 
 	// combat items, important
-	if (name == "boulder" || name == "drill" || name == "keg" ||
+	if (name == "boulder" || name == "drill" || name == "keg" || name == "saw" ||
 	    name == "mine" || name == "satchel" || name == "crate")
 	{
 		scale *= 0.41f;


### PR DESCRIPTION
-corpses made super low priority (used to still have decent priority when extremely close)
-added builder materials priority (gold > stone > wood)
-added saw to combat items (will ensure saw > seed for wood farms)