### PR TITLE
Quick swap class

### DIFF
--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -16,11 +16,6 @@ void InitRespawnCommand(CBlob@ this)
 	this.addCommandID("class menu");
 }
 
-bool isInRadius(CBlob@ this, CBlob @caller)
-{
-	return ((this.getPosition() - caller.getPosition()).Length() < this.getRadius() * 2.0f + caller.getRadius());
-}
-
 bool canChangeClass(CBlob@ this, CBlob@ blob)
 {
 
@@ -72,6 +67,7 @@ void onRespawnCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				// build menu for them
 				CBlob@ caller = getBlobByNetworkID(params.read_u16());
 				BuildRespawnMenuFor(this, caller);
+				this.set_bool("quick switch class", false);
 			}
 		}
 		break;
@@ -177,4 +173,37 @@ void PutInvInStorage(CBlob@ blob)
 				return;
 			}
 		}
+}
+
+void CycleClass(CBlob@ this, CBlob@ blob)
+{
+	//get available classes
+	PlayerClass[]@ classes;
+	if (this.get("playerclasses", @classes))
+	{
+		CBitStream params;
+		PlayerClass @newclass;
+
+		//find current class
+		for (uint i = 0; i < classes.length; i++)
+		{
+			PlayerClass @pclass = classes[i];
+			if (pclass.name.toLower() == blob.getName())
+			{
+				//cycle to next class
+				@newclass = classes[(i + 1) % classes.length];
+				break;
+			}
+		}
+
+		if (newclass is null)
+		{
+			//select default class
+			@newclass = getDefaultClass(this);
+		}
+
+		//switch to class
+		write_classchange(params, blob.getNetworkID(), newclass.configFilename);
+		this.SendCommand(SpawnCmd::changeClass, params);
+	}
 }

--- a/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
+++ b/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
@@ -2,6 +2,8 @@
 
 #include "ClassSelectMenu.as"
 #include "StandardRespawnCommand.as"
+#include "StandardControlsCommon.as"
+#include "RespawnCommandCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -19,6 +21,23 @@ void onInit(CBlob@ this)
 	this.Tag("change class drop inventory");
 
 	this.getSprite().SetZ(-50.0f);   // push to background
+}
+
+void onTick(CBlob@ this)
+{
+	//quick switch class
+	CBlob@ blob = getLocalPlayerBlob();
+	if (blob !is null && blob.isMyPlayer())
+	{
+		if (
+			isInRadius(this, blob) && //blob close enough to ruins
+			blob.isKeyJustReleased(key_use) && //just released e
+			isTap(blob, 7) && //tapped e
+			blob.getTickSinceCreated() > 1 //prevents infinite loop of swapping class
+		) {
+			CycleClass(this, blob);
+		}
+	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
@@ -43,8 +62,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (canChangeClass(this, caller))
 	{
-		Vec2f pos = this.getPosition();
-		if ((pos - caller.getPosition()).Length() < this.getRadius())
+		if (isInRadius(this, caller))
 		{
 			BuildRespawnMenuFor(this, caller);
 		}
@@ -57,4 +75,9 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	}
 
 	// warning: if we don't have this button just spawn menu here we run into that infinite menus game freeze bug
+}
+
+bool isInRadius(CBlob@ this, CBlob @caller)
+{
+	return (this.getPosition() - caller.getPosition()).Length() < this.getRadius();
 }

--- a/Entities/Special/Tent/TentLogic.as
+++ b/Entities/Special/Tent/TentLogic.as
@@ -1,6 +1,7 @@
 // Tent logic
 
 #include "StandardRespawnCommand.as"
+#include "StandardControlsCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -19,6 +20,23 @@ void onInit(CBlob@ this)
 
 	// defaultnobuild
 	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 8.0f));
+}
+
+void onTick(CBlob@ this)
+{
+	//quick switch class
+	CBlob@ blob = getLocalPlayerBlob();
+	if (blob !is null && blob.isMyPlayer())
+	{
+		if (
+			canChangeClass(this, blob) && blob.getTeamNum() == this.getTeamNum() && //can change class
+			blob.isKeyJustReleased(key_use) && //just released e
+			isTap(blob, 4) && //tapped e
+			blob.getTickSinceCreated() > 1 //prevents infinite loop of swapping class
+		) {
+			CycleClass(this, blob);
+		}
+	}
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Special/WAR/WAR_base/WAR_base.as
+++ b/Entities/Special/WAR/WAR_base/WAR_base.as
@@ -397,6 +397,11 @@ s16 woodTilUpgrade(CBlob@ this)
 	return upgradeAmount(this, upgrade_level) - wood_amount;
 }
 
+bool isInRadius(CBlob@ this, CBlob @caller)	
+{	
+	return ((this.getPosition() - caller.getPosition()).Length() < this.getRadius() * 2.0f + caller.getRadius());	
+}
+
 ////////////////////////////////////////////////////
 //Interactions
 ////////////////////////////////////////////////////


### PR DESCRIPTION
## Status

**READY**

## Description

- Tap 'e' to quickly swap to each class at a tent or TDM ruins
- Ruins require you to tap within 7 ticks (the same as quick switching bomb/arrow types)
- Tents require you to tap within 4 ticks otherwise it would be irritating waiting for the menu to open
- Halls have been neglected for the time being since they are acting a bit spoopy :P

Closes #373

## Steps to Test or Reproduce

Tap the use key ('e') while in front of a tent or ruins