### PR TITLE
In-game emote binder

### DIFF
--- a/Entities/Common/Emotes/EmoteHotkeys.as
+++ b/Entities/Common/Emotes/EmoteHotkeys.as
@@ -1,7 +1,6 @@
 
 #include "EmotesCommon.as";
 
-bool init = false;
 u8 emote_1 = 0;
 u8 emote_2 = 0;
 u8 emote_3 = 0;
@@ -14,64 +13,15 @@ u8 emote_9 = 0;
 
 const string emote_config_file = "EmoteBindings.cfg";
 
-//helper - allow integer entries as well as name entries
-u8 read_emote(ConfigFile@ cfg, string name, u8 default_value)
-{
-	string attempt = cfg.read_string(name, "");
-	if (attempt != "")
-	{
-		//replace quoting and semicolon
-		//TODO: how do we not have a string lib for this?
-		string[] check_str = {";",   "\"", "\"",  "'",  "'"};
-		bool[] check_pos =   {false, true, false, true, false};
-		for(int i = 0; i < check_str.length; i++)
-		{
-			string check = check_str[i];
-			if(check_pos[i]) //check front
-			{
-				if(attempt.substr(0, 1) == check)
-				{
-					attempt = attempt.substr(1, attempt.size() - 1);
-				}
-			}
-			else //check back
-			{
-				if(attempt.substr(attempt.size() - 1, 1) == check)
-				{
-					attempt = attempt.substr(0, attempt.size() - 1);
-				}
-			}
-		}
-		//match
-		for(int i = 0; i < Emotes::names.length; i++)
-		{
-			if(attempt == Emotes::names[i])
-			{
-				return i;
-			}
-		}
-
-		//fallback to u8 read
-		u8 read_val = cfg.read_u8(name, default_value);
-		return read_val;
-	}
-	return default_value;
-}
-
 void onInit(CBlob@ this)
 {
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
 
-	if (!init)
+	ConfigFile cfg = ConfigFile();
+	if (cfg.loadFile("../Cache/" + emote_config_file) ||
+		cfg.loadFile(emote_config_file))
 	{
-		//only load the cfg once to avoid
-		//too much file access!
-		init = true;
-
-		ConfigFile cfg = ConfigFile();
-		cfg.loadFile(emote_config_file);
-
 		emote_1 = read_emote(cfg, "emote_1", Emotes::attn);
 		emote_2 = read_emote(cfg, "emote_2", Emotes::smile);
 		emote_3 = read_emote(cfg, "emote_3", Emotes::frown);

--- a/Entities/Common/Emotes/EmotesCommon.as
+++ b/Entities/Common/Emotes/EmotesCommon.as
@@ -153,3 +153,46 @@ bool is_emote(CBlob@ this, u8 emote = 255, bool checkBlank = false)
 	return time > getGameTime() && index != Emotes::off && (!checkBlank || (index != Emotes::dots));
 }
 
+//helper - allow integer entries as well as name entries
+u8 read_emote(ConfigFile@ cfg, string name, u8 default_value)
+{
+	string attempt = cfg.read_string(name, "");
+	if (attempt != "")
+	{
+		//replace quoting and semicolon
+		//TODO: how do we not have a string lib for this?
+		string[] check_str = {";",   "\"", "\"",  "'",  "'"};
+		bool[] check_pos =   {false, true, false, true, false};
+		for(int i = 0; i < check_str.length; i++)
+		{
+			string check = check_str[i];
+			if(check_pos[i]) //check front
+			{
+				if(attempt.substr(0, 1) == check)
+				{
+					attempt = attempt.substr(1, attempt.size() - 1);
+				}
+			}
+			else //check back
+			{
+				if(attempt.substr(attempt.size() - 1, 1) == check)
+				{
+					attempt = attempt.substr(0, attempt.size() - 1);
+				}
+			}
+		}
+		//match
+		for(int i = 0; i < Emotes::names.length; i++)
+		{
+			if(attempt == Emotes::names[i])
+			{
+				return i;
+			}
+		}
+
+		//fallback to u8 read
+		u8 read_val = cfg.read_u8(name, default_value);
+		return read_val;
+	}
+	return default_value;
+}

--- a/Entities/Common/Emotes/EmotesCommon.as
+++ b/Entities/Common/Emotes/EmotesCommon.as
@@ -52,6 +52,7 @@ namespace Emotes
 		kiss,
 		pickup,
 		raised,
+		clap,
 
 		emotes_total,
 		off
@@ -103,7 +104,8 @@ namespace Emotes
 		"love",
 		"kiss",
 		"pickup",
-		"raised"
+		"raised",
+		"clap"
 	};
 }
 

