### PR TITLE
Makes bomb arrow damage consistant

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -221,6 +221,12 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			return;
 		}
 		else
+		if (arrowType == ArrowType::bomb)
+		{
+			this.server_Die();
+			return;
+		}
+		else
 		{
 			// this isnt synced cause we want instant collision for arrow even if it was wrong
 			dmg = ArrowHitBlob(this, point1, initVelocity, dmg, blob, Hitters::arrow, arrowType);


### PR DESCRIPTION
As requested in bounty # 3 for July 2018.

Fixes bomb arrows acting strangely by making them explode immediatly on contact with enemies. This will deal 1.5 damage to the hit enemy.

This was tested on a server for a while in a number of scenarios, however it's possible the issue may still exist. If it does I'll be happy to fix it.