### PR TITLE
Shrink nobuild zone during warmup to the red barrier

### DIFF
--- a/Rules/CommonScripts/RedBarrier.as
+++ b/Rules/CommonScripts/RedBarrier.as
@@ -168,7 +168,8 @@ void onRender(CRules@ this)
 }
 
 //extra area of no build around the barrier
-const float noBuildExtra = 8.0f * 3.0f;
+//const float noBuildExtra = 8.0f * 3.0f;
+const float noBuildExtra = 0.0f; // as for now, make the nobuild match the red barrier
 
 void getBarrierPositions(f32 &out x1, f32 &out x2, f32 &out y1, f32 &out y2)
 {


### PR DESCRIPTION
```
[modified] nobuild zone during the preparation time now matches the red barrier
```

It seems better to have the nobuild zone match the red barrier so the red barrier is the only restriction, which should be more intuitive. It should also solve that on certain maps it was made impossible to build a flag base wall larger than a block.