### PR TITLE
Fix archer grapple beyond the map top 

### DIFF
--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -497,7 +497,8 @@ void doRopeUpdate(CSprite@ this, CBlob@ blob, ArcherInfo@ archer)
 		return;
 	}
 
-	Vec2f off = archer.grapple_pos - blob.getPosition();
+	Vec2f adjusted_pos = Vec2f(archer.grapple_pos.x, Maths::Max(0.0, archer.grapple_pos.y));
+	Vec2f off = adjusted_pos - blob.getPosition();
 
 	f32 ropelen = Maths::Max(0.1f, off.Length() / 32.0f);
 	if (ropelen > 200.0f)

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -623,6 +623,8 @@ bool checkGrappleStep(CBlob@ this, ArcherInfo@ archer, CMap@ map, const f32 dist
 
 		archer.grapple_ratio = Maths::Max(0.2, Maths::Min(archer.grapple_ratio, dist / archer_grapple_length));
 
+		archer.grapple_pos.y = Maths::Max(0.0, archer.grapple_pos.y);
+
 		if (canSend(this)) SyncGrapple(this);
 
 		return true;


### PR DESCRIPTION
- The grapple hook is not physically affected during its movement when it's beyond the map top, but will visually look capped to the map top. It looked off when the grapple would hit a topmost block enough for me to think it's a better thing to deal with it like that.
- When the grapple hook hits a block, its position is clamped to the map top (this is the actual fix).

The other option would have been to just let the grapple go when it's over the map top.