### PR TITLE
Re-Adds Crates to CTF and Reworks them

### DIFF
--- a/Entities/Characters/Scripts/RunnerDrowning.as
+++ b/Entities/Characters/Scripts/RunnerDrowning.as
@@ -12,6 +12,7 @@ void onInit(CBlob@ this)
 	this.set_u8("air_count", default_aircount);
 	this.getCurrentScript().removeIfTag = "dead";
 	this.getCurrentScript().tickFrequency = FREQ; // opt
+	this.getCurrentScript().runFlags &= Script::tick_ininventory;
 }
 
 void onTick(CBlob@ this)
@@ -25,6 +26,8 @@ void onTick(CBlob@ this)
 		Vec2f pos = this.getPosition();
 		const bool inwater = this.isInWater() && this.getMap().isInWater(pos + Vec2f(0.0f, -this.getRadius() * 0.66f));
 
+		const bool suffocating = this.isInInventory();
+		
 		u8 aircount = this.get_u8("air_count");
 
 		this.getCurrentScript().tickFrequency = FREQ;
@@ -42,6 +45,22 @@ void onTick(CBlob@ this)
 				this.server_Hit(this, pos, Vec2f(0, 0), 0.5f, Hitters::drown, true);
 				Sound::Play("Gurgle", pos, 2.0f);
 				aircount += 30;
+			}
+		}
+		else
+		if (suffocating)
+		{
+			const int SuffFreq = Maths::Max(FREQ/6,1);
+			if (aircount >= SuffFreq)
+			{
+				aircount -= SuffFreq;
+			}
+
+			//drown damage
+			if (aircount < SuffFreq)
+			{
+				this.server_Hit(this, pos, Vec2f(0, 0), 0.25f, Hitters::drown, true);
+				aircount += 60;
 			}
 		}
 		else

--- a/Entities/Common/Emotes/EmoteBubble.as
+++ b/Entities/Common/Emotes/EmoteBubble.as
@@ -29,6 +29,8 @@ void onInit(CBlob@ blob)
 	}
 
 	AddBubblesToMenu(blob);
+	
+	blob.getCurrentScript().runFlags &= Script::tick_ininventory;
 }
 
 
@@ -43,7 +45,7 @@ void onTick(CBlob@ blob)
 		CSpriteLayer@ emote = sprite.getSpriteLayer("bubble");
 
 		const u8 index = blob.get_u8("emote");
-		if (is_emote(blob, index) && !blob.hasTag("dead"))
+		if (is_emote(blob, index) && !blob.hasTag("dead") && !blob.isInInventory())
 		{
 			blob.getCurrentScript().tickFrequency = 1;
 			if (emote !is null)

--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -12,7 +12,8 @@ namespace CTFCosts
 	//Building.as
 	s32 buildershop_wood, quarters_wood, knightshop_wood, archershop_wood,
 		boatshop_wood, boatshop_gold, vehicleshop_wood, vehicleshop_gold,
-		storage_stone, storage_wood, tunnel_stone, tunnel_wood, tunnel_gold;
+		storage_stone, storage_wood, tunnel_stone, tunnel_wood, tunnel_gold,
+		quarry_stone, quarry_gold;
 
 	//ArcherShop.as
 	s32 arrows, waterarrows, firearrows, bombarrows;
@@ -22,7 +23,7 @@ namespace CTFCosts
 
 	//BuilderShop.as
 	s32 lantern_wood, bucket_wood, filled_bucket, sponge, boulder_stone,
-		trampoline_wood, saw_wood, saw_stone, drill_stone, drill;
+		trampoline_wood, saw_wood, saw_stone, drill_stone, drill, crate_wood;
 
 	//BoatShop.as
 	s32 dinghy, dinghy_wood, longboat, longboat_wood, warboat;
@@ -94,6 +95,8 @@ void InitCosts()
 	CTFCosts::tunnel_stone =                ReadCost(cfg, "cost_tunnel_stone"       , 100);
 	CTFCosts::tunnel_wood =                 ReadCost(cfg, "cost_tunnel_wood"        , 50);
 	CTFCosts::tunnel_gold =                 ReadCost(cfg, "cost_tunnel_gold"        , 50);
+	CTFCosts::quarry_stone =				ReadCost(cfg, "cost_quarry_stone"       , 150);
+	CTFCosts::quarry_gold =					ReadCost(cfg, "cost_quarry_gold"        , 100);
 
 	//ArcherShop.as
 	CTFCosts::arrows =                      ReadCost(cfg, "cost_arrows"             , 15);
@@ -118,6 +121,7 @@ void InitCosts()
 	CTFCosts::saw_stone =                   ReadCost(cfg, "cost_saw_stone"          , 100);
 	CTFCosts::drill_stone =                 ReadCost(cfg, "cost_drill_stone"        , 100);
 	CTFCosts::drill =                       ReadCost(cfg, "cost_drill"              , 25);
+	CTFCosts::crate_wood =                  ReadCost(cfg, "cost_crate_wood"         , 30);
 
 	//BoatShop.as
 	CTFCosts::dinghy =                      ReadCost(cfg, "cost_dinghy"             , 25);

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -53,13 +53,6 @@ void onInit(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::boulder_stone);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
-		s.customButton = true;
-		s.buttonwidth = 2;
-		s.buttonheight = 1;
-		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::boulder_stone);
-	}
-	{
 		ShopItem@ s = addShopItem(this, "Trampoline", "$trampoline$", "trampoline", Descriptions::trampoline, false);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::trampoline_wood);
 	}

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -53,6 +53,13 @@ void onInit(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::boulder_stone);
 	}
 	{
+		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::boulder_stone);
+	}
+	{
 		ShopItem@ s = addShopItem(this, "Trampoline", "$trampoline$", "trampoline", Descriptions::trampoline, false);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::trampoline_wood);
 	}
