### PR TITLE
Fixed Shy github accolade. Broke with name change.

### DIFF
--- a/Rules/CommonScripts/accolade_data.cfg
+++ b/Rules/CommonScripts/accolade_data.cfg
@@ -1307,7 +1307,7 @@ cameron =
 	# github - THD intern
 	# community - made the popular Gather mod
 
-ComputerCat =
+Shy =
 	github;
 	# github - 'Fixed arrow spawn location for mounted bows.' pull request
 


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes my github contributor accolade to match my new KAG username.

## Steps to Test or Reproduce

join game with Shy

## Images

![image](https://user-images.githubusercontent.com/28541112/51744395-b6afa800-206d-11e9-9b39-25eb7bcb64ba.png)
