### PR TITLE
Archers don't auto switch to special arrows

### DIFF
--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -474,7 +474,7 @@ void DrawBowEffects(CSprite@ this, CBlob@ blob, ArcherInfo@ archer, const u8 arr
 	}
 
 	//quiver
-	bool has_arrows = blob.get_bool("has_arrow");
+	bool has_arrows = hasAnyArrows(blob);
 	doQuiverUpdate(this, has_arrows, true);
 }
 

--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -442,7 +442,7 @@ void DrawBow(CSprite@ this, CBlob@ blob, ArcherInfo@ archer, f32 armangle, const
 
 	// fire arrow particles
 
-	if (arrowType == ArrowType::fire && getGameTime() % 6 == 0)
+	if (arrowType == ArrowType::fire && hasArrows(blob) && getGameTime() % 6 == 0)
 	{
 		Vec2f offset = Vec2f(12.0f, 0.0f);
 
@@ -462,7 +462,7 @@ void DrawBowEffects(CSprite@ this, CBlob@ blob, ArcherInfo@ archer, const u8 arr
 
 	if (arrowType == ArrowType::fire)
 	{
-		if (IsFiring(blob))
+		if (IsFiring(blob) && hasArrows(blob))
 		{
 			blob.SetLight(true);
 			blob.SetLightRadius(blob.getRadius() * 2.0f);

--- a/Entities/Characters/Archer/ArcherCommon.as
+++ b/Entities/Characters/Archer/ArcherCommon.as
@@ -178,6 +178,18 @@ bool hasArrows(CBlob@ this, u8 arrowType)
 	return this.getBlobCount(arrowTypeNames[arrowType]) > 0;
 }
 
+bool hasAnyArrows(CBlob@ this)
+{
+	for (uint i = 0; i < ArrowType::count; i++)
+	{
+		if (hasArrows(this, i))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 void SetArrowType(CBlob@ this, const u8 type)
 {
 	ArcherInfo@ archer;

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -271,6 +271,7 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 	CSprite@ sprite = this.getSprite();
 	bool ismyplayer = this.isMyPlayer();
 	bool hasarrow = archer.has_arrow;
+	bool hasnormal = hasArrows(this, ArrowType::normal);
 	s8 charge_time = archer.charge_time;
 	u8 charge_state = archer.charge_state;
 	const bool pressed_action2 = this.isKeyPressed(key_action2);
@@ -282,18 +283,11 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		{
 			hasarrow = hasArrows(this);
 
-			if (!hasarrow)
+			if (!hasarrow && hasnormal)
 			{
 				// set back to default
-				for (uint i = 0; i < ArrowType::count; i++)
-				{
-					hasarrow = hasArrows(this, i);
-					if (hasarrow)
-					{
-						archer.arrow_type = i;
-						break;
-					}
-				}
+				archer.arrow_type = ArrowType::normal;
+				hasarrow = hasnormal;
 			}
 		}
 
@@ -375,10 +369,10 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			charge_state = ArcherParams::readying;
 			hasarrow = hasArrows(this);
 
-			if (!hasarrow)
+			if (!hasarrow && hasnormal)
 			{
 				archer.arrow_type = ArrowType::normal;
-				hasarrow = hasArrows(this);
+				hasarrow = hasnormal;
 
 			}
 


### PR DESCRIPTION
## Status

**READY** (community feedback needed)

## Description

As suggested by @norill, archers shouldn't auto switch to special arrows when they are out of regular arrows. I have extended on his idea by preventing auto switch to special arrows when out of any arrow type. You still auto switch to regular arrows when out of special arrows.

Advantage:
- Reduces the likelihood of accidentally shooting special arrows

Disadvantage:
- Requires the player to manually select / quick switch to special arrows in more situations

Closes #231 

## Steps to Test or Reproduce

Test 1: Have normal + special arrow in inventory, shoot all of normal arrows (you shouldn't auto switch to special arrow)
Test 2: Have normal + special arrow in inventory, shoot all of special arrows (you should auto switch to normal arrows)
Test 3: Have two types of special arrows in inventory, shoot all of one type (you shouldn't auto switch to other special arrow)