@@ -64,10 +71,17 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Saw", "$saw$", "saw", Descriptions::saw, false);
 		s.customButton = true;
-		s.buttonwidth = 2;
+		s.buttonwidth = 1;
 		s.buttonheight = 1;
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::saw_wood);
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::saw_stone);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Crate", "$crate$", "crate", Descriptions::crate, false);
+		s.customButton = true;
+		s.buttonwidth = 1;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::crate_wood);
 	}
 }
 

--- a/Entities/Industry/CTFShops/CTFCosts.cfg
+++ b/Entities/Industry/CTFShops/CTFCosts.cfg
@@ -14,13 +14,15 @@
 	cost_tunnel_stone               = 100
 	cost_tunnel_wood                = 50
 	cost_tunnel_gold                = 50
+	cost_quarry_stone               = 150
+	cost_quarry_gold                = 100
 
 	#knight shop
 	cost_bomb                       = 25
 	cost_waterbomb                  = 30
 	cost_mine                       = 60
 	cost_keg                        = 120
-	
+
 	#archer shop
 	cost_arrows                     = 15
 	cost_waterarrows                = 20
@@ -38,6 +40,7 @@
 	cost_saw_stone                  = 100
 	cost_drill_stone                = 100
 	cost_drill                      = 25
+	cost_crate_wood                 = 30
 
 	#boat shop
 	cost_dinghy                     = 25

--- a/Entities/Industry/CTFShops/CTFCosts.cfg
+++ b/Entities/Industry/CTFShops/CTFCosts.cfg
@@ -14,8 +14,6 @@
 	cost_tunnel_stone               = 100
 	cost_tunnel_wood                = 50
 	cost_tunnel_gold                = 50
-	cost_quarry_stone               = 150
-	cost_quarry_gold                = 100
 
 	#knight shop
 	cost_bomb                       = 25

--- a/Entities/Industry/CTFShops/Storage/AutoPickUpMats.as
+++ b/Entities/Industry/CTFShops/Storage/AutoPickUpMats.as
@@ -1,0 +1,28 @@
+
+void onInit(CBlob@ this){
+	this.getCurrentScript().tickFrequency = 60;
+}
+
+void onTick(CBlob@ this)
+{
+	PickupOverlap(this);
+}
+
+void PickupOverlap(CBlob@ this)
+{
+	if (getNet().isServer())
+	{
+		Vec2f tl, br;
+		this.getShape().getBoundingRect(tl, br);
+		CBlob@[] blobs;
+		this.getMap().getBlobsInBox(tl, br, @blobs);
+		for (uint i = 0; i < blobs.length; i++)
+		{
+			CBlob@ blob = blobs[i];
+			if (!blob.isAttached() && blob.isOnGround() && blob.hasTag("material") && blob.getName() != "mat_arrows")
+			{
+				this.server_PutInInventory(blob);
+			}
+		}
+	}
+}

