### PR TITLE
Grain plants can be 'cut' by arrows when shot at the block below

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -529,6 +529,20 @@ void ArrowHitMap(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, u8 c
 	}
 
 	this.set_Vec2f("fire pos", (worldPoint + (norm * 0.5f)));
+
+	CBlob@[] blobsInRadius;
+	if (this.getMap().getBlobsInRadius(worldPoint, this.getRadius() * 1.3f, @blobsInRadius))
+	{
+		for (uint i = 0; i < blobsInRadius.length; i++)
+		{
+			CBlob @b = blobsInRadius[i];
+			if (b.getName() == "grain_plant")
+			{
+				this.server_Hit(b, worldPoint, Vec2f(0, 0), velocity.Length() / 7.0f, Hitters::arrow);
+				break;
+			}
+		}
+	}
 }
 
 void FireUp(CBlob@ this)


### PR DESCRIPTION
## Status

**READY**

## Description

Since archers currently don't have a way to get grain from grain plants, I decided it would be useful for arrows to 'cut' grain plants if shot at the block below them. It takes into account arrow velocity which means stray arrows don't instantly destroy grain.

A fully charged shot at point-blank range instantly destroys the plant, half shot in two and quarter shot in three. The number of arrows it takes increases depending on the range since arrow velocity is reduced.

## Steps to Test or Reproduce

Shoot the block below a grain plant at varying strengths and distances
