### PR TITLE
Archer command validation

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -804,6 +804,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		bool legolas;
 		if (!params.saferead_bool(legolas)) return;
 
+		if (arrowType >= arrowTypeNames.length) return;
+
 		ArcherInfo@ archer;
 		if (!this.get("archerInfo", @archer))
 		{

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -795,10 +795,14 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("shoot arrow"))
 	{
-		Vec2f arrowPos = params.read_Vec2f();
-		Vec2f arrowVel = params.read_Vec2f();
-		u8 arrowType = params.read_u8();
-		bool legolas = params.read_bool();
+		Vec2f arrowPos;
+		if (!params.saferead_Vec2f(arrowPos)) return;
+		Vec2f arrowVel;
+		if (!params.saferead_Vec2f(arrowVel)) return;
+		u8 arrowType;
+		if (!params.saferead_u8(arrowType)) return;
+		bool legolas;
+		if (!params.saferead_bool(legolas)) return;
 
 		ArcherInfo@ archer;
 		if (!this.get("archerInfo", @archer))
@@ -1090,4 +1094,3 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 		}
 	}
 }
-


### PR DESCRIPTION
## Status
- **READY**

## Description

A attacker can send invalid parameters in a shoot command, which will crash the archer script and break the archer class.

## Steps to Test or Reproduce

- Start a game
- Spawn any kind of arrow
- Switch to that arrow
- The arrow gets switched
- Run this code
```
CBlob@[] all;
getBlobs(@all);

  for (u32 i = 0; i < all.length; i++)
  {
    CBlob@ blob = all[i];

    if (blob.hasCommandID("shoot arrow"))
    {
	Vec2f zero = Vec2f(0,0);
	CBitStream params;
	params.write_Vec2f(zero);
	params.write_Vec2f(zero);
	params.write_u8(4);
	params.write_bool(false);
        blob.SendCommand(blob.getCommandID("shoot arrow"), params);
    }
  }
```
- Nothing happens
