### PR TITLE
CTF Flag arbitrary chat message

### DIFF
--- a/Entities/Special/CTF/CTF_Flag.as
+++ b/Entities/Special/CTF/CTF_Flag.as
@@ -211,13 +211,17 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	}
 	else if (cmd == this.getCommandID("capture"))
 	{
-		Sound::Play("/flag_score.ogg");
+		u16 id;
+		if (!params.saferead_u16(id)) return;
 
-		string name;
-		if (!params.saferead_string(name)) return;
+		CBlob@ blob = getBlobByNetworkID(id);
+		if (blob !is null && blob.getPlayer() !is null)
+		{
+			needsmessage = true;
+			message = "captured by " + blob.getPlayer().getUsername() + "!";
 
-		needsmessage = true;
-		message = "captured by " + name + "!";
+			Sound::Play("/flag_score.ogg");
+		}
 	}
 	else if (cmd == this.getCommandID("return"))
 	{

--- a/Entities/Special/CTF/CTF_Flag.as
+++ b/Entities/Special/CTF/CTF_Flag.as
@@ -196,14 +196,18 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 	if (cmd == this.getCommandID("pickup"))
 	{
-		this.set_u16(return_prop, 0);
-		Sound::Play("/flag_capture.ogg");
+		u16 id;
+		if (!params.saferead_u16(id)) return;
 
-		string name;
-		if (!params.saferead_string(name)) return;
+		CBlob@ blob = getBlobByNetworkID(id);
+		if (blob !is null && blob.getPlayer() !is null)
+		{
+			needsmessage = true;
+			message = "picked up by " + blob.getPlayer().getUsername() + "!";
 
-		needsmessage = true;
-		message = "picked up by " + name + "!";
+			this.set_u16(return_prop, 0);
+			Sound::Play("/flag_capture.ogg");
+		}
 	}
 	else if (cmd == this.getCommandID("capture"))
 	{

--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -161,16 +161,8 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 			{
 				blob.server_AttachTo(b, "PICKUP"); //attach to player
 
-				CPlayer@ player = blob.getPlayer();
-
-				string name = "someone";
-				if (player !is null)
-				{
-					name = player.getUsername();
-				}
-
 				CBitStream params;
-				params.write_string(name);
+				params.write_u16(blob.getNetworkID());
 
 				b.SendCommand(b.getCommandID("pickup"), params);
 			}

--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -179,16 +179,8 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 			//smash the flag
 			this.server_Hit(b, b.getPosition(), Vec2f(), 5.0f, 0xfa, true);
 
-			CPlayer@ player = blob.getPlayer();
-
-			string name = "someone";
-			if (player !is null)
-			{
-				name = player.getUsername();
-			}
-
 			CBitStream params;
-			params.write_string(name);
+			params.write_u16(blob.getNetworkID());
 			b.SendCommand(b.getCommandID("capture"), params);
 		}
 	}


### PR DESCRIPTION
## Status
- **READY**

## Description

A attacker can use ctf flag commands to write arbitrary chat messages without exposing his username.

## Steps to Test or Reproduce

- Start a game
- Pickup a flag normally
- The normal "picked up by username" appears
- Run this code
```
CBlob@[] all;
  getBlobs(@all);

  for (u32 i = 0; i < all.length; i++)
  {
    CBlob@ blob = all[i];

    if (blob.getName() == "ctf_flag")
    {
      CBitStream params;
      params.write_string("Hello there!");
      blob.SendCommand(blob.getCommandID("pickup"), params);
	  return;
    }
  }
```

- Nothing is displayed in chat

