### PR TITLE
Use highest absorbed sponge first when stunned by water

### DIFF
--- a/Entities/Characters/Scripts/RunnerKnock.as
+++ b/Entities/Characters/Scripts/RunnerKnock.as
@@ -67,19 +67,19 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	{
 		//get sponge
 		CBlob@ sponge = null;
-		//find the sponge with lowest absorbed
+		//find the sponge with highest absorbed
 		CInventory@ inv = this.getInventory();
 		if (inv !is null)
 		{
-			u8 lowest_absorbed = 100;
+			int8 highest_absorbed = -1;
 			for (int i = 0; i < inv.getItemsCount(); i++)
 			{
 				CBlob@ invitem = inv.getItem(i);
 				if(invitem.getName() == "sponge")
 				{
-					if(invitem.get_u8("absorbed") < lowest_absorbed)
+					if(invitem.get_u8("absorbed") > highest_absorbed)
 					{
-						lowest_absorbed = invitem.get_u8("absorbed");
+						highest_absorbed = invitem.get_u8("absorbed");
 						@sponge = invitem;
 					}
 				}


### PR DESCRIPTION
## Status

**READY**

## Description

When you have multiple sponges in your inventory, the one which has absorbed the highest amount of water is used first. This reduces inventory clutter by using each sponge one at a time rather than spreading uses over all of them.

## Steps to Test or Reproduce

Put sponges in your inventory and stun yourself with water
