### PR TITLE
Gold auto-pickup change

### DIFF
--- a/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -12,9 +12,10 @@ void Take(CBlob@ this, CBlob@ blob)
 {
 	const string blobName = blob.getName();
 
-	if (blobName == "mat_gold" || blobName == "mat_stone" ||
-	        blobName == "mat_wood" /*|| blobName == "grain"*/)
-	{
+	if (blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
+		blobName == "mat_stone" ||
+		blobName == "mat_wood"
+	) {
 		if ((this.getDamageOwnerPlayer() is blob.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
 		{
 			if (this.server_PutInInventory(blob))
@@ -32,6 +33,11 @@ void Take(CBlob@ this, CBlob@ blob)
 			return;
 		}
 	}
+}
+
+bool pickupCriteria(CBlob@ this, CBlob@ blob, uint16 quantity)
+{
+	return blob.getQuantity() >= quantity || this.hasBlob(blob.getName(), 1);
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)

--- a/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -12,7 +12,8 @@ void Take(CBlob@ this, CBlob@ blob)
 {
 	const string blobName = blob.getName();
 
-	if (blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
+	if (
+		blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
 		blobName == "mat_stone" ||
 		blobName == "mat_wood"
 	) {

--- a/Entities/Materials/MaterialCommon.as
+++ b/Entities/Materials/MaterialCommon.as
@@ -21,7 +21,7 @@ namespace Material
 
     uint8 frames = animation.getFramesCount();
     uint16 quantity = this.getQuantity();
-    uint8 index = frames * (quantity - 1) / this.maxQuantity;
+    uint8 index = (frames - 1) * quantity / this.maxQuantity;
 
     // Animation frame update
     animation.SetFrameIndex(index);


### PR DESCRIPTION
## Status

**READY** (community feedback needed)

## Description

This adds what was suggested in @Frankulushus' suggestion (#288). I also changed the material anim index equation so the biggest stack sprite is only shown for a max stack. This will make it easier to visually see which stacks of gold will be auto picked up (and which stacks have enough gold to be useful).

Closes #288

## Steps to Test or Reproduce

Test 1: Mine 50 gold, drop it on the ground, wait a bit, then walk over it (it should auto pickup like usual)
Test 2: Mine less than 50 gold, drop it on the ground, wait a bit, then walk over it (it shouldn't auto pickup since its quantity is too small)
Test 3: Mine more than 50 gold, drop both stacks on the ground, manually pick up the larger stack, wait a bit, then walk over the smaller stack (it should auto pickup even though its quantity is too small since you already have gold in your inventory)