### PR TITLE
Close range arrow stun duration change

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -732,13 +732,16 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 
 			hitBlob.AddForce(velocity * force);
 
+			// check if shielded
+			const bool hitShield = hitBlob.hasTag("shielded") && blockAttack(hitBlob, vel, 0.0f);
+
 			// stun if shot real close
 			if (
 				this.getTickSinceCreated() <= 4 &&
 				speed > ArcherParams::shoot_max_vel * 0.845f &&
 				hitBlob.hasTag("player")
 			) {
-				SetKnocked(hitBlob, 20);
+				SetKnocked(hitBlob, hitShield ? 25 : 35);
 				Sound::Play("/Stun", hitBlob.getPosition(), 1.0f, this.getSexNum() == 0 ? 1.0f : 1.5f);
 			}
 		}

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -741,7 +741,7 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 				speed > ArcherParams::shoot_max_vel * 0.845f &&
 				hitBlob.hasTag("player")
 			) {
-				SetKnocked(hitBlob, hitShield ? 25 : 35);
+				SetKnocked(hitBlob, hitShield ? 20 : 25);
 				Sound::Play("/Stun", hitBlob.getPosition(), 1.0f, this.getSexNum() == 0 ? 1.0f : 1.5f);
 			}
 		}


### PR DESCRIPTION
## Status

**READY**

## Description

@Franrek wants to increase arrow stuns duration by 5 ticks (1/6sec) if not shielded.

It would make it possible for archer to sneak in 0.5hp damage using quarter-shot after successful stun. Exactly like knight does 1hp damage with jab after slashing or shieldstunnig enemy, except harder to execute since you need to charge it and get the timing right.

The change would allow archers for more aggressive play instead of the strange "foward and back" dance with tripleshot which is completely stupid and boring. Like that archers can risk more to deal more damage making the archer-knight combat more interesting and less stale for both classes.

The 0.5hp sneak in after shieldstun was possible before but there was really no point in using it without 0ping since it would just not work most of the times.

## Steps to Test or Reproduce

Shoot an enemy knight at close range while they are shielding and not shielding