### PR TITLE
Crate fixes + dump out items with spacebar

### DIFF
--- a/Entities/Characters/Scripts/RunnerActivateable.as
+++ b/Entities/Characters/Scripts/RunnerActivateable.as
@@ -2,5 +2,6 @@ void onInit(CBlob@ this)
 {
 	//these don't actually use it, they take the controls away
 	this.push("names to activate", "lantern");
+	this.push("names to activate", "crate");
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -157,6 +157,46 @@ void onTick(CBlob@ this)
 	}
 
 	CBlob @carryBlob = this.getCarriedBlob();
+	
+
+	// bubble menu
+
+	if (this.isKeyJustPressed(key_bubbles))
+	{
+		this.CreateBubbleMenu();
+		Tap(this);
+	}
+
+	/*else dont use this cause menu won't be release/clickable
+	if (this.isKeyJustReleased(key_bubbles))
+	{
+	    this.ClearBubbleMenu();
+	} */
+
+	// in crate
+
+	if (this.isInInventory())
+	{
+		if (this.isKeyJustPressed(key_pickup))
+		{
+			CBlob@ invblob = this.getInventoryBlob();
+			// Use the inventoryblob command if it has one (crate for example)
+			if (invblob.hasCommandID("getout"))
+			{
+				CBitStream params;
+				params.write_u16(this.getNetworkID());
+				invblob.SendCommand(invblob.getCommandID("getout"), params);
+			}
+			else
+			{
+				this.SendCommand(this.getCommandID("getout"));
+			}
+		}
+
+		return;
+	}
+
+	// no more stuff possible while in crate...
 
 	// inventory menu
 
@@ -217,45 +257,6 @@ void onTick(CBlob@ this)
 			}
 		}
 	}
-
-	// bubble menu
-
-	if (this.isKeyJustPressed(key_bubbles))
-	{
-		this.CreateBubbleMenu();
-		Tap(this);
-	}
-
-	/*else dont use this cause menu won't be release/clickable
-	if (this.isKeyJustReleased(key_bubbles))
-	{
-	    this.ClearBubbleMenu();
-	} */
-
-	// in crate
-
-	if (this.isInInventory())
-	{
-		if (this.isKeyJustPressed(key_pickup))
-		{
-			CBlob@ invblob = this.getInventoryBlob();
-			// Use the inventoryblob command if it has one (crate for example)
-			if (invblob.hasCommandID("getout"))
-			{
-				CBitStream params;
-				params.write_u16(this.getNetworkID());
-				invblob.SendCommand(invblob.getCommandID("getout"), params);
-			}
-			else
-			{
-				this.SendCommand(this.getCommandID("getout"));
-			}
-		}
-
-		return;
-	}
-
-	// no more stuff possible while in crate...
 
 	// release action1 to click buttons
 

--- a/Entities/Common/Emotes/EmotesCommon.as
+++ b/Entities/Common/Emotes/EmotesCommon.as
@@ -107,15 +107,15 @@ namespace Emotes
 	};
 }
 
-void set_emote(CBlob@ this, u8 emote, int time, CBlob@ sender = null)
+void set_emote(CBlob@ this, u8 emote, int time)
 {
 	if (emote >= Emotes::emotes_total)
 	{
 		emote = Emotes::off;
 	}
+
 	this.set_u8("emote", emote);
 	this.set_u32("emotetime", getGameTime() + time);
-
 	bool client = this.getPlayer() !is null && this.isMyPlayer();
 	this.Sync("emote", !client);
 	this.Sync("emotetime", !client);

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -368,6 +368,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBlob@ mine = getBlobByNetworkID(params.read_u16());
 		if (caller !is null && mine !is null && this.get_u32("boobytrap_cooldown_time") <= getGameTime())
 		{
+			this.set_u32("boobytrap_cooldown_time", getGameTime() + 30);
 			this.server_PutOutInventory(mine);
 			Vec2f pos = this.getPosition();
 			pos.y = this.getTeamNum() == caller.getTeamNum() ? pos.y - 5
@@ -377,7 +378,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			mine.setVelocity(Vec2f((caller.getPosition().x - mine.getPosition().x) / 30.0f, -5.0f));
 			mine.set_u8("mine_timer", 255);
 			mine.SendCommand(mine.getCommandID("mine_primed"));
-			this.set_u32("boobytrap_cooldown_time", getGameTime() + 30);
 		}
 	}
 }

--- a/Entities/Items/Crate/Crate.cfg
+++ b/Entities/Items/Crate/Crate.cfg
@@ -82,6 +82,7 @@ $name                                             = crate
 													Crate.as;
 													CrateAutoPickup.as;
 													EmoteBubble.as;
+													Activatable.as;
 													ClamberableCollision.as;
 													# SetTeamToCarrier.as;
 													DecayIfSpammed;

--- a/Entities/Items/Crate/CratePickupCommon.as
+++ b/Entities/Items/Crate/CratePickupCommon.as
@@ -2,6 +2,11 @@
 
 bool crateTake(CBlob@ this, CBlob@ blob)
 {
+    if (this.exists("packed"))
+    {
+        return false;
+    }
+
     const string blobName = blob.getName();
 
     if (   blobName == "mat_gold"


### PR DESCRIPTION
There was a way to take players out of crates and hold them in your own hand / inventory...
You could even get in another crate + go into someone else's inventory for infinite crate clown car...

Yeah...

...Sorry for fixing it before you got to abuse it :P 

Other fixes/additions:
 - You can now activate held crates with spacebar to dump out all non-player items that were in there, so you can put only what you want in it
 - Fixed opening own inventory and taking out items while inside crate (to do things like teleport + use phantom drills)
 - Fixed crashing sandbox/localhost by booby trapping crates with more than one mine
 - Fixed vehicle crates / crates with stuff packed in them from picking up items (note: !crate with sv_test still counts as a packed crate because you can do !crate blob, so test with crates purchased from shops)