### PR TITLE
Halve the stun from water if it was shielded

### DIFF
--- a/Entities/Characters/Scripts/RunnerKnock.as
+++ b/Entities/Characters/Scripts/RunnerKnock.as
@@ -108,9 +108,16 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		bool has_sponge = sponge !is null;
 		bool wet_sponge = false;
 
-		bool undefended = (force || !this.hasTag("shielded"));
-		if ((customData == Hitters::water_stun && undefended) ||
-		        customData == Hitters::water_stun_force)
+		bool defended = this.hasTag("shielded");
+
+		// If the class has a shield (check for ShieldVars) then check that the shield is pointing in the right direction
+		if (getShieldVars(this) !is null) {
+			if (!blockAttack(this, velocity, damage))
+				defended = false;
+		}
+
+		if (customData == Hitters::water_stun && !defended
+			|| customData == Hitters::water_stun_force)
 		{
 			if (has_sponge)
 			{
@@ -120,6 +127,12 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			else
 			{
 				time = 45;
+			}
+
+			// Halve the stun if it was blocked
+			if (defended) {
+				Sound::Play("ShieldHit.ogg", this.getPosition(), this.isMyPlayer() ? 1.3f : 0.7f);
+				time *= 0.5;
 			}
 
 			this.Tag("dazzled");

--- a/Entities/Characters/Scripts/RunnerKnock.as
+++ b/Entities/Characters/Scripts/RunnerKnock.as
@@ -117,6 +117,10 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 				defended = false;
 		}
 
+		// Don't allow the player to shield their own water explosives
+		if (hitterBlob.getDamageOwnerPlayer() is this.getPlayer())
+			defended = false;
+
 		if (customData == Hitters::water_stun && !defended
 			|| customData == Hitters::water_stun_force)
 		{

--- a/Entities/Characters/Scripts/RunnerKnock.as
+++ b/Entities/Characters/Scripts/RunnerKnock.as
@@ -1,6 +1,7 @@
 // stun
 #include "/Entities/Common/Attacks/Hitters.as";
 #include "Knocked.as";
+#include "ShieldCommon.as";
 
 void onInit(CBlob@ this)
 {


### PR DESCRIPTION
## Status

READY

## Description

This PR adds some counterplay to water stuns by allowing them to be blocked. If successfully blocked then the stun is halved (22 rather than 45 ticks).

22 ticks is still a long time - enough for water stuns to be powerful but not oppressive.

Sponges function as normal.
This affects water bombs and water arrows. I've tested both in sandbox.

References #241

## Steps to Test or Reproduce
Test it on my server (Eluded TDM)

- Play as knight
- Throw a water bomb upwards so it lands just to the left/right of you
- Notice that if you're shielding in the right direction then the stun is halved
