### PR TITLE
No longer able to buy items from destroyed shops

### DIFF
--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -107,6 +107,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (caller is null) { return; }
 		CInventory@ inv = caller.getInventory();
 
+		if (this.getHealth() <= 0)
+		{
+			caller.ClearMenus();
+			return;
+		}
+
 		if (inv !is null && isInRadius(this, caller))
 		{
 			ShopItem[]@ shop_items;


### PR DESCRIPTION
## Status

**READY**

## Description

This prevents purchasing items while looking at a shop's menu after it's been destroyed. Clicking on a shop item just closes the menu and does nothing.

Fixes [this](https://forum.thd.vg/threads/27069/) bug

## Steps to Test or Reproduce

1. Build a shop
2. Open shop menu
3. Have another player destroy the shop
4. Attempt to buy an item