### PR TITLE
 Add support for customizable redzone

### DIFF
--- a/Rules/CommonScripts/RedBarrier.as
+++ b/Rules/CommonScripts/RedBarrier.as
@@ -84,11 +84,28 @@ void onRender(CRules@ this)
 void getBarrierPositions(f32 &out x1, f32 &out x2, f32 &out y1, f32 &out y2)
 {
 	CMap@ map = getMap();
+
 	const f32 mapWidth = map.tilemapwidth * map.tilesize;
 	const f32 mapMiddle = mapWidth * 0.5f;
 	const f32 barrierWidth = BARRIER_PERCENT * mapWidth;
+
+	// set horizontal positions based on BARRIER_PERCENT
 	x1 = mapMiddle - barrierWidth;
 	x2 = mapMiddle + barrierWidth;
+
+	// overwrite x1 and x2 if 2 red barrier markers are found
+	Vec2f[] barrierPositions;
+	if (map.getMarkers("red barrier", barrierPositions))
+	{
+		if (barrierPositions.length() == 2)
+		{
+			int left = barrierPositions[0].x < barrierPositions[1].x ? 0 : 1;
+			x1 = barrierPositions[left].x;
+			x2 = barrierPositions[1 - left].x;
+		}
+	}
+
+	// set vertical positions
 	y2 = map.tilemapheight * map.tilesize;
 	y1 = -y2;
 	y2 *= 2.0f;

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -237,6 +237,9 @@ class PNGLoader
 			case map_colors::aqua_main_spawn:   autotile(offset); spawnHall(map, offset, 5); break;
 			case map_colors::teal_main_spawn:   autotile(offset); spawnHall(map, offset, 6); break;
 			case map_colors::gray_main_spawn:   autotile(offset); spawnHall(map, offset, 7); break;
+
+			// Red Barrier
+			case map_colors::redbarrier:    autotile(offset); AddMarker(map, offset, "red barrier");  break;
 			
 			// Normal spawns
 			case map_colors::blue_spawn:     autotile(offset); AddMarker(map, offset, "blue spawn");   break;

--- a/Scripts/MapLoaders/LoaderColors.as
+++ b/Scripts/MapLoaders/LoaderColors.as
@@ -256,5 +256,8 @@ namespace map_colors
 
 		// TUTORIAL
 		dummy                  = 0xFFE78C43, // ARGB(255, 231, 140,  67);
+
+		// RED BARRIER
+		redbarrier			   = 0xFFE43771
 	};
 }


### PR DESCRIPTION
Title.

Add two `A5BDC8` coloured pixels on your map's png to use custom red barrier coordinates. Example:
![image](https://user-images.githubusercontent.com/4616537/40448744-b602f438-5ed6-11e8-935f-68a5f53508ff.png)
