### PR TITLE
Normal arrows are ignited when passing through flames

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -96,9 +96,20 @@ void turnOffFire(CBlob@ this)
 	this.getSprite().PlaySound("/ExtinguishFire.ogg");
 }
 
+void turnOnFire(CBlob@ this)
+{
+	this.SetLight(true);
+	this.set_u8("arrow type", ArrowType::fire);
+	this.Tag("fire source");
+	this.getSprite().SetAnimation("fire arrow");
+	this.getSprite().PlaySound("/FireFwoosh.ogg");
+}
+
 void onTick(CBlob@ this)
 {
 	CShape@ shape = this.getShape();
+
+	const u8 arrowType = this.get_u8("arrow type");
 
 	f32 angle;
 	bool processSticking = true;
@@ -138,6 +149,12 @@ void onTick(CBlob@ this)
 
 			processSticking = false;
 		}
+
+		// ignite arrow
+		if (arrowType == ArrowType::normal && this.isInFlames())
+		{
+			turnOnFire(this);
+		}
 	}
 
 	// sticking
@@ -163,8 +180,6 @@ void onTick(CBlob@ this)
 		this.setPosition(this.get_Vec2f("lock"));
 		shape.SetStatic(true);
 	}
-
-	const u8 arrowType = this.get_u8("arrow type");
 
 	// fire arrow
 	if (arrowType == ArrowType::fire)


### PR DESCRIPTION
## Status

**READY**

## Description

Similarly to how fire arrows are extinguished when passing through water, normal arrows are ignited when passing through flames

## Steps to Test or Reproduce

1. Build a wooden structure with backwall or find grass, bushes or trees
2. Set fire to the structure or flora
3. Shoot normal arrows through the fire
