### PR TITLE
Limit the ballista to shooting it's ammo type

### DIFF
--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -261,6 +261,14 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		CBlob@ blob = getBlobByNetworkID(params.read_netid());
 		const u8 charge = params.read_u8();
+		
+		// check for valid bolt
+		if (blob.getName() != "ballista_bolt"){
+			// Output warning
+			warn("Attempted to launch invalid object!");
+			return;
+		}
+		
 		VehicleInfo@ v;
 		if (!this.get("VehicleInfo", @v))
 		{

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -262,18 +262,19 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBlob@ blob = getBlobByNetworkID(params.read_netid());
 		const u8 charge = params.read_u8();
 		
-		// check for valid bolt
-		if (blob.getName() != "ballista_bolt"){
-			// Output warning
-			warn("Attempted to launch invalid object!");
-			return;
-		}
-		
 		VehicleInfo@ v;
 		if (!this.get("VehicleInfo", @v))
 		{
 			return;
 		}
+		
+		// check for valid ammo
+		if (blob.getName() != v.bullet_name){
+			// output warning
+			warn("Attempted to launch invalid object!");
+			return;
+		}
+		
 		Vehicle_onFire(this, v, blob, charge);
 	}
 }


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request prevents the ballista from shooting anything other than it's configured ammo type. Because f2p is being worked on, securing the game is essential. Currently, by injecting client side code, it is possible to launch all blobs on the map using a ballista.

## Steps to Test or Reproduce

- Start a sandbox game
- Spawn a ballista
- Shoot a bolt: it behaves like normal
- Open the console and run this code:
```
  CBlob@[] all;
  getBlobs(@all);

  for (u32 i = 0; i < all.length; i++)
  {
    CBlob@ blob = all[i];


    if (blob.hasCommandID("fire blob"))
    {
      for (u32 x = 0; i < all.length; x++)
      {
        CBitStream params;
        params.write_netid(all[x].getNetworkID());
        params.write_u8(100);
        blob.SendCommand(blob.getCommandID("fire blob"), params);
      }

      break;
    }
  }
```
- One or more warnings appear in the console, the player does not fly into the air
