### PR TITLE
Change range of the buy button for trader post

### DIFF
--- a/Entities/Industry/Trading/TradingMenu.as
+++ b/Entities/Industry/Trading/TradingMenu.as
@@ -54,7 +54,8 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
-		caller.CreateGenericButton("$trade$", Vec2f_zero, this, this.getCommandID("stock"), getTranslatedString("Shop"), params);
+		CButton@ button = caller.CreateGenericButton("$trade$", Vec2f_zero, this, this.getCommandID("stock"), getTranslatedString("Shop"), params);
+		button.enableRadius = 32;
 	}
 }
 


### PR DESCRIPTION
Before you could buy stuff far away from trading post.
This fix make player be able to buy stuff only when he is close to it.

Images:
before
![image](https://user-images.githubusercontent.com/26719582/50442299-4814e880-090f-11e9-9b89-6253896f0f91.png)

after
![image](https://user-images.githubusercontent.com/26719582/50442305-54994100-090f-11e9-9a4b-618f03a45342.png)

proposed to me by Biurza (: