### PR TITLE
Held item is no longer dropped when using eat key

### DIFF
--- a/Entities/Characters/Scripts/EatFoodButton.as
+++ b/Entities/Characters/Scripts/EatFoodButton.as
@@ -1,26 +1,10 @@
 #include "Knocked.as"
+#include "EatCommon.as";
 
 void onInit(CBlob@ this)
 {
 	this.getCurrentScript().removeIfTag = "dead";
 }
-
-bool canEat(CBlob@ this, CBlob@ blob)
-{
-	return blob.exists("eat sound");
-}
-
-bool Eat(CBlob@ this, CBlob@ blob)
-{
-	if (canEat(this, blob))
-	{
-		this.server_Pickup(blob);
-		this.server_DetachFrom(blob);
-		return true;
-	}
-	return false;
-}
-
 
 void onTick(CBlob@ this)
 {
@@ -31,9 +15,9 @@ void onTick(CBlob@ this)
 		this.getHealth() < this.getInitialHealth()
 	) {
 		CBlob @carried = this.getCarriedBlob();
-		if (carried !is null && canEat(this, carried))
+		if (carried !is null && canEat(carried))
 		{
-			Eat(this, carried);
+			Heal(this, carried);
 		}
 		else // search in inv
 		{
@@ -41,9 +25,9 @@ void onTick(CBlob@ this)
 			for (int i = 0; i < inv.getItemsCount(); i++)
 			{
 				CBlob @blob = inv.getItem(i);
-				if (canEat(this, blob))
+				if (canEat(blob))
 				{
-					Eat(this, blob);
+					Heal(this, blob);
 					return;
 				}
 			}

--- a/Entities/Items/Food/EatCommon.as
+++ b/Entities/Items/Food/EatCommon.as
@@ -1,0 +1,29 @@
+const string heal_id = "heal command";
+
+bool canEat(CBlob@ blob)
+{
+	return blob.exists("eat sound");
+}
+
+void Heal(CBlob@ this, CBlob@ food)
+{
+	bool exists = getBlobByNetworkID(food.getNetworkID()) !is null;
+	if (getNet().isServer() && this.hasTag("player") && this.getHealth() < this.getInitialHealth() && !food.hasTag("healed") && exists)
+	{
+		CBitStream params;
+		params.write_u16(this.getNetworkID());
+
+		u8 heal_amount = 255; //in quarter hearts, 255 means full hp
+
+		if (food.getName() == "heart")	    // HACK
+		{
+			heal_amount = 4;
+		}
+
+		params.write_u8(heal_amount);
+
+		food.SendCommand(food.getCommandID(heal_id), params);
+
+		food.Tag("healed");
+	}
+}

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -1,5 +1,4 @@
-
-const string heal_id = "heal command";
+#include "EatCommon.as";
 
 void onInit(CBlob@ this)
 {
@@ -9,29 +8,6 @@ void onInit(CBlob@ this)
 	}
 
 	this.addCommandID(heal_id);
-}
-
-void Heal(CBlob@ this, CBlob@ blob)
-{
-	bool exists = getBlobByNetworkID(this.getNetworkID()) !is null;
-	if (getNet().isServer() && blob.hasTag("player") && blob.getHealth() < blob.getInitialHealth() && !this.hasTag("healed") && exists)
-	{
-		CBitStream params;
-		params.write_u16(blob.getNetworkID());
-
-		u8 heal_amount = 255; //in quarter hearts, 255 means full hp
-
-		if (this.getName() == "heart")	    // HACK
-		{
-			heal_amount = 4;
-		}
-
-		params.write_u8(heal_amount);
-
-		this.SendCommand(this.getCommandID(heal_id), params);
-
-		this.Tag("healed");
-	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
@@ -76,7 +52,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 
 	if (getNet().isServer() && !blob.hasTag("dead"))
 	{
-		Heal(this, blob);
+		Heal(blob, this);
 	}
 }
 
@@ -84,7 +60,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
 	if (getNet().isServer())
 	{
-		Heal(this, attached);
+		Heal(attached, this);
 	}
 }
 
@@ -92,7 +68,7 @@ void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 {
 	if (getNet().isServer())
 	{
-		Heal(this, detached);
+		Heal(detached, this);
 	}
 }
 


### PR DESCRIPTION
## Status

**READY**

## Description

Fixed issue where the item your holding is dropped if you heal using the eat key.

## Steps to Test or Reproduce

1. Have food in your inventory
2. Damage yourself
3. Hold a random item in your hand
4. Heal using the eat key