--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -44,6 +44,7 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 15

--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -44,7 +44,7 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
-													EmoteBinderMenu.as;
+													BindingsMenu.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 15

--- a/Rules/Challenge/gamemode.cfg
+++ b/Rules/Challenge/gamemode.cfg
@@ -10,6 +10,7 @@
     scripts                            = KAG.as;
                                          Challenge.as;
 										 RequestSpawnOnDeath.as;
+                                         EmoteBinderMenu.as;
 										 JoinCoreHooks.as;
 										 CoreHooks.as;
 										 ChatCommands.as;

--- a/Rules/Challenge/gamemode.cfg
+++ b/Rules/Challenge/gamemode.cfg
@@ -33,7 +33,7 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
-										 EmoteBinderMenu.as;
+										 BindingsMenu.as;
 
 no_shadowing                                      = 0
 

--- a/Rules/Challenge/gamemode.cfg
+++ b/Rules/Challenge/gamemode.cfg
@@ -10,7 +10,6 @@
     scripts                            = KAG.as;
                                          Challenge.as;
 										 RequestSpawnOnDeath.as;
-                                         EmoteBinderMenu.as;
 										 JoinCoreHooks.as;
 										 CoreHooks.as;
 										 ChatCommands.as;
@@ -34,6 +33,7 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
+										 EmoteBinderMenu.as;
 
 no_shadowing                                      = 0
 

--- a/Rules/CommonScripts/BindingsMenu.as
+++ b/Rules/CommonScripts/BindingsMenu.as
@@ -1,0 +1,7 @@
+#include "EmoteBinderMenu.as";
+
+void onMainMenuCreated(CRules@ this, CContextMenu@ menu)
+{
+	CContextMenu@ bindingsMenu = Menu::addContextMenu(menu, getTranslatedString("Bindings"));
+	Menu::addContextItem(bindingsMenu, getTranslatedString("Bind Emotes"), "EmoteBinderMenu.as", "void NewEmotesMenu()");
+}

