### PR TITLE
Implemented better crouch dodge code

### DIFF
--- a/Entities/Characters/Builder/BuilderLogic.as
+++ b/Entities/Characters/Builder/BuilderLogic.as
@@ -96,6 +96,8 @@ void onTick(CBlob@ this)
 		this.get("hitdata", @hitdata);
 		hitdata.blobID = 0;
 		hitdata.tilepos = bc.buildable ? bc.tileAimPos : Vec2f(-8, -8);
+
+		this.Tag("allow crouch");
 	}
 
 	// get rid of the built item

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -587,6 +587,8 @@ void onTick(CBlob@ this)
 					setShieldDirection(this, Vec2f(horiz, -3));
 				}
 			}
+
+			this.Tag("allow crouch");
 		}
 
 		// shield up = collideable

--- a/Entities/Characters/Scripts/CrouchCommon.as
+++ b/Entities/Characters/Scripts/CrouchCommon.as
@@ -1,0 +1,12 @@
+bool isCrouching(CBlob@ this)
+{
+	return
+		this.isOnGround() &&
+		this.isKeyPressed(key_down) &&
+		!this.isKeyPressed(key_left) &&
+		!this.isKeyPressed(key_right) &&
+		(( // normal crouch check
+			!this.isKeyPressed(key_action1) &&
+			(!this.isKeyPressed(key_action2) || this.getName() == "archer") // archer grapple special case
+		) || this.hasTag("allow crouch"));
+}

--- a/Entities/Characters/Scripts/RunnerCollision.as
+++ b/Entities/Characters/Scripts/RunnerCollision.as
@@ -1,5 +1,7 @@
 // character was placed in crate
 
+#include "CrouchCommon.as";
+
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
 {
 	this.doTickScripts = true; // run scripts while in crate
@@ -58,12 +60,10 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 
 		const bool still = !this.isKeyPressed(key_left) && !this.isKeyPressed(key_right);
 
-		if (this.isKeyPressed(key_down) &&
-		        this.isOnGround() && still)
+		if (isCrouching(this))
 		{
-			CShape@ s = blob.getShape();
-			if (s !is null && !s.isStatic() &&
-			        !blob.hasTag("ignore crouch"))
+			CShape@ shape = this.getShape();
+			if (shape !is null && !shape.isStatic())
 			{
 				return false;
 			}

--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -26,6 +26,7 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
+	this.Untag("allow crouch");
 	DoKnockedUpdate(this);
 }
 


### PR DESCRIPTION
## Status

**READY**

## Description

This includes the requested changes from my previous pull request. This implementation uses the `"allow crouch"` tag to specify which states allow crouch dodging and an `isCrouching()` function to check if you’re crouching.

States which enable crouch dodging:
- Visibly crouching
- Placing blocks as builder
- Shielding as knight

I went with whitelisting instead of blacklisting because only a few states allow crouch dodging.
I included the builder's block place state because it isn't an attacking frame which doesn't allow people to attack while crouch dodging.

## Steps to Test or Reproduce

Test 1: Throw a boulder in the air and crouch to dodge it while in different animation states
Test 2: Place a boulder on the ground and crouch grapple through it