### PR TITLE
Even more fireplace improvements

### DIFF
--- a/Entities/Characters/Builder/BuilderHittable.as
+++ b/Entities/Characters/Builder/BuilderHittable.as
@@ -6,7 +6,7 @@ const string[] builder_alwayshit =
 {
 	//handmade
 	"workbench",
-	//"fireplace",
+	"fireplace",
 	"ladder",
 
 	//faketiles

--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -24,7 +24,7 @@ namespace CTFCosts
 	//BuilderShop.as
 	s32 lantern_wood, bucket_wood, filled_bucket, sponge, boulder_stone,
 		trampoline_wood, saw_wood, saw_stone, drill_stone, drill,
-		crate_wood, crate;
+		crate_wood, crate, fireplace_wood, fireplace_stone;
 
 	//BoatShop.as
 	s32 dinghy, dinghy_wood, longboat, longboat_wood, warboat;
@@ -124,6 +124,8 @@ void InitCosts()
 	CTFCosts::drill =                       ReadCost(cfg, "cost_drill"              , 25);
 	CTFCosts::crate_wood =                  ReadCost(cfg, "cost_crate_wood"         , 150);
 	CTFCosts::crate =                       ReadCost(cfg, "cost_crate"              , 20);
+	CTFCosts::fireplace_wood =              ReadCost(cfg, "cost_fireplace_wood"     , 100);
+	CTFCosts::fireplace_stone =             ReadCost(cfg, "cost_fireplace_stone"    , 100);
 
 	//BoatShop.as
 	CTFCosts::dinghy =                      ReadCost(cfg, "cost_dinghy"             , 25);

--- a/Entities/Common/Includes/Descriptions.as
+++ b/Entities/Common/Includes/Descriptions.as
@@ -38,6 +38,7 @@ namespace Descriptions
 	saw                        = getTranslatedString("A circular saw that turns tree logs into wood material."),
 	drill                      = getTranslatedString("A mining drill. Increases speed of digging and gathering resources, but gains only half the possible resources."),
 	crate                      = getTranslatedString("An empty wooden crate for storing and transporting inventory."),
+	fireplace                  = getTranslatedString("A log-powered fireplace which ignites arrows that pass through its flames."),
 	food                       = getTranslatedString("For healing. Don't think about this too much."),
 
 	tradingpost                = getTranslatedString("A trading post. Requires a trader to reside inside."),

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -19,7 +19,7 @@ void onInit(CBlob@ this)
 
 	// SHOP
 	this.set_Vec2f("shop offset", Vec2f_zero);
-	this.set_Vec2f("shop menu size", Vec2f(4, 4));
+	this.set_Vec2f("shop menu size", Vec2f(4, 5));
 	this.set_string("shop description", "Buy");
 	this.set_u8("shop icon", 25);
 
@@ -76,6 +76,14 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Crate (coins)", "$crate$", "crate", Descriptions::crate, false);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::crate);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Fireplace", "$fireplace$", "fireplace", Descriptions::fireplace, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::fireplace_wood);
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::fireplace_stone);
 	}
 }
 

--- a/Entities/Industry/Fireplace/Fireplace.as
+++ b/Entities/Industry/Fireplace/Fireplace.as
@@ -126,6 +126,8 @@ void Extinguish(CBlob@ this)
 	this.getSprite().SetAnimation("nofire");
 	this.getSprite().SetEmitSoundPaused(true);
 	this.getSprite().PlaySound("/ExtinguishFire.ogg");
+
+	this.set_f32("fire time", 0);
 	
 	CSpriteLayer@ fire = this.getSprite().getSpriteLayer("fire_animation_large");
 	if (fire !is null)
@@ -161,4 +163,9 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		Extinguish(this);
 	}
 	return damage;
+}
+
+bool canBePickedUp(CBlob@ this, CBlob@ blob)
+{
+	return this.getSprite().isAnimation("nofire");
 }

--- a/Entities/Industry/Fireplace/Fireplace.cfg
+++ b/Entities/Industry/Fireplace/Fireplace.cfg
@@ -11,7 +11,7 @@ $sprite_texture                            = Fireplace.png
 s32_sprite_frame_width                     = 16
 s32_sprite_frame_height                    = 16
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = -3
+f32 sprite_offset_y                        = -5
 
 	$sprite_gibs_start                     = *start*
 
