### PR TITLE
Added raycast check for seats

### DIFF
--- a/Entities/Vehicles/Common/SeatHop.as
+++ b/Entities/Vehicles/Common/SeatHop.as
@@ -33,7 +33,8 @@ void onTick(CBlob@ this)
 			if ((blob !is this) &&
 			        blob.hasTag("seats") &&
 			        blob !is carried &&
-			        (blob.getTeamNum() > 8 || blob.getTeamNum() == this.getTeamNum()))
+			        (blob.getTeamNum() > 8 || blob.getTeamNum() == this.getTeamNum()) &&
+					!this.getMap().rayCastSolid(this.getPosition(), blob.getPosition()))
 			{
 				//can't get into carried blob - can pick it up after they get in though
 				//(prevents dinghy rockets)

--- a/Entities/Vehicles/Common/SeatsGUI.as
+++ b/Entities/Vehicles/Common/SeatsGUI.as
@@ -37,6 +37,12 @@ void onRender(CSprite@ this)
 		return;
 	}
 
+	//behind solid blocks
+	if (localBlob.getMap().rayCastSolid(localBlob.getPosition(), blob.getPosition()))
+	{
+		return;
+	}
+
 	// dont draw if angle is upside down
 	f32 angle = blob.getAngleDegrees();
 


### PR DESCRIPTION
## Status

**READY**

## Description

To prevent players from sitting on vehicles/animals that are behind blocks, a raycast check has been added to check for solid blocks. The bobbing arrows also don't show when there is a solid block preventing you from sitting.

## Steps to Test or Reproduce

1. Spawn siege/shark/bison
2. Place blocks above it
3. Try sitting on it
