### PR TITLE
added random inventory exit velocity

### DIFF
--- a/Entities/Common/Scripts/RandomExitVelocity.as
+++ b/Entities/Common/Scripts/RandomExitVelocity.as
@@ -1,0 +1,10 @@
+void onRemoveFromInventory(CBlob@ this, CBlob@ blob)
+{
+    // allow blacklisting for random exit velocity
+    if (!blob.hasTag("blacklist random exit vel " + this.getName()))
+    {
+        int x_speed = XORRandom(8) - 4;
+        int y_speed = (XORRandom(5) + 3) * -1; // don't go into the ground, that's bad
+        blob.setVelocity(Vec2f(x_speed, y_speed));
+    }
+}

--- a/Entities/Industry/CTFShops/Storage/Storage.cfg
+++ b/Entities/Industry/CTFShops/Storage/Storage.cfg
@@ -73,6 +73,7 @@ $name                                             = storage
 													IsFlammable.as;
 													BuildingEffects.as;
 													GenericDestruction.as;
+													RandomExitVelocity.as;
 f32_health                                        = 6.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Storage Cache

--- a/Entities/Vehicles/Boats/Dinghy.cfg
+++ b/Entities/Vehicles/Boats/Dinghy.cfg
@@ -116,6 +116,7 @@ $name                                      = dinghy
 										# RunOverPeople.as;
 										 BoatCommon.as;   # put last for rowing sounds	
 										 IsFlammable.as;
+										 RandomExitVelocity.as;
 f32 health                                 = 5.0
 # looks & behaviour inside inventory
 $inventory_name                            = Dinghy

--- a/Entities/Vehicles/Boats/LongBoat.cfg
+++ b/Entities/Vehicles/Boats/LongBoat.cfg
@@ -125,6 +125,8 @@ $name                                      = longboat
 										 FakeBoatCollision.as;
 										 BoatCommon.as;   # put last for rowing sounds	
 										 IsFlammable.as;
+										 RandomExitVelocity.as;
+
 f32 health                                 = 15.0
 # looks & behaviour inside inventory
 $inventory_name                            = Long Boat

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.cfg
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.cfg
@@ -126,6 +126,7 @@ $name                                      = warboat
 										 FakeBoatCollision.as;
 										 BoatCommon.as;   # put last for rowing sounds	
 										 IsFlammable.as;
+										 RandomExitVelocity.as;
 										 
 f32 health                                 = 45.0
 # looks & behaviour inside inventory


### PR DESCRIPTION
Added a script for blobs to have a random (upward) velocity when leaving another blob's inventory. Can tag blobs with "blacklist random exit vel <blobname>" to blacklist this behavior when leaving <blobname> blobs.
Added this script to boats.