### PR TITLE
Implemented a 'smarter' trampoline cooldown that can support the cooldown of multiple objects

### DIFF
--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -2,96 +2,120 @@
 
 namespace Trampoline
 {
-	const string TIMER = "trampoline_timer";
-	const u16 COOLDOWN = 7;
-	const u8 SCALAR = 10;
+    const string TIMER = "trampoline_timer";
+    const u16 COOLDOWN = 7;
+    const u8 SCALAR = 10;
+    const bool SAFETY = true;
 }
+
+class TrampolineCooldown{
+    u16 netid;
+    u32 timer;
+    TrampolineCooldown(u16 netid, u16 timer){this.netid = netid; this.timer = timer;}
+};
 
 void onInit(CBlob@ this)
 {
-	this.set_u32(Trampoline::TIMER, 0);
+    TrampolineCooldown @[] cooldowns;
+    this.set(Trampoline::TIMER, cooldowns);
+    this.getShape().getConsts().collideWhenAttached = true;
 
-	this.getShape().getConsts().collideWhenAttached = true;
+    this.Tag("no falldamage");
+    this.Tag("medium weight");
+    // Because BlobPlacement.as is *AMAZING*
+    this.Tag("place norotate");
 
-	this.Tag("no falldamage");
-	this.Tag("medium weight");
-	// Because BlobPlacement.as is *AMAZING*
-	this.Tag("place norotate");
+    AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
+    point.SetKeysToTake(key_action1 | key_action2);
 
-	AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
-	point.SetKeysToTake(key_action1 | key_action2);
-
-	this.getCurrentScript().runFlags |= Script::tick_attached;
+    this.getCurrentScript().runFlags |= Script::tick_attached;
 }
 
 void onTick(CBlob@ this)
 {
-	AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
+    AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
 
-	CBlob@ holder = this.getAttachments().getAttachedBlob("PICKUP", 0);
-	if(holder is null) return;
+    CBlob@ holder = this.getAttachments().getAttachedBlob("PICKUP", 0);
+    if(holder is null) return;
 
-	Vec2f ray = holder.getAimPos() - this.getPosition();
-	ray.Normalize();
+    Vec2f ray = holder.getAimPos() - this.getPosition();
+    ray.Normalize();
 
-	f32 angle = ray.Angle();
-	angle = angle > 135 || angle < 45? (holder.isFacingLeft()? 135 : 45) : 90;
-	angle -= 90;
+    f32 angle = ray.Angle();
+    angle = angle > 135 || angle < 45? (holder.isFacingLeft()? 135 : 45) : 90;
+    angle -= 90;
 
-	this.setAngleDegrees(-angle);
+    this.setAngleDegrees(-angle);
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1, Vec2f point2)
 {
-	if (blob is null || blob.isAttached() || blob.getShape().isStatic()) return;
+    if (blob is null || blob.isAttached() || blob.getShape().isStatic()) return;
 
-	AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
-	CBlob@ holder = point.getOccupied();
+    AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
+    CBlob@ holder = point.getOccupied();
 
-	//cant bounce holder
-	if(holder is blob) return;
+    //cant bounce holder
+    if(holder is blob) return;
 
-	//cant bounce while held by something attached to something else
-	if (holder !is null && holder.isAttached()) return;
+    //cant bounce while held by something attached to something else
+    if (holder !is null && holder.isAttached()) return;
 
-	if (this.get_u32(Trampoline::TIMER) < getGameTime())
-	{
-		Vec2f velocity_old = blob.getOldVelocity();
-		if (velocity_old.Length() < 1.0f) return;
+    TrampolineCooldown@[]@ cooldowns;
+    if(!this.get(Trampoline::TIMER, @cooldowns)) return;
 
-		float angle = this.getAngleDegrees();
+    if(Trampoline::SAFETY && cooldowns.length > 8) cooldowns.clear();
 
-		Vec2f direction = Vec2f(0.0f, -1.0f);
-		direction.RotateBy(angle);
+    u16 netid = blob.getNetworkID();
+    bool block = false;
+    for(int i = 0; i < cooldowns.length; i++){
+        if(netid == cooldowns[i].netid && cooldowns[i].timer >= getGameTime()){
+            block = true;
+        }
+        if(cooldowns[i].timer < getGameTime()){
+            cooldowns.removeAt(i);
+            i--;
+        }
+    }
+    if (!block)
+    {
+        Vec2f velocity_old = blob.getOldVelocity();
+        if (velocity_old.Length() < 1.0f) return;
 
-		float velocity_angle = direction.AngleWith(velocity_old);
+        float angle = this.getAngleDegrees();
 
-		if (Maths::Abs(velocity_angle) > 90)
-		{
-			//this.set_u32(Trampoline::TIMER, getGameTime() + Trampoline::COOLDOWN);
+        Vec2f direction = Vec2f(0.0f, -1.0f);
+        direction.RotateBy(angle);
 
-			Vec2f velocity = Vec2f(0, -Trampoline::SCALAR);
-			velocity.RotateBy(angle);
+        float velocity_angle = direction.AngleWith(velocity_old);
 
-			blob.setVelocity(velocity);
+        if (Maths::Abs(velocity_angle) > 90)
+        {
+            TrampolineCooldown cooldown(netid, getGameTime() + Trampoline::COOLDOWN);
+            cooldowns.push_back(cooldown);
 
-			CSprite@ sprite = this.getSprite();
-			if (sprite !is null)
-			{
-				sprite.SetAnimation("default");
-				sprite.SetAnimation("bounce");
-				sprite.PlaySound("TrampolineJump.ogg");
-			}
-		}
-	}
+            Vec2f velocity = Vec2f(0, -Trampoline::SCALAR);
+            velocity.RotateBy(angle);
+
+            blob.setVelocity(velocity);
+
+            CSprite@ sprite = this.getSprite();
+            if (sprite !is null)
+            {
+                sprite.SetAnimation("default");
+                sprite.SetAnimation("bounce");
+                sprite.PlaySound("TrampolineJump.ogg");
+            }
+        }
+    }
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
-	return blob.getShape().isStatic();
+    return blob.getShape().isStatic();
 }
 
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {
-	return !this.hasTag("no pickup");
+    return !this.hasTag("no pickup");
 }

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -68,7 +68,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 
 		if (Maths::Abs(velocity_angle) > 90)
 		{
-			this.set_u32(Trampoline::TIMER, getGameTime() + Trampoline::COOLDOWN);
+			//this.set_u32(Trampoline::TIMER, getGameTime() + Trampoline::COOLDOWN);
 
 			Vec2f velocity = Vec2f(0, -Trampoline::SCALAR);
 			velocity.RotateBy(angle);


### PR DESCRIPTION
## Status
**READY**

## Description
Implemented a 'smarter' cooldown that can support up the cooldown of up to 8 objects. The limit is a safety feature that limits the number of cooldowns that need to be process on every collision. there is a SAFETY bool that can be set to false to disable the feature.

## Steps to Test or Reproduce
create a trampoline and build a tall column of background blocks.
at the top of the background blocks, build a block. 
place multiple objects on top of the block. 
destroy the block. 
observe the multiple objects bouncing on the trampoline at the same time.
