### PR TITLE
[modified] Mapcycle - move 8 old maps to returning maps pool

### DIFF
--- a/Rules/CTF/mapcycle.cfg
+++ b/Rules/CTF/mapcycle.cfg
@@ -6,8 +6,6 @@ mapcycle =
 			Maps/CTF/Community/Aug17/4zK_Rorschach.png;
 			Maps/CTF/Community/Aug17/4zK_Stubs.png;
 				#8x
-			Maps/CTF/Community/8x_PorkBuns.png;
-			Maps/CTF/Community/Dec16/8x_BaldJoyce.png;
 			Maps/CTF/Community/Jan18/8x_Gloryhill2.png;
 			Maps/CTF/Community/Aug17/8x_Grounds.png;
 				#Asu
@@ -16,20 +14,14 @@ mapcycle =
 			Maps/CTF/Community/Jan18/bunnie_Lech_Walesa.png;
 			Maps/CTF/Community/Oct18/bunnie_Luthadel.png;
 				#Ej
-			Maps/CTF/Community/Ej_Chambers.png;
 			Maps/CTF/Community/Oct18/Ej_Cataracts.png;
 				#Ferrezinhre
 			Maps/CTF/Community/Jan18/Ferrezinhre_Highlands.png;
 				#Geti
 			Maps/CTF/HearthPlains.png;
 			Maps/CTF/Snatchmark.png;
-				#Gurin
-			Maps/CTF/Community/Gurin_DoubleSided.png;
 				#Fuzzle
 			Maps/CTF/Community/Aug17/Fuzzle_Stale.png;
-				#JTG
-			Maps/CTF/Community/JTG_Aqueduct.png;
-			Maps/CTF/Community/Nov16/JTG_FirstBadlands.png;
 				#mcrifel
 			Maps/CTF/Community/Mar17/mcrifel_Steppes.png;
 			Maps/CTF/Community/Oct17/mcrifel_fish.png;
@@ -40,7 +32,6 @@ mapcycle =
 				#Oodle
 			Maps/CTF/Community/Oodle_Stonethrow.png;
 				#Punk123 (Panky :3)
-			Maps/CTF/Community/Oct16/Punk123_PlatformedPredicament.png;
 			Maps/CTF/Community/Aug17/Punk123_SkinnedCastle.png;
 			Maps/CTF/Community/Jan18/Punk123_PrincessCity2.png;
 				#Radioactive
@@ -54,7 +45,6 @@ mapcycle =
 			Maps/CTF/Community/Aug17/SJD360_Abrogation.png;
 			Maps/CTF/Community/Oct17/SJD360_Stampede.png;
 				#Skinney
-			Maps/CTF/Community/Skinney_Bluff.png;
 			Maps/CTF/Community/Skinney_Crypt.png;
 			Maps/CTF/Community/Skinney_Typhoon.png;
 			Maps/CTF/Community/Aug17/Skinney_Descent.png;


### PR DESCRIPTION
## Status

**READY**

## Description

Move 8 old maps to the returning maps pool so CTF mapcycle stays at 30.