--- a/Rules/CommonScripts/EmoteBinderMenu.as
+++ b/Rules/CommonScripts/EmoteBinderMenu.as
@@ -1,0 +1,166 @@
+//TODO: display emote names when hovered (would require a complete list which EmoteEntries.cfg is not)
+//		update emotes instantly
+
+#include "EmotesCommon.as";
+
+const array<u8> EXCLUDED_EMOTES = {
+	Emotes::dots,
+	Emotes::pickup
+};
+const u8 MENU_WIDTH = 9;
+const u8 MENU_HEIGHT = Maths::Ceil((Emotes::emotes_total - EXCLUDED_EMOTES.length) / MENU_WIDTH) + 2;
+
+int selected = -1;
+
+void onInit(CRules@ this)
+{
+	this.addCommandID("bind emote");
+	this.addCommandID("select keybind");
+	this.addCommandID("close menu");
+
+	//load emote icons
+	for (u16 i = 0; i < Emotes::emotes_total; i++)
+	{
+		AddIconToken(getIconName(i), "Emoticons.png", Vec2f(32, 32), i);
+	}
+}
+
+void NewMenu()
+{
+	//ensure a keybind isn't selected
+	selected = -1;
+	ShowMenu();
+}
+
+void ShowMenu()
+{
+	CPlayer@ player = getLocalPlayer();
+	if (player !is null)
+	{
+		//hide main menu and other gui
+		Menu::CloseAllMenus();
+		getHUD().ClearMenus(true);
+
+		CRules@ rules = getRules();
+		Vec2f center = getDriver().getScreenCenterPos();
+		string description = getTranslatedString("Emote Hotkey Binder");
+		
+		//display main grid menu
+		CGridMenu@ menu = CreateGridMenu(center, null, Vec2f(MENU_WIDTH, MENU_HEIGHT), description);
+		if (menu !is null)
+		{
+			menu.deleteAfterClick = false;
+
+			//press escape to close
+			CBitStream params;
+			menu.AddKeyCommand(KEY_ESCAPE, rules.getCommandID("close menu"), params);
+			menu.SetDefaultCommand(rules.getCommandID("close menu"), params);
+
+			//display emote grid
+			for (int i = 0; i < Emotes::emotes_total; i++)
+			{
+				if (EXCLUDED_EMOTES.find(i) > -1)
+				{
+					continue;
+				}
+
+				CBitStream params;
+				params.write_u8(i);
+				CGridButton@ button = menu.AddButton(getIconName(i), description, rules.getCommandID("bind emote"), Vec2f(1, 1), params);
+			}
+			
+			//fill in extra slots in emote grid
+			menu.FillUpRow();
+
+			//separator with info
+			CGridButton@ separator = menu.AddTextButton("Select a keybind below, then select the emote you want", Vec2f(MENU_WIDTH, 1));
+			separator.clickable = false;
+			separator.SetEnabled(false);
+
+			//get current emote keybinds
+			ConfigFile cfg = ConfigFile();
+			if (!cfg.loadFile("../Cache/EmoteBindings.cfg") &&
+				!cfg.loadFile("EmoteBindings.cfg"))
+			{
+				return;
+			}
+
+			array<u8> emoteBinds = {
+				read_emote(cfg, "emote_1", Emotes::attn),
+				read_emote(cfg, "emote_2", Emotes::smile),
+				read_emote(cfg, "emote_3", Emotes::frown),
+				read_emote(cfg, "emote_4", Emotes::mad),
+				read_emote(cfg, "emote_5", Emotes::laugh),
+				read_emote(cfg, "emote_6", Emotes::wat),
+				read_emote(cfg, "emote_7", Emotes::troll),
+				read_emote(cfg, "emote_8", Emotes::disappoint),
+				read_emote(cfg, "emote_9", Emotes::ladder)
+			};
+			
+			//display row of current emote keybinds
+			for (int i = 0; i < 9; i++)
+			{
+				CBitStream params;
+				params.write_u8(i);
+				CGridButton@ button = menu.AddButton(getIconName(emoteBinds[i]), "Select key " + (i + 1), rules.getCommandID("select keybind"), Vec2f(1, 1), params);
+				button.selectOneOnClick = true;
+				// button.hoverText = "     Key " + (i + 1) + "\n";
+
+				//reselect keybind if one was selected before
+				if (selected == i)
+				{
+					button.SetSelected(1);
+				}
+			}
+		}
+	}
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream @params)
+{
+	if (cmd == this.getCommandID("bind emote"))
+	{
+		//must select keybind first
+		if (selected == -1)
+		{
+			return;
+		}
+
+		u8 emote = params.read_u8();
+		string key = "emote_" + (selected + 1);
+
+		//get emote bindings cfg file
+		ConfigFile cfg = ConfigFile();
+		if (!cfg.loadFile("../Cache/EmoteBindings.cfg") &&
+			!cfg.loadFile("EmoteBindings.cfg"))
+		{
+			return;
+		}
+
+		//bind emote
+		cfg.add_string(key, "" + emote);
+		cfg.saveFile("EmoteBindings.cfg");
+
+		//update keybinds in menu
+		ShowMenu();
+	}
+	else if (cmd == this.getCommandID("select keybind"))
+	{
+		selected = params.read_u8();
+	}
+	else if (cmd == this.getCommandID("close menu"))
+	{
+		getHUD().ClearMenus(true);
+	}
+}
+
+void onMainMenuCreated(CRules@ this, CContextMenu@ menu)
+{
+	//add button to main menu
+	Menu::addContextItem(menu, getTranslatedString("Bind Emotes"), "EmoteBinderMenu.as", "void NewMenu()");
+}
+
+string getIconName(u8 emoteIndex)
+{
+	return "$EMOTE" + (emoteIndex + 1) + "$";
+}

--- a/Rules/CommonScripts/EmoteBinderMenu.as
+++ b/Rules/CommonScripts/EmoteBinderMenu.as
@@ -8,7 +8,7 @@ const array<u8> EXCLUDED_EMOTES = {
 	Emotes::pickup
 };
 const u8 MENU_WIDTH = 9;
