### PR TITLE
[modified] Gold ore tiles yield 5 (instead of 4) gold per hit

### DIFF
--- a/Entities/Materials/MaterialCommon.as
+++ b/Entities/Materials/MaterialCommon.as
@@ -224,7 +224,7 @@ namespace Material
     }
     else if (map.isTileGold(type))
     {
-      createFor(this, 'mat_gold', 4.f * damage);
+      createFor(this, 'mat_gold', 5.f * damage);
     }
   }
 }


### PR DESCRIPTION
So each block of ore is worth 25 gold instead of 20.
- 50 gold every two blocks instead of the current 52 every two and 3/5 blocks
- Much neater stacking / spending
- This will add more gold to every map, but just one functional unit (50) per 10 ore tiles on the map so it doesn't seem that drastic to me. Especially if there's a new gold workshop being added anyway