### PR TITLE
Tunnel bounds check bypass

### DIFF
--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -216,6 +216,7 @@ void onTunnelCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				params.write_u16(caller.getNetworkID());
 				params.write_u16(tunnel.getNetworkID());
 				this.SendCommand(this.getCommandID("server travel to"), params);
+				Travel(this, caller, tunnel);
 			}
 		}
 		else if (caller !is null && caller.isMyPlayer())
@@ -223,9 +224,12 @@ void onTunnelCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	}
 	else if (cmd == this.getCommandID("server travel to"))
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_u16());
-		CBlob@ tunnel = getBlobByNetworkID(params.read_u16());
-		Travel(this, caller, tunnel);
+		if (getNet().isClient())
+		{
+			CBlob@ caller = getBlobByNetworkID(params.read_u16());
+			CBlob@ tunnel = getBlobByNetworkID(params.read_u16());
+			Travel(this, caller, tunnel);
+		}
 	}
 	else if (cmd == this.getCommandID("travel none"))
 	{


### PR DESCRIPTION
## Status
- **IN DEVELOPMENT**

## Description

A attacker can abuse a command that should only be called by the server, to bypass exisiting bounds checks for traveling to a tunnel. This allows every blob on the map to be teleported to a tunnel.
This fix hasn't yet been tested with multiple clients, so I can't assure that it has no side effects.

## Steps to Test or Reproduce

Due to the fact that this bug is critical and requires a patched binary, I will not post instructions here. Feel free to pm me if you want instructions.
