### PR TITLE
Arrows pass through migrants

### DIFF
--- a/Entities/Characters/Migrant/MigrantLogic.as
+++ b/Entities/Characters/Migrant/MigrantLogic.as
@@ -10,6 +10,7 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -1.5f);
 	this.Tag("player");
 	this.Tag("flesh");
+	this.Tag("ignore_arrow");
 
 	this.getCurrentScript().tickFrequency = 150; // opt
 }

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -396,7 +396,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 	if (hitBlob !is null)
 	{
 		Pierce(this, hitBlob);
-		if (this.hasTag("collided")) return 0.0f;
+		if (this.hasTag("collided") || hitBlob.hasTag("migrant")) return 0.0f;
 
 		// check if invincible + special -> add force here
 		if(specialArrowHit(hitBlob))

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -396,7 +396,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 	if (hitBlob !is null)
 	{
 		Pierce(this, hitBlob);
-		if (this.hasTag("collided") || hitBlob.hasTag("migrant")) return 0.0f;
+		if (this.hasTag("collided")) return 0.0f;
 
 		// check if invincible + special -> add force here
 		if(specialArrowHit(hitBlob))


### PR DESCRIPTION
## Status

**READY**

## Description

Arrows now pass through migrants instead of sticking in them and doing no damage. This will make it easier for archers to kill enemies surrounded by migrants. If you want to kill enemy migrants, you can always slash them as knight.

Inspired by [this](https://forum.thd.vg/threads/26687/) bug report by Coroz

## Steps to Test or Reproduce

Shoot any migrant regardless of team