### PR TITLE
Fix endless TTH games

### DIFF
--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -916,6 +916,41 @@ void onInit(CRules@ this)
 	this.set_s32("restart_rules_after_game_time", 25 * 30);
 }
 
+void onStateChange(CRules@ this, const u8 oldState)
+{
+	RulesCore@ core;
+	this.get("core", @core);
+
+	if (core is null)
+	{
+		return;
+	}
+
+	if (this.getCurrentState() == GAME)
+	{
+		bool[] teamHalls(core.teams.length, false); // wat, doesn't default to false?
+
+		CBlob@[] rooms;
+		getBlobsByName("hall", @rooms);
+		for (uint i = 0; i < rooms.length; ++i)
+		{
+			CBlob@ room = rooms[i];
+			const u8 team = room.getTeamNum();
+			if (team < teamHalls.length)
+			{
+				teamHalls[team] = true;
+			}
+		}
+
+		for (uint i = 0; i < teamHalls.length; ++i)
+		{
+			if (teamHalls[i] == false)
+			{
+				core.teams[i].lost = true;
+			}
+		}
+	}
+}
 
 void CheckWin(CRules@ this, CBlob@ blob, const int oldTeam)
 {

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -651,6 +651,8 @@ shared class WarCore : RulesCore
 		}
 		if (lostCount > 1)
 		{
+			rules.SetCurrentState(GAME_OVER);
+			rules.SetGlobalMessage("It's a tie!");
 			return; // tie condition - no halls
 		}
 		else if (lostCount == 1)


### PR DESCRIPTION
See this [bug report](https://forum.thd.vg/threads/2311-never-ending-tth-game.27231/).

The game now checks when warmup finishes for the following cases:
- When one team caps a hall but not the other, the former wins.
- When no team caps halls, it's a tie.