### PR TITLE
improved efficiency by only syncing when necessary

### DIFF
--- a/Rules/CommonScripts/Holiday/Holiday.as
+++ b/Rules/CommonScripts/Holiday/Holiday.as
@@ -60,7 +60,7 @@ void onRestart(CRules@ this)
                 break;
             }
         }
-        sync = true;
+        if(holiday != holiday_cache) sync = true;//only sync when there is actually something to be synced. this
     }
 }
 


### PR DESCRIPTION
## Status
READY

## Description
This basically just eliminates the need for the script to send the command to sync when nothing actually needs to be synced. This will reduce the number of commands that need to be sent at the beginning of a match. Also, this will help temporarily alleviate the bug where holiday.as tries to load a seemingly random script.

## Steps to Test or Reproduce
the best way to test the holiday scripts in general is to add this segment of code
`int rand = XORRandom(calendar.length+1);
if(rand != calendar.length) holiday = calendar[rand].m_name;
else holiday = "";`
after line 62 and before line 63
this will basically simulate the holidays changing over and over after every "next map".