@@ -44,47 +44,54 @@ f32 sprite_offset_y                        = -3
 $shape_factory                             = box2d_shape
 
 @$shape_scripts                            = 
-f32 shape_mass                             = 10.0
+f32 shape_mass                             = 40.0
 f32 shape_radius                           = 8.0
-f32 shape_friction                         = 0.0
-f32 shape_elasticity                       = 0.0
+f32 shape_friction                         = 0.6
+f32 shape_elasticity                       = 0.2
 f32 shape_buoyancy                         = 0.0
-f32 shape_drag                             = 0.0
+f32 shape_drag                             = 0.5
 bool shape_collides                        = no
 bool shape_ladder                          = no
 bool shape_platform                        = no
  #block_collider
-@f32 verticesXY                            = 0.0; 0.0;
-                                             16.0; 0.0;
-                                             16.0; 8.0;
-                                             0.0; 8.0;
+@f32 verticesXY                            = 5.0; 3.0;
+											 11.0; 3.0;
+                                             15.0; 6.0;
+                                             13.0; 8.0;
+                                             3.0; 8.0;
+                                             1.0; 6.0;
+											 
 
 u8 block_support                           = 0
 bool block_background                      = no
 bool block_lightpasses                     = no
-bool block_snaptogrid                      = yes
+bool block_snaptogrid                      = no
 
 $movement_factory                          =
 $brain_factory                             =	
-$attachment_factory                        =
+
+$attachment_factory                        = box2d_attachment
+@$attachment_scripts                       =
+@$attachment_points                        = PICKUP; 0; 0; 1; 0; 0;
+
 $inventory_factory                         =
 
 # general
 
 $name                                      = fireplace
-@$scripts                                  = DefaultNoBuild.as;
-											 Settle.as;
-											 DecayInWater.as;
+@$scripts                                  = DecayInWater.as;
 											 Wooden.as;
 											 Fireplace.as;
 											 WoodStructureHit.as;
-f32_health                                 = 6.0
+											 GenericHit.as;
+											 SetTeamToCarrier.as;
+f32_health                                 = 4.0
 # looks & behaviour inside inventory
 $inventory_name                            = Fireplace
 $inventory_icon                            = -
 u8 inventory_icon_frame                    = 0
-u8 inventory_icon_frame_width          = 0
-u8 inventory_icon_frame_height         = 0
-u8 inventory_used_width                    = 0
-u8 inventory_used_height                   = 0
-u8 inventory_max_stacks                    = 0
+u8 inventory_icon_frame_width              = 0
+u8 inventory_icon_frame_height             = 0
+u8 inventory_used_width                    = 1
+u8 inventory_used_height                   = 1
+u8 inventory_max_stacks                    = 1

--- a/Entities/Industry/Workbench/Workbench.as
+++ b/Entities/Industry/Workbench/Workbench.as
@@ -21,6 +21,8 @@ void InitWorkshop(CBlob@ this)
 {
 	InitCosts(); //read from cfg
 
+	AddIconToken("$_buildershop_filled_bucket$", "Bucket.png", Vec2f(16, 16), 1);
+
 	this.set_Vec2f("shop offset", Vec2f_zero);
 	this.set_Vec2f("shop menu size", Vec2f(4, 5));
 
@@ -33,16 +35,25 @@ void InitWorkshop(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::bucket_wood);
 	}
 	{
+		ShopItem@ s = addShopItem(this, "Filled Bucket", "$_buildershop_filled_bucket$", "filled_bucket", Descriptions::filled_bucket, false);
+		s.spawnNothing = true;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::bucket_wood);
+		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::filled_bucket);
+	}
+	{
 		ShopItem@ s = addShopItem(this, "Sponge", "$sponge$", "sponge", Descriptions::sponge, false);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::sponge_wood);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Trampoline", "$trampoline$", "trampoline", Descriptions::trampoline, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::trampoline_wood);
