### PR TITLE
Factory Named Properly

### DIFF
--- a/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -107,14 +107,14 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 	else if(TTH)
 	{
 		{
-			BuildBlock b(0, "factory", "$building$", "Workshop");
+			BuildBlock b(0, "factory", "$building$", "Factory\nAn item-producing factory\nRequires migrant");
 			AddRequirement(b.reqs, "blob", "mat_wood", "Wood", WARCosts::factory_wood);
 			b.buildOnGround = true;
 			b.size.Set(40, 24);
 			blocks[0].insertAt(9, b);
 		}
 		{
-			BuildBlock b(0, "workbench", "$workbench$", "Workbench");
+			BuildBlock b(0, "workbench", "$workbench$", "Workbench\nCreate trampolines, saws, and more");
 			AddRequirement(b.reqs, "blob", "mat_wood", "Wood", WARCosts::workbench_wood);
 			b.buildOnGround = true;
 			b.size.Set(32, 16);

--- a/Entities/Industry/Factory/Factory.as
+++ b/Entities/Industry/Factory/Factory.as
@@ -75,7 +75,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	if (!hasTech(this) && caller.isOverlapping(this))
 	{
-		caller.CreateGenericButton(12, Vec2f(0, 0), this, this.getCommandID("upgrade factory menu"), getTranslatedString("Convert Workshop"), params);
+		caller.CreateGenericButton(12, Vec2f(0, 0), this, this.getCommandID("upgrade factory menu"), getTranslatedString("Convert Factory"), params);
 	}
 	else
 	{

--- a/Entities/Industry/Factory/Factory.as
+++ b/Entities/Industry/Factory/Factory.as
@@ -36,7 +36,7 @@ void onInit(CBlob@ this)
 
 	this.set_TileType("background tile", CMap::tile_wood_back);
 
-	SetHelp(this, "help use", "builder", getTranslatedString("$workshop$Convert workshop    $KEY_E$"), "", 3);
+	SetHelp(this, "help use", "builder", getTranslatedString("$workshop$Convert factory    $KEY_E$"), "", 3);
 
 	if (hasTech(this))
 	{


### PR DESCRIPTION
In TTH at the moment, (generic aka default) factories are called "Workshops" - the same for the default building in CTF/Sandbox. All the other specific factories do have "factory" in their name, though. When I first started playing KAG (specifically Take The Halls), I got confused by this, thinking I could build CTF shops, wanting to make a builder shop. So, I wasted my un-re-gainable mats on the factory when I should've built a Workbench. So I want to fix this, even though it'll mostly just help KAG beginners.

So, I've changed the factory's name in the Builder's menu to "Factory," and I also added a short description for the !factory and !workbench structures (in the building menu).