### PR TITLE
Added ability to upgrade damaged wood blocks

### DIFF
--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -86,9 +86,9 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 	{
 		//repair like tiles
 	}
-	else if (backtile.type == CMap::tile_wood && buildTile == CMap::tile_castle)
+	else if (buildTile == CMap::tile_castle && backtile.type >= CMap::tile_wood && backtile.type <= CMap::tile_wood_d0 && !map.isInFire(p))
 	{
-		// can build stone on wood, do nothing
+		// can build stone on wood when not on fire, do nothing
 	}
 	else if (buildTile == CMap::tile_wood_back && backtile.type == CMap::tile_castle_back)
 	{


### PR DESCRIPTION
## Status

**READY**

## Description

This adds the ability to place stone blocks on damaged wood blocks only if the wood isn't on fire. You shouldn't be able to repair wood blocks that are on fire because that'll make stopping fire easier.

Closes #295

## Steps to Test or Reproduce

Place stone blocks on damaged wood