### PR TITLE
Enabled flip and change class buttons on enemy sieges

### DIFF
--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -235,7 +235,7 @@ void onTick(CBlob@ this)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
-	if (caller.getTeamNum() == this.getTeamNum() && isOverlapping(this, caller) && !caller.isAttached())
+	if (isOverlapping(this, caller) && !caller.isAttached())
 	{
 		if (!isAnotherRespawnClose(this) && !isFlipped(this))
 		{
@@ -244,7 +244,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 			CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, -4), this, SpawnCmd::buildMenu, getTranslatedString("Change class"), params);
 		}
 
-		if (!Vehicle_AddFlipButton(this, caller))
+		if (!Vehicle_AddFlipButton(this, caller) && caller.getTeamNum() == this.getTeamNum())
 		{
 			Vehicle_AddLoadAmmoButton(this, caller);
 		}

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -134,7 +134,7 @@ void onTick(CBlob@ this)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
-	if (this.getTeamNum() == caller.getTeamNum() && !Vehicle_AddFlipButton(this, caller) && isOverlapping(this, caller) && !caller.isAttached())
+	if (!Vehicle_AddFlipButton(this, caller) && this.getTeamNum() == caller.getTeamNum() && isOverlapping(this, caller) && !caller.isAttached())
 	{
 		Vehicle_AddLoadAmmoButton(this, caller);
 	}


### PR DESCRIPTION
## Status

**READY**

## Description

Added what was suggested by @bunniewormy in #292 but also decided to enabled the flip button. This is because it would be useful to flip the siege upright as your capturing it instead of having to watch it destroy itself.

Closes #292 

## Steps to Test or Reproduce

Spawn a siege, flip it, swap team and try to use the buttons