### PR TITLE
[modified] Gold material now stacks to 100 (two lumps of 50)

### DIFF
--- a/Entities/Materials/Construction/MaterialGold.as
+++ b/Entities/Materials/Construction/MaterialGold.as
@@ -1,7 +1,7 @@
 
 void onInit(CBlob@ this)
 {
-  this.maxQuantity = 250;
+  this.maxQuantity = 50;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }


### PR DESCRIPTION
It's better this way because:
- Easily grabbable chunks of 50 which is how gold is always spent, so you don't have to run out of base with your team's entire gold supply if you want to set up a tunnel
- Harder (but still possible) for one team to collect all the gold and hoard it at their base
- Easier to see when a functional amount (50) is lying on the ground instead of the current small yellow pebble
- Mining 5 blocks of ore gives you an even 100 gold anyway