### PR TITLE
Make Boulders Fit in Inventory

### DIFF
--- a/Entities/Items/Boulder/Boulder.cfg
+++ b/Entities/Items/Boulder/Boulder.cfg
@@ -113,9 +113,9 @@ f32 health                          = 1.5
 # looks & behaviour inside inventory
 $inventory_name                     = Boulder
 $inventory_icon                     = -             # default
-u8 inventory_icon_frame             = 0
+u8 inventory_icon_frame             = 3
 u8 inventory_icon_frame_width       = 0
 u8 inventory_icon_frame_height      = 0
-u8 inventory_used_width             = 3
-u8 inventory_used_height            = 3
+u8 inventory_used_width             = 2
+u8 inventory_used_height            = 2
 u8 inventory_max_stacks             = 1


### PR DESCRIPTION
Make the boulders 2x2 so they can fit in a normal class's (and storage shop's) inventory. Also changed the icon's specific sprite frame so it doesn't look as bad in the hot bar when in the player's inventory.