### PR TITLE
Improved keg functionality

### DIFF
--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -57,6 +57,14 @@ void onTick(CSprite@ this)
 
 }
 
+void onTick(CBlob@ this)
+{
+	if (this.isInFlames() && !this.hasTag("exploding"))
+	{
+		this.SendCommand(this.getCommandID("activate"));
+	}
+}
+
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
 	if (getNet().isServer())
@@ -87,6 +95,22 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		case Hitters::sword:
 		case Hitters::arrow:
 			damage *= 0.25f; //quarter damage from these
+			break;
+		case Hitters::water:
+			if (hitterBlob.getName() == "bucket" && this.hasTag("exploding"))
+			{
+				this.SendCommand(this.getCommandID("deactivate"));
+			}
+		case Hitters::keg:
+			if (!this.hasTag("exploding"))
+			{
+				this.SendCommand(this.getCommandID("activate"));
+			}
+			//set fuse to shortest fuse time - either current time or new random time
+			//so it doesn't explode at the exact same time as hitter keg
+			this.set_s32("explosion_timer", Maths::Min(this.get_s32("explosion_timer"), getGameTime() + XORRandom(this.get_f32("keg_time")) / 3));
+
+			damage *= 0.0f; //invincible to allow keg chain reaction
 			break;
 		default:
 			damage *= 0.5f; //half damage from everything else

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -69,6 +69,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		this.SetLight(true);
 		this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
 		this.getSprite().SetEmitSound("/Sparkle.ogg");
+		this.getSprite().SetEmitSoundSpeed(1.0f);
+		this.getSprite().SetEmitSoundVolume(1.0f);
 		this.getSprite().SetEmitSoundPaused(false);
 	}
 	else if (cmd == this.getCommandID("deactivate"))

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -466,6 +466,11 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 		if (arrowType == ArrowType::fire)
 		{
 			this.server_SetTimeToDie(0.5f);
+			
+			if (hitBlob.getName() == "keg" && !hitBlob.hasTag("exploding"))
+			{
+				hitBlob.SendCommand(hitBlob.getCommandID("activate"));
+			}
 		}
 		else
 		{


### PR DESCRIPTION
## Status

**READY**

## Description

Improvements:
- Fire/fire arrows activate (arrows only collide with unlit enemy kegs and any lit keg)
- Water buckets deactivate (only water buckets to still allow launching kegs with water bombs)
- Explosion chain reaction
- Invincible to other keg explosions (to allow for chain reaction)
- Fixed weird fuse sound when relighting keg after it was frozen by admin

10-1 in favour of these changes. People were indecisive whether the fire and/or water changes were good. This will most likely still require a #democracy vote in Discord since this changes the most powerful weapon in kag.

Closes #279

## Steps to Test or Reproduce

!keg