--- a/Entities/Industry/CTFShops/Storage/Storage.as
+++ b/Entities/Industry/CTFShops/Storage/Storage.as
@@ -82,31 +82,6 @@ void onInit(CBlob@ this)
 	AddIconToken("$store_inventory$", "InteractionIcons.png", Vec2f(32, 32), 28);
 	this.inventoryButtonPos = Vec2f(12, 0);
 	this.addCommandID("store inventory");
-	this.getCurrentScript().tickFrequency = 60;
-}
-
-void onTick(CBlob@ this)
-{
-	PickupOverlap(this);
-}
-
-void PickupOverlap(CBlob@ this)
-{
-	if (getNet().isServer())
-	{
-		Vec2f tl, br;
-		this.getShape().getBoundingRect(tl, br);
-		CBlob@[] blobs;
-		this.getMap().getBlobsInBox(tl, br, @blobs);
-		for (uint i = 0; i < blobs.length; i++)
-		{
-			CBlob@ blob = blobs[i];
-			if (!blob.isAttached() && blob.isOnGround() && blob.hasTag("material") && blob.getName() != "mat_arrows")
-			{
-				this.server_PutInInventory(blob);
-			}
-		}
-	}
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Industry/CTFShops/Storage/Storage.cfg
+++ b/Entities/Industry/CTFShops/Storage/Storage.cfg
@@ -73,6 +73,7 @@ $name                                             = storage
 													IsFlammable.as;
 													BuildingEffects.as;
 													GenericDestruction.as;
+													AutoPickUpMats.as;
 f32_health                                        = 6.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Storage Cache

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -87,7 +87,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 void Blend(CBlob@ this, CBlob@ tobeblended)
 {
 	if (this is tobeblended || tobeblended.hasTag("sawed") ||
-	        tobeblended.hasTag("invincible") || !getSawOn(this))
+	        tobeblended.hasTag("invincible") || !getSawOn(this)
+			|| tobeblended.hasTag("saw_immune"))
 	{
 		return;
 	}

--- a/Entities/Items/Crate/Crate.cfg
+++ b/Entities/Items/Crate/Crate.cfg
@@ -67,7 +67,7 @@ $attachment_factory                               = box2d_attachment
 $inventory_factory                                = generic_inventory
 @$inventory_scripts                               =
 u8 inventory_slots_width                          = 4
-u8 inventory_slots_height                         = 4
+u8 inventory_slots_height                         = 2
 $inventory_name                                   = Crate
 
 $name                                             = crate

--- a/Entities/Items/Crate/Crate.cfg
+++ b/Entities/Items/Crate/Crate.cfg
@@ -78,6 +78,7 @@ $name                                             = crate
 													IsFlammable.as;
 													SetTeamToCarrier.as;
 													DecayIfSpammed;
+													AutoPickUpMats.as;
 f32 health                                        = 4.0
 $inventory_name                                   = Crate
 $inventory_icon                                   = -


### PR DESCRIPTION
A patch for July 2018 # 2 Bounty.

Other than allowing crates to be used as transport again, these changes also make it more useful as an inventory.

- Made crates 2 high invetory wise, to match storage.
- Players start suffocating (really slowly) if they stay in a crate far too long.
- When crates contain a player and they suffer a hard impact, they break. So you can throw teammates off of a cliff if they aren't be useful.
- Crates added to buildershop for 30 wood.
- Crates no longer get destroyed upon the last item being removed, however they still break when a player leaves them.
- Crates now automatically pick up materials they're overlapping, exactly the same as the storage building.
- Additionally, crates also now pick up any materials they collide with them.
- Crates are now immune to saws.
- Disabled emotes when inside inventories.