### PR TITLE
[modified] ignore item aim when tapping pickup

### DIFF
--- a/Entities/Common/Controls/StandardControlsCommon.as
+++ b/Entities/Common/Controls/StandardControlsCommon.as
@@ -24,7 +24,18 @@ void Tap(CBlob@ this)
 	this.set_s32("tap_time", getGameTime());
 }
 
+void TapPickup(CBlob@ this)
+{
+	this.set_s32("tap_pickup_time", getGameTime());
+}
+
 bool isTap(CBlob@ this, int ticks = 15)
 {
 	return (getGameTime() - this.get_s32("tap_time") < ticks);
+}
+
+bool isTapPickup(CBlob@ this, int ticks = 15)
+{
+	// TODO: merge some code with the above and make it generalized to all keys if ever useful
+	return (getGameTime() - this.get_s32("tap_pickup_time") < ticks);
 }

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -31,6 +31,8 @@ void onTick(CBlob@ this)
 	// drop / pickup / throw
 	if (this.isKeyJustPressed(key_pickup))
 	{
+		TapPickup(this);
+
 		CBlob @carryBlob = this.getCarriedBlob();
 
 		/*if (isTap( this ))	tap pickup
@@ -349,10 +351,13 @@ CBlob@ getClosestBlob(CBlob@ this)
 			FillAvailable(this, available, pickupBlobs);
 		}
 
-		CBlob@ closestAimed = getClosestAimedBlob(this, available);
-		if (closestAimed !is null)
+		if (!isTapPickup(this))
 		{
-			return closestAimed;
+			CBlob@ closestAimed = getClosestAimedBlob(this, available);
+			if (closestAimed !is null)
+			{
+				return closestAimed;
+			}
 		}
 
 		float closestFactor = 999999.9f;


### PR DESCRIPTION
This should make it hopefully more reliable to tap [C] during a battle so it doesn't pickup aimed items in an undesired way by introducing a 15 ticks (0.5 second) delay before aim is taken into account for pickup.
It might be worth merging all the tap logic for all keys in one place if the logic happens to be copied across scripts maybe?