### PR TITLE
Adjust grapple length

### DIFF
--- a/Entities/Characters/Archer/ArcherCommon.as
+++ b/Entities/Characters/Archer/ArcherCommon.as
@@ -40,6 +40,8 @@ const f32 archer_grapple_force = 2.0f;
 const f32 archer_grapple_accel_limit = 1.5f;
 const f32 archer_grapple_stiffness = 0.1f;
 
+const f32 archer_grapple_min_ratio = 0.2f;
+
 namespace ArrowType
 {
 	enum type
@@ -67,6 +69,7 @@ shared class ArcherInfo
 	bool grappling;
 	u16 grapple_id;
 	f32 grapple_ratio;
+	f32 grapple_ratio_target;
 	f32 cache_angle;
 	Vec2f grapple_pos;
 	Vec2f grapple_vel;

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -84,6 +84,7 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 			archer.grappling = true;
 			archer.grapple_id = 0xffff;
 			archer.grapple_pos = pos;
+			archer.grapple_ratio_target = archer_grapple_min_ratio;
 
 			archer.grapple_ratio = 1.0f; //allow fully extended
 
@@ -126,10 +127,32 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 
 			CMap@ map = this.getMap();
 
+			//adjust grapple
+			u8 retractRate = 0.8f / getTicksASecond();
+			if (this.isKeyPressed(key_up))
+			{
+				archer.grapple_ratio_target -= retractRate;
+				archer.grapple_ratio_target = Maths::Max(archer.grapple_ratio_target, archer_grapple_min_ratio);
+			}
+			if (this.isKeyPressed(key_down))
+			{
+				archer.grapple_ratio_target += retractRate;
+				archer.grapple_ratio_target = Maths::Min(archer.grapple_ratio_target, 1.0f);
+			}
+
 			//reel in
 			//TODO: sound
-			if (archer.grapple_ratio > 0.2f)
-				archer.grapple_ratio -= 1.0f / getTicksASecond();
+			u8 reelRate = 1.0f / getTicksASecond();
+			if (archer.grapple_ratio > archer.grapple_ratio_target)
+			{
+				archer.grapple_ratio -= reelRate;
+				archer.grapple_ratio = Maths::Max(archer.grapple_ratio, archer.grapple_ratio_target);
+			}
+			if (archer.grapple_ratio < archer.grapple_ratio_target)
+			{
+				archer.grapple_ratio += reelRate;
+				archer.grapple_ratio = Maths::Min(archer.grapple_ratio, archer.grapple_ratio_target);
+			}
 
 			//get the force and offset vectors
 			Vec2f force;
@@ -150,10 +173,9 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 				}
 			}
 
-			//left map? too long? close grapple
+			//left map? close grapple
 			if (archer.grapple_pos.x < 0 ||
-			        archer.grapple_pos.x > (map.tilemapwidth)*map.tilesize ||
-			        dist > archer_grapple_length * 3.0f)
+				archer.grapple_pos.x > (map.tilemapwidth)*map.tilesize)
 			{
 				if (canSend(this))
 				{

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -128,7 +128,7 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 			CMap@ map = this.getMap();
 
 			//adjust grapple
-			u8 retractRate = 0.8f / getTicksASecond();
+			f32 retractRate = 0.8f / getTicksASecond();
 			if (this.isKeyPressed(key_up))
 			{
 				archer.grapple_ratio_target -= retractRate;
@@ -142,7 +142,7 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 
 			//reel in
 			//TODO: sound
-			u8 reelRate = 1.0f / getTicksASecond();
+			f32 reelRate = 1.0f / getTicksASecond();
 			if (archer.grapple_ratio > archer.grapple_ratio_target)
 			{
 				archer.grapple_ratio -= reelRate;


### PR DESCRIPTION
## Status

**READY**

## Description

This adds the ability for archers to adjust the length of their grapple. This gives them a bit better control while grappling up and around walls while barely impacting the current grapple meta. The grapple extends within the rope's current limits to prevent players from extending the rope to an 'unrealistic' length. You are able to adjust the grapple as it's being thrown and while it's attached to a block. The speed of adjustment can be changed in code if it's too slow, but I found that increasing the speed causes the player to wobble about too much.

Resolves [this](https://forum.thd.vg/threads/15981/) suggestion from 2013 lol

## Steps to Test or Reproduce

Press W and S while your grapple is out
