### PR TITLE
Miscellaneous dinghy improvements.

### DIFF
--- a/Entities/Vehicles/Boats/Dinghy.as
+++ b/Entities/Vehicles/Boats/Dinghy.as
@@ -27,6 +27,7 @@ void onInit(CBlob@ this)
 	this.getShape().SetCenterOfMassOffset(Vec2f(-1.5f, 4.5f));
 	this.getShape().getConsts().transports = true;
 	this.Tag("medium weight");
+	this.Tag("short raid time"); // captures quicker
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Vehicles/Boats/Dinghy.as
+++ b/Entities/Vehicles/Boats/Dinghy.as
@@ -85,7 +85,8 @@ bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {
 	return !this.hasAttached() &&
 	       (!this.isInWater() || this.isOnMap()) &&
-	       this.getOldVelocity().LengthSquared() < 4.0f;
+	       this.getOldVelocity().LengthSquared() < 4.0f &&
+		   this.getTeamNum() == byBlob.getTeamNum();
 }
 
 void onTick(CBlob@ this)

--- a/Entities/Vehicles/Boats/Dinghy.cfg
+++ b/Entities/Vehicles/Boats/Dinghy.cfg
@@ -9,6 +9,8 @@ $sprite_factory                            = generic_sprite
 @$sprite_scripts                           = SeatsGUI.as;
 											 Wooden.as;
 											 FireAnim.as;
+											 # add VehicleConvert.as to sprites for capture bar.
+											 # VehicleConvert.as;
 $sprite_texture                            = Dinghy.png
 s32_sprite_frame_width                     = 64
 s32_sprite_frame_height                    = 32

--- a/Entities/Vehicles/Boats/Dinghy.cfg
+++ b/Entities/Vehicles/Boats/Dinghy.cfg
@@ -108,7 +108,7 @@ $name                                      = dinghy
 										 Seats.as;
 										 Wooden.as;
 										# DecayOnLand.as;
-										 DecayIfLeftAlone.as;
+										# DecayIfLeftAlone.as;
 										 #HurtOnCollide.as;
 										 GenericHit.as;
 										 Vehicle.as;

--- a/Entities/Vehicles/Common/VehicleConvert.as
+++ b/Entities/Vehicles/Common/VehicleConvert.as
@@ -4,17 +4,20 @@
 
 const string counter_prop = "capture ticks";
 const string raid_tag = "under raid";
-const int capture_seconds = 15;
+const int capture_half_seconds = 30;
+const int short_capture_half_seconds = 15;
 const int capture_radius = 80;
 
 const string friendly_prop = "capture friendly count";
 const string enemy_prop = "capture enemy count";
 
+const string short_raid_tag = "short raid time";
+
 void onInit(CBlob@ this)
 {
 	this.addCommandID("convert");
-	this.getCurrentScript().tickFrequency = 30;
-	this.set_s16(counter_prop, capture_seconds);
+	this.getCurrentScript().tickFrequency = 15;
+	this.set_s16(counter_prop, GetCaptureTime(this));
 	this.set_s16(friendly_prop, 0);
 	this.set_s16(enemy_prop, 0);
 }
@@ -71,13 +74,13 @@ void onTick(CBlob@ this)
 			}
 		}
 
-		int ticks = capture_seconds;
+		int ticks = GetCaptureTime(this);
 		if (this.hasTag(raid_tag))
 		{
 			ticks = this.get_s16(counter_prop);
 		}
 
-		if (attackersCount > 0 || ticks < capture_seconds)
+		if (attackersCount > 0 || ticks < GetCaptureTime(this))
 		{
 			//convert
 			if (attackersCount > friendlyCount)
@@ -87,7 +90,7 @@ void onTick(CBlob@ this)
 			//un-convert gradually
 			else if (attackersCount < friendlyCount || attackersCount == 0)
 			{
-				ticks = Maths::Min(ticks + 1, capture_seconds);
+				ticks = Maths::Min(ticks + 1, GetCaptureTime(this));
 			}
 
 			this.set_s16(counter_prop, ticks);
@@ -118,7 +121,7 @@ void onTick(CBlob@ this)
 		this.set_s16(friendly_prop, 0);
 		this.set_s16(enemy_prop, 0);
 
-		this.set_s16(counter_prop, capture_seconds);
+		this.set_s16(counter_prop, GetCaptureTime(this));
 		this.Untag(raid_tag);
 		sync = true;
 	}
@@ -162,6 +165,15 @@ void ConvertPoint(CBlob@ this, const string pointName)
 	}
 }
 
+int GetCaptureTime(CBlob@ blob)
+{
+	if (blob.hasTag(short_raid_tag))
+	{
+		return short_capture_half_seconds;
+	}
+	return capture_half_seconds;
+}
+
 
 // alert and capture progress bar
 
@@ -199,6 +211,6 @@ void onRender(CSprite@ this)
 	s32 captureTime = blob.get_s16(counter_prop);
 	GUI::DrawProgressBar(Vec2f(pos2d.x - hwidth + padding, pos2d.y + hheight - 18 - padding),
 	                     Vec2f(pos2d.x + hwidth - padding, pos2d.y + hheight - padding),
-	                     1.0f - float(captureTime) / float(capture_seconds));
+	                     1.0f - float(captureTime) / float(GetCaptureTime(blob)));
 
 }


### PR DESCRIPTION
## Status

- **READY**

## Description

1. Added a button to dinghy akin to storage's dump-inventory button. Dumps every item in your inventory into the dinghy.
2. Dinghies can only be picked up by same team players.
3. Dinghies take less time to capture than other vehicles (7.5 seconds compared to 15 seconds)

## Steps to Test or Reproduce

**0.** Spawn a dinghy with !dinghy (assuming sv_test is set to 1)
**1.** Dinghy dump inventory button
     - Put items in your inventory. Button should not appear if there are no items in your inventory.
     - Test with dinghy not carried / carried. Button should only appear when not carried.
     - Test with dinghy same / different team. Button should only appear with same team.

**2.** Dinghy can only be picked up by same team players.
    - Try to pick up a dinghy as same team and different team. 
**3.** Dinghy captures quicker than other vehicles.
    - Capture a dinghy and compare to other vehicle capture times.