+		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", WARCosts::boulder_stone);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Crate", "$crate$", "crate", Descriptions::crate, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::crate_wood);
+		ShopItem@ s = addShopItem(this, "Trampoline", "$trampoline$", "trampoline", Descriptions::trampoline, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::trampoline_wood);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Drill", "$drill$", "drill", Descriptions::drill, false);
@@ -51,17 +62,35 @@ void InitWorkshop(CBlob@ this)
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Saw", "$saw$", "saw", Descriptions::saw, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::saw_wood);
 		AddRequirement(s.requirements, "tech", "saw", "Saw Technology");
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Dinghy", "$dinghy$", "dinghy", Descriptions::dinghy, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::dinghy_wood);
-		AddRequirement(s.requirements, "tech", "dinghy", "Dinghy Technology");
+		ShopItem@ s = addShopItem(this, "Crate (wood)", "$crate$", "crate", Descriptions::crate, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::crate_wood);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
-		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", WARCosts::boulder_stone);
+		ShopItem@ s = addShopItem(this, "Crate (coins)", "$crate$", "crate", Descriptions::crate, false);
+		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::crate);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Fireplace", "$fireplace$", "fireplace", Descriptions::fireplace, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::fireplace_wood);
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::fireplace_stone);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Dinghy", "$dinghy$", "dinghy", Descriptions::dinghy, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::dinghy_wood);
+		AddRequirement(s.requirements, "tech", "dinghy", "Dinghy Technology");
 	}
 }
 
@@ -79,6 +108,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		bool producing = params.read_bool();
 		string blobName = params.read_string();
 		u8 s_index = params.read_u8();
+
+		CBlob@ callerBlob = getBlobByNetworkID(callerID);
+		if (callerBlob is null)
+		{
+			return;
+		}
+
+		if (blobName == "filled_bucket")
+		{
+			CBlob@ b = server_CreateBlobNoInit("bucket");
+			b.setPosition(callerBlob.getPosition());
+			b.server_setTeamNum(callerBlob.getTeamNum());
+			b.Tag("_start_filled");
+			b.Init();
+			callerBlob.server_Pickup(b);
+		}
 
 		// check spam
 		//if (blobName != "factory" && isSpammed( blobName, this.getPosition(), 12 ))

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -312,6 +312,12 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 		return false;
 	}
 
+	//collide so normal arrows can be ignited
+	if (blob.getName() == "fireplace")
+	{
+		return true;
+	}
+
 	//anything to always hit
 	if (specialArrowHit(blob))
 	{

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -269,7 +269,7 @@ class PNGLoader
 			case map_colors::research:        autotile(offset); spawnBlob(map, "research",    offset); break;
 
 			case map_colors::workbench:       autotile(offset); spawnBlob(map, "workbench",   offset, 255, true); break;
-			case map_colors::campfire:        autotile(offset); spawnBlob(map, "fireplace",   offset, 255, true, Vec2f(0.0f, -4.0f)); break;
+			case map_colors::campfire:        autotile(offset); spawnBlob(map, "fireplace",   offset, 255); break;
 			case map_colors::saw:             autotile(offset); spawnBlob(map, "saw",         offset); break;
 
 			// Flora


### PR DESCRIPTION
## Status

**READY**

## Description

**Changes**
- Unlit fireplaces can be picked up and put in your inventory (1x1 slot size)
- Fireplaces rotate so they don't look like they are levitating when put on the edge of a block
- Modified fireplace hitbox which makes it sit properly on the ground when upside down. It also makes it slightly harder for it to roll upside down
- Builders can hit fireplaces
- Bombs / water bombs knock around fireplaces now that fireplaces no longer become static
- Fireplaces are log-powered, except those spawned in with the map (or spawned in using commands when your team is -1)
- Added fireplace to builder shop (CTF) and workbench (TTH) which costs 100 wood and 100 stone

**Fixes**
- Fireplaces no longer become static, especially when the map loads which caused them to float
- Added missing shop items to workbench and reorganised them to match builder shop layout

**Issues**
- You can throw fireplaces into logs to fuel the fireplace which doesn't really make sense. It does make it easy to fuel the fireplace with a lot of logs though. I don't know the best way to fix this.

## Steps to Test or Reproduce

Experiment with builder shop, workbench, fireplaces and logs
