### PR TITLE
Adds Stalemates to CTF

### DIFF
--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -80,6 +80,16 @@ void onTick(CBlob@ this)
 					this.server_AttachTo(b, "FLAG");
 					b.SetFacingLeft(this.isFacingLeft());
 				}
+				if (b.hasTag("stalemate_return"))
+				{
+					//sync tag, flag can play sounds
+					b.server_DetachAll();
+					this.SendCommand(this.getCommandID(flag_return));
+					b.Untag("stalemate_return"); //local
+
+					this.server_AttachTo(b, "FLAG");
+					b.SetFacingLeft(this.isFacingLeft());
+				}
 			}
 			else
 			{

--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -82,7 +82,6 @@ void onTick(CBlob@ this)
 				}
 				if (b.hasTag("stalemate_return"))
 				{
-					//sync tag, flag can play sounds
 					b.server_DetachAll();
 					this.SendCommand(this.getCommandID(flag_return));
 					b.Untag("stalemate_return"); //local

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -23,7 +23,7 @@ void Config(CTFCore@ this)
 
 	//how long to wait for everyone to spawn in?
 	s32 warmUpTimeSeconds = cfg.read_s32("warmup_time", 30);
-	this.warmUpTime = 1;//(getTicksASecond() * warmUpTimeSeconds);
+	this.warmUpTime = (getTicksASecond() * warmUpTimeSeconds);
 
 	s32 stalemateTimeSeconds = cfg.read_s32("stalemate_time", 30);
 	this.stalemateTime = (getTicksASecond() * stalemateTimeSeconds);
@@ -603,42 +603,56 @@ shared class CTFCore : RulesCore
 			}
 		}
 
-		if(stalemate){
-			if(!rules.exists("stalemate_breaker")){
-				rules.set_s16("stalemate_breaker",stalemateTime);
-			} else {
-				rules.sub_s16("stalemate_breaker",1);
+		if(stalemate)
+		{
+			if(!rules.exists("stalemate_breaker"))
+			{
+				rules.set_s16("stalemate_breaker", stalemateTime);
+			} 
+			else 
+			{
+				rules.sub_s16("stalemate_breaker", 1);
 			}
 			
-			if((rules.get_s16("stalemate_breaker")/30) > 0){
+			if((rules.get_s16("stalemate_breaker")/30) > 0)
+			{
 				rules.SetGlobalMessage("Stalemate: both teams have no flags.\nFlags respawning in: "+(rules.get_s16("stalemate_breaker")/30));
-			} else {
-				rules.set_s16("stalemate_breaker",-60);
+			} 
+			else 
+			{
+				rules.set_s16("stalemate_breaker", -60);
 				
-				for (uint i = 0; i < flags.length; i++)
+				if(isServer())
 				{
-					CBlob @flag = flags[i];
-					if (flag !is null)
+					for (uint i = 0; i < flags.length; i++)
 					{
-						flag.Tag("stalemate_return");
-						if(isServer())flag.Sync("stalemate_return",true);
+						CBlob @flag = flags[i];
+						if (flag !is null)
+						{
+							flag.Tag("stalemate_return");
+						}
 					}
 				}
 			}
 			
-		} else {
+		} 
+		else 
+		{
 			int stalemate_timer = rules.get_s16("stalemate_breaker");
-			if(stalemate_timer > -10 && stalemate_timer != stalemateTime){
+			if(stalemate_timer > -10 && stalemate_timer != stalemateTime)
+			{
 				rules.SetGlobalMessage("");
-				rules.set_s16("stalemate_breaker",stalemateTime);
-			} else
-			if(stalemate_timer <= -10){
+				rules.set_s16("stalemate_breaker", stalemateTime);
+			} else ///??? how the hell are elses stylised if not like this?
+			if(stalemate_timer <= -10)
+			{
 				rules.SetGlobalMessage("Stalemate resolved: Flags returned.");
-				rules.add_s16("stalemate_breaker",1);
+				rules.add_s16("stalemate_breaker", 1);
 			}
 		}
 		
-		if(isServer())rules.Sync("stalemate_breaker",true);
+		if(isServer())
+			rules.Sync("stalemate_breaker",true);
 	}
 
 	void addKill(int team)

--- a/Rules/CTF/ctf_vars.cfg
+++ b/Rules/CTF/ctf_vars.cfg
@@ -13,5 +13,9 @@
 	#anything less than 0 means the game never ends
 	game_time = -1; #minutes
 	
+	#stalemate time in seconds. stalemate occurs on both teams having eachothr's flags with none of thier own. this is the time until flags are reset
+	#less than 0 turns this feature off
+	stalemate_time = 60
+	
 	#whether to scramble teams each game
 	scramble_teams = true;


### PR DESCRIPTION
Upon both teams capturing eachother's flags at the same time, a timer will start which will return all flags after a configurable amount of time. The timer can also be disabled in cfgs.