### PR TITLE
Fixed bug where dead blob isn't detached from quarters

### DIFF
--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -122,7 +122,7 @@ void onTick(CBlob@ this)
 		CBlob@ patient = bed.getOccupied();
 		if (patient !is null)
 		{
-			if (bed.isKeyJustPressed(key_up))
+			if (bed.isKeyJustPressed(key_up) || patient.getHealth() == 0)
 			{
 				if (isServer)
 				{


### PR DESCRIPTION
## Status

**READY**

## Description

If you are killed at the same time you sleep in a quarters, your dead body sleeps in the bed

## Steps to Test or Reproduce
1. Build quarters
2. Spike yourself twice
3. Spike yourself a third time and sleep in the quarters at the same time
It seems to only occur on servers and it's somewhat difficult to reproduce