### PR TITLE
Fix to ensure emote menu disappears when you die

### DIFF
--- a/Entities/Common/Emotes/EmoteMenu.as
+++ b/Entities/Common/Emotes/EmoteMenu.as
@@ -41,7 +41,11 @@ void onTick(CRules@ rules)
 {
 	CBlob@ blob = getLocalPlayerBlob();
 
-	if (blob is null) return;
+	if (blob is null)
+	{
+		set_active_wheel_menu(null);
+		return;
+	}
 
 	WheelMenu@ menu = get_wheel_menu("emotes");
 


### PR DESCRIPTION
## Status

**READY**

## Description

This fix ensures the emote wheel disappears when you die

## Steps to Test or Reproduce

Die while holding Q