### PR TITLE
Added player heads to scoreboard

### DIFF
--- a/Entities/Characters/Scripts/RunnerHead.as
+++ b/Entities/Characters/Scripts/RunnerHead.as
@@ -115,6 +115,7 @@ void onPlayerInfoChanged(CSprite@ this)
 CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 {
 	CBlob@ blob = this.getBlob();
+	CPlayer@ player = blob.getPlayer();
 
 	// strip old head
 	this.RemoveSpriteLayer("head");
@@ -132,10 +133,9 @@ CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 	{
 		//accolade custom head handling
 		//todo: consider pulling other custom head stuff out to here
-		CPlayer@ p = blob.getPlayer();
-		if (p !is null && !p.isBot())
+		if (player !is null && !player.isBot())
 		{
-			Accolades@ acc = getPlayerAccolades(p.getUsername());
+			Accolades@ acc = getPlayerAccolades(player.getUsername());
 			if (acc.hasCustomHead())
 			{
 				texture_file = "Sprites/" + acc.customHeadTexture + ".png";
@@ -150,12 +150,11 @@ CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 		//not default head; do not use accolades data
 	}
 
+	int team = doTeamColour(headsPackIndex) ? blob.getTeamNum() : 0;
+	int skin = doSkinColour(headsPackIndex) ? blob.getSkinNum() : 0;
+
 	//add new head
-	CSpriteLayer@ head = this.addSpriteLayer(
-		"head", texture_file, 16, 16,
-		(doTeamColour(headsPackIndex) ? this.getBlob().getTeamNum() : 0),
-		(doSkinColour(headsPackIndex) ? this.getBlob().getSkinNum() : 0)
-	);
+	CSpriteLayer@ head = this.addSpriteLayer("head", texture_file, 16, 16, team, skin);
 
 	//
 	headIndex = headIndex % 256; // wrap DLC heads into "pack space"
@@ -179,6 +178,17 @@ CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 	//setup gib properties
 	blob.set_s32("head index", headFrame);
 	blob.set_string("head texture", texture_file);
+	blob.set_s32("head team", team);
+	blob.set_s32("head skin", skin);
+
+	//properties for scoreboard head icon
+	if (player !is null)
+	{
+		player.set_s32("head index", headFrame);
+		player.set_string("head texture", texture_file);
+		player.set_s32("head team", team);
+		player.set_s32("head skin", skin);
+	}
 
 	return head;
 }

--- a/Rules/CommonScripts/ScoreboardCommon.as
+++ b/Rules/CommonScripts/ScoreboardCommon.as
@@ -43,6 +43,58 @@ SColor getNameColour(CPlayer@ p)
 
 }
 
+//similar to the one in RunnerHead.as
+int getHeadFrame(CPlayer@ player, int headIndex, bool default_pack)
+{
+	if(headIndex < NUM_UNIQUEHEADS)
+	{
+		return headIndex * NUM_HEADFRAMES;
+	}
+
+	//special heads logic for default heads pack
+	if(default_pack && (headIndex == 255 || headIndex == NUM_UNIQUEHEADS))
+	{
+		CRules@ rules = getRules();
+		bool holidayhead = false;
+		if(rules !is null && rules.exists("holiday"))
+		{
+			const string HOLIDAY = rules.get_string("holiday");
+			if(HOLIDAY == "Halloween")
+			{
+				headIndex = NUM_UNIQUEHEADS + 43;
+				holidayhead = true;
+			}
+			else if(HOLIDAY == "Christmas")
+			{
+				headIndex = NUM_UNIQUEHEADS + 61;
+				holidayhead = true;
+			}
+		}
+
+		//if nothing special set
+		if(!holidayhead)
+		{
+			u16 classnum = player.getScoreboardFrame();
+			switch (classnum)
+			{
+				case 3:
+					headIndex = NUM_UNIQUEHEADS + 1;
+					break;
+				case 2:
+					headIndex = NUM_UNIQUEHEADS + 2;
+					break;
+				case 1:
+				default:
+					headIndex = NUM_UNIQUEHEADS;
+					break;
+			}
+		}
+	}
+
+	return (((headIndex - NUM_UNIQUEHEADS / 2) * 2) +
+	        (player.getSex() == 0 ? 0 : 1)) * NUM_HEADFRAMES;
+}
+
 void setSpectatePlayer(string username)
 {
     CPlayer@ player = getLocalPlayer();

--- a/Rules/CommonScripts/ScoreboardCommon.as
+++ b/Rules/CommonScripts/ScoreboardCommon.as
@@ -43,58 +43,6 @@ SColor getNameColour(CPlayer@ p)
 
 }
 
-//similar to the one in RunnerHead.as
-int getHeadFrame(CPlayer@ player, int headIndex, bool default_pack)
-{
-	if(headIndex < NUM_UNIQUEHEADS)
-	{
-		return headIndex * NUM_HEADFRAMES;
-	}
-
-	//special heads logic for default heads pack
-	if(default_pack && (headIndex == 255 || headIndex == NUM_UNIQUEHEADS))
-	{
-		CRules@ rules = getRules();
-		bool holidayhead = false;
-		if(rules !is null && rules.exists("holiday"))
-		{
-			const string HOLIDAY = rules.get_string("holiday");
-			if(HOLIDAY == "Halloween")
-			{
-				headIndex = NUM_UNIQUEHEADS + 43;
-				holidayhead = true;
-			}
-			else if(HOLIDAY == "Christmas")
-			{
-				headIndex = NUM_UNIQUEHEADS + 61;
-				holidayhead = true;
-			}
-		}
-
-		//if nothing special set
-		if(!holidayhead)
-		{
-			u16 classnum = player.getScoreboardFrame();
-			switch (classnum)
-			{
-				case 3:
-					headIndex = NUM_UNIQUEHEADS + 1;
-					break;
-				case 2:
-					headIndex = NUM_UNIQUEHEADS + 2;
-					break;
-				case 1:
-				default:
-					headIndex = NUM_UNIQUEHEADS;
-					break;
-			}
-		}
-	}
-
-	return (((headIndex - NUM_UNIQUEHEADS / 2) * 2) +
-	        (player.getSex() == 0 ? 0 : 1)) * NUM_HEADFRAMES;
-}
-
 void setSpectatePlayer(string username)
 {
     CPlayer@ player = getLocalPlayer();

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -1,6 +1,5 @@
 #include "ScoreboardCommon.as";
 #include "Accolades.as";
-#include "RunnerHead.as";
 
 CPlayer@ hoveredPlayer;
 Vec2f hoveredPos;
@@ -41,7 +40,7 @@ string[] age_description = {
 //returns the bottom
 float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emblem)
 {
-	if (players.size() <= 0)
+	if (players.size() <= 0 || team is null)
 		return topleft.y;
 	Vec2f orig = topleft; //save for later
 
@@ -149,35 +148,12 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 		string playername = p.getCharacterName();
 		string clantag = p.getClantag();
 
-		//head vars
-		int headIndex = p.getHead();
-		int headsPackIndex = getHeadsPackIndex(headIndex);
-		HeadsPack@ headsPack = getHeadsPackByIndex(headsPackIndex);
-		string textureFile = headsPack.filename;
-		int teamIndex = doTeamColour(headsPackIndex) ? p.getTeamNum() : 0;
-		bool overrideHead = false;
+		//head icon
+		int headIndex = p.get_s32("head index");
+		string headTexture = p.get_string("head texture");
+		int teamIndex = p.get_s32("head team");
 
-		//accolade head check
-		bool defaultHead = (headIndex == 255 || headIndex == NUM_UNIQUEHEADS);
-		if (defaultHead && !p.isBot())
-		{
-			Accolades@ acc = getPlayerAccolades(p.getUsername());
-			if (acc.hasCustomHead())
-			{
-				textureFile = "Sprites/" + acc.customHeadTexture + ".png";
-				headIndex = acc.customHeadIndex;
-				headsPackIndex = 0;
-				overrideHead = true;
-			}
-		}
-
-		//override head index if accolade head
-		headIndex = overrideHead ?
-			(headIndex * NUM_HEADFRAMES) :
-			getHeadFrame(p, headIndex, headsPackIndex == 0);
-
-		//display head icon
-		GUI::DrawIcon(textureFile, headIndex, Vec2f(16, 16), topleft + Vec2f(22, -12), 1.0f, teamIndex);
+		GUI::DrawIcon(headTexture, headIndex, Vec2f(16, 16), topleft + Vec2f(22, -12), 1.0f, teamIndex);
 
 		//have to calc this from ticks
 		s32 ping_in_ms = s32(p.getPing() * 1000.0f / 30.0f);

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -405,7 +405,7 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 		GUI::DrawText("" + ping_in_ms, Vec2f(bottomright.x - 260, topleft.y), SColor(0xffffffff));
 		GUI::DrawText("" + p.getKills(), Vec2f(bottomright.x - 190, topleft.y), SColor(0xffffffff));
 		GUI::DrawText("" + p.getDeaths(), Vec2f(bottomright.x - 120, topleft.y), SColor(0xffffffff));
-		GUI::DrawText(("" + getKDR(p)).substr(0, 4), Vec2f(bottomright.x - 50, topleft.y), SColor(0xffffffff));
+		GUI::DrawText("" + formatFloat(getKDR(p), "", 0, 2), Vec2f(bottomright.x - 50, topleft.y), SColor(0xffffffff));
 	}
 
 	return topleft.y;


### PR DESCRIPTION
## Status

**READY**

## Description

- Adds player heads to the scoreboard
- Works with head packs, holiday, accolade and special heads
- Slightly increased padding between players on the scoreboard so heads don't overlap as much
- Includes change to ensure KDR always has two decimal places

Closes #321

## Steps to Test or Reproduce

Press tab