### PR TITLE
More Fireplace Produce

### DIFF
--- a/Entities/Industry/Fireplace/Fireplace.as
+++ b/Entities/Industry/Fireplace/Fireplace.as
@@ -48,10 +48,38 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
 	if (blob !is null)
 	{
+		// Convert items (and animals) into food blobs (different textures and names from your regular !food)
 		if (blob.getName() == "fishy" && this.getSprite().isAnimation("fire"))
 		{
 			blob.getSprite().PlaySound("SparkleShort.ogg");
-			CBlob@ food = server_MakeFood(blob.getPosition(), "Cooked Fish", 1);
+			CBlob@ food = server_MakeFood(blob.getPosition(), "Cooked Fish", 1); // Cooked Fish
+			if (food !is null) {
+				food.setVelocity(blob.getVelocity().opMul(0.5f));
+			}
+			blob.server_Die();
+		}
+		else if (blob.getName() == "steak" && this.getSprite().isAnimation("fire"))
+		{
+			blob.getSprite().PlaySound("SparkleShort.ogg");
+			CBlob@ food = server_MakeFood(blob.getPosition(), "Cooked Steak", 0); // Cooked Steak
+			if (food !is null) {
+				food.setVelocity(blob.getVelocity().opMul(0.5f));
+			}
+			blob.server_Die();
+		}
+		else if (blob.getName() == "grain" && this.getSprite().isAnimation("fire"))
+		{
+			blob.getSprite().PlaySound("SparkleShort.ogg");
+			CBlob@ food = server_MakeFood(blob.getPosition(), "Bread", 4); // Bread
+			if (food !is null) {
+				food.setVelocity(blob.getVelocity().opMul(0.5f));
+			}
+			blob.server_Die();
+		}
+		else if (blob.getName() == "egg" && this.getSprite().isAnimation("fire"))
+		{
+			blob.getSprite().PlaySound("SparkleShort.ogg");
+			CBlob@ food = server_MakeFood(blob.getPosition(), "Cake", 5); // Cake
 			if (food !is null) {
 				food.setVelocity(blob.getVelocity().opMul(0.5f));
 			}


### PR DESCRIPTION
Right now, the campfire (!fireplace) will only "cook" aka convert the fishy blob into a food blob with the texture of a cooked fish (with the tooltip name "Cooked Fish") food blob. In this PR I extend that functionality to steaks (creates "Cooked Steaks"), grain ("Bread"), and eggs ("Cake").

"Half" of this PR is just a visual difference (Cooked Steak), while the rest are actual mechanical benefits (Bread, Cake) for the player. Hopefully, this will encourage the player to use the fireplace more, even when it is located in a spot where using it to light fire arrows would be useless..