### PR TITLE
[added] ability to report reports to discord bot

### DIFF
--- a/Rules/CommonScripts/Report.as
+++ b/Rules/CommonScripts/Report.as
@@ -93,8 +93,12 @@ void report(CRules@ this, CPlayer@ player, CPlayer@ baddie)
 		//increment the report count
 		baddie.add_u8("reportCount", 1);
 
+		string playerUsername = player.getUsername();
 		string baddieUsername = baddie.getUsername();
 		string baddieCharacterName = baddie.getCharacterName();
+
+		//notify discord bot
+		tcpr("*REPORT " + playerUsername + " " + baddieUsername + " " + baddie.get_u8("reportCount"));
 
 		//print message to mods
 		CPlayer@ localPlayer = getLocalPlayer();


### PR DESCRIPTION
Small change, prints a string to tcp, the bot reads it and if the baddie has 1 report it notifies the oksa in discord. If the baddie has 2 or more reports it pings the admins

For the future:
- It would be ideal to synchronize bans throughout all the official servers.
- Handling seclevs accordingly.