### PR TITLE
[modified] All wooden blocks (platform + door) now at wooden coin rate (1 coin per block)

### DIFF
--- a/Rules/CTF/Scripts/CTF_Trading.as
+++ b/Rules/CTF/Scripts/CTF_Trading.as
@@ -182,12 +182,16 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 					g.params.ResetBitIndex();
 					string name = g.params.read_string();
 
-					if (name.findFirst("door") != -1 ||
-					        name == "wooden_platform" ||
+					if (name == "stone_door" ||
 					        name == "trap_block" ||
 					        name == "spikes")
 					{
 						coins = coinsOnBuild;
+					}
+					else if (name == "wooden_platform" ||
+								name == "wooden_door")
+					{
+						coins = coinsOnBuildWood;
 					}
 					else if (name == "building")
 					{


### PR DESCRIPTION
It honestly seems like it might have been an accident that the wooden blocks other than the tile were ever worth coinsOnBuild instead of coinsOnBuildWood.

I know it's going to be hard for some of us (myself included) to be unable to earn mad dosh by spamming platforms at the tent, but that was always cheesy and we all know it.

I feel like even with this change, builders who are actually building legit useful structures are still gonna manage to accumulate lots of coins with relative ease, but it is gonna kind of put a damper on that. Maybe they'll end up with like 100 coins instead of 400. Maybe that's a good thing.

As I see it, the main problem that might arise from this change is people mining stone near tent in order to immediately waste it on coinfarming, but uh, I don't know what to do about that. Maybe it's their problem.