### PR TITLE
Instantly return flags that fall into the void

### DIFF
--- a/Entities/Special/CTF/CTF_Flag.as
+++ b/Entities/Special/CTF/CTF_Flag.as
@@ -58,6 +58,15 @@ void onTick(CBlob@ this)
 
 	if (can_return)
 	{
+		CMap@ map = this.getMap();
+		if (map !is null)
+		{
+			if (this.getPosition().y >= map.getMapDimensions().y)
+			{
+				returncount = return_time;
+			}
+		}
+
 		bool fast_return = shouldFastReturn(this);
 
 		if (returncount < return_time)


### PR DESCRIPTION
## Status

**READY**

## Description

Flags that fall into the void are instantly returned to base. This is good because it's currently annoying to wait for the flag to respawn and the flag begins to glitch out when sitting at the bottom.

Inspired by [this](https://forum.thd.vg/threads/25490/) suggestion by Makmoud

## Steps to Test or Reproduce

Throw a flag into the void