-const u8 MENU_HEIGHT = Maths::Ceil((Emotes::emotes_total - EXCLUDED_EMOTES.length) / MENU_WIDTH) + 2;
+const u8 MENU_HEIGHT = Maths::Ceil((Emotes::emotes_total - EXCLUDED_EMOTES.length - 1) / MENU_WIDTH) + 2;
 
 int selected = -1;
 
@@ -25,14 +25,14 @@ void onInit(CRules@ this)
 	}
 }
 
-void NewMenu()
+void NewEmotesMenu()
 {
 	//ensure a keybind isn't selected
 	selected = -1;
-	ShowMenu();
+	ShowEmotesMenu();
 }
 
-void ShowMenu()
+void ShowEmotesMenu()
 {
 	CPlayer@ player = getLocalPlayer();
 	if (player !is null)
@@ -70,7 +70,10 @@ void ShowMenu()
 			}
 			
 			//fill in extra slots in emote grid
-			menu.FillUpRow();
+			if (menu.getButtonsCount() % MENU_WIDTH != 0)
+			{
+				menu.FillUpRow();
+			}
 
 			//separator with info
 			CGridButton@ separator = menu.AddTextButton("Select a keybind below, then select the emote you want", Vec2f(MENU_WIDTH, 1));
@@ -142,7 +145,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 		cfg.saveFile("EmoteBindings.cfg");
 
 		//update keybinds in menu
-		ShowMenu();
+		ShowEmotesMenu();
 	}
 	else if (cmd == this.getCommandID("select keybind"))
 	{
@@ -152,12 +155,6 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 	{
 		getHUD().ClearMenus(true);
 	}
-}
-
-void onMainMenuCreated(CRules@ this, CContextMenu@ menu)
-{
-	//add button to main menu
-	Menu::addContextItem(menu, getTranslatedString("Bind Emotes"), "EmoteBinderMenu.as", "void NewMenu()");
 }
 
 string getIconName(u8 emoteIndex)

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -44,7 +44,7 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
-													EmoteBinderMenu.as;
+													BindingsMenu.as;
 
 daycycle_speed                                    = 10
 daycycle_start                                    = 0.3

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -44,6 +44,7 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
 
 daycycle_speed                                    = 10
 daycycle_start                                    = 0.3

--- a/Rules/TDM/gamemode.cfg
+++ b/Rules/TDM/gamemode.cfg
@@ -43,7 +43,7 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
-													EmoteBinderMenu.as;
+													BindingsMenu.as;
 
 no_shadowing                                      = 1
 

--- a/Rules/TDM/gamemode.cfg
+++ b/Rules/TDM/gamemode.cfg
@@ -43,6 +43,7 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
 
 no_shadowing                                      = 1
 

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -42,7 +42,7 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
-										 EmoteBinderMenu.as;
+										 BindingsMenu.as;
 
     daycycle_speed                     = 15			# 1 day = X minutes; / 0 no cycle
     daycycle_start                     = 0.5        # 0.0 midnight; 0.5 - midday; 1.0 midnight

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -42,7 +42,7 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
-                                         EmoteBinderMenu.as;
+										 EmoteBinderMenu.as;
 
     daycycle_speed                     = 15			# 1 day = X minutes; / 0 no cycle
     daycycle_start                     = 0.5        # 0.0 midnight; 0.5 - midday; 1.0 midnight

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -42,6 +42,7 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
+                                         EmoteBinderMenu.as;
 
     daycycle_speed                     = 15			# 1 day = X minutes; / 0 no cycle
     daycycle_start                     = 0.5        # 0.0 midnight; 0.5 - midday; 1.0 midnight


### PR DESCRIPTION
## Status

**READY**

## Description

This adds an in-game menu which allows you to change the emote for each hotkey.

![image](https://user-images.githubusercontent.com/30195802/50675559-f83acd80-1042-11e9-844b-20ed356e4419.png)


Closes #154

## Steps to Test or Reproduce

1. Join a game
2. Open main menu by clicking escape key
3. Click "Bind Emotes" button
4. Change emotes
5. Respawn to update emotes