### PR TITLE
Builder quickswap fixes/tweaks

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -321,6 +321,11 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 				blob.SendCommand(Builder::make_block + blob.get_u8("prev block"));
 			}
 		}
+		
+		if (this.isMyPlayer())
+		{
+			Sound::Play("/CycleInventory.ogg");
+		}
 	}
 }
 

--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -258,8 +258,17 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 
 			if (blob.get_u8("current block") != i)
 			{
-				blob.set_u8("prev block", blob.get_u8("current block"));
-				blob.set_u8("current block", i);
+				if (block.name == "building")
+				{
+					u8 temp = blob.get_u8("current block");
+					blob.set_u8("current block", blob.get_u8("prev block"));
+					blob.set_u8("prev block", temp);
+				}
+				else
+				{
+					blob.set_u8("prev block", blob.get_u8("current block"));
+					blob.set_u8("current block", i);
+				}
 			}
 		}
 	}
@@ -321,8 +330,8 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 				blob.SendCommand(Builder::make_block + blob.get_u8("prev block"));
 			}
 		}
-		
-		if (this.isMyPlayer())
+
+		if (blob.isMyPlayer())
 		{
 			Sound::Play("/CycleInventory.ogg");
 		}


### PR DESCRIPTION
It was supposed to make a sound effect so it's more obvious what just happened and less confusing if you accidentally use the quickswap. It's the same sound effect that plays when you tap F as archer/knight.

Also, it was kind of weird that you could "quickswap" to the building, because that has the effect of immediately using 150 wood, so it should ignore building selection.