### PR TITLE
Update Spanish_es.json

### DIFF
--- a/Locales/Spanish_es.json
+++ b/Locales/Spanish_es.json
@@ -43,7 +43,7 @@
 	"Stone Block\nBasic building block"                     :"Bloque de piedra\nBloque básico de construcción",
 	"Back Stone Wall\nExtra support"                        :"Pared de piedra\nSoporte extra",
 	"Stone Door\nPlace next to walls"                       :"Puerta de piedra\nConstruir al lado de paredes",
-	"Wood Block\nCheap block\nwatch out for fire!"          :"Pared de madera\nBloque barato\nse puede prender en llamas!",
+	"Wood Block\nCheap block\nwatch out for fire!"          :"Bloque de madera\nBloque barato\nse puede prender en llamas!",
 	"Back Wood Wall\nCheap extra support"                   :"Pared de madera\nSoporte extra barato",
 	"Wooden Door\nPlace next to walls"                      :"Puerta de madera\nConstruir al lado de paredes",
 	"Trap Block\nOnly enemies can pass"                     :"Bloque trampa\nSolamente enemigos pueden pasar",


### PR DESCRIPTION
**READY**

Fixed a little typo with wood block and wood backwall:
    "Wood Block\nCheap block\nwatch out for fire!"          :"Pared de madera\nBloque barato\nse puede prender en llamas!",
    "Back Wood Wall\nCheap extra support"                   :"Pared de madera\nSoporte extra barato",
