### PR TITLE
[added] scoreboard scrolling

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -585,10 +585,10 @@ void onRenderScoreboard(CRules@ this)
 
 		float fullOffset = (scoreboardHeight + scoreboardMargin) - screenHeight;
 
-		if(scrollOffset < fullOffset && mousePos.y > screenHeight*0.75f) {
+		if(scrollOffset < fullOffset && mousePos.y > screenHeight*0.83f) {
 			scrollOffset += scrollSpeed;
 		}
-		else if(scrollOffset > 0.0f && mousePos.y < screenHeight*0.25f) {
+		else if(scrollOffset > 0.0f && mousePos.y < screenHeight*0.16f) {
 			scrollOffset -= scrollSpeed;
 		}
 

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -10,6 +10,10 @@ int hovered_tier = -1;
 bool draw_age = false;
 bool draw_tier = false;
 
+float scoreboardMargin = 52.0f;
+float scrollOffset = 0.0f;
+float scrollSpeed = 4.0f;
+
 string[] age_description = {
 	"New Player - Welcome them to the game!",
 	//first month
@@ -508,16 +512,10 @@ void onRenderScoreboard(CRules@ this)
 	@hoveredPlayer = null;
 
 	Vec2f topleft(100, 150);
-	if (blueplayers.size() + redplayers.size() > 18)
-	{
-		topleft.y = drawServerInfo(10);
+	drawServerInfo(40);
 
-	}
-	else
-	{
-		drawServerInfo(40);
-
-	}
+	// start the scoreboard lower or higher.
+	topleft.y -= scrollOffset;
 
 	//(reset)
 	hovered_accolade = -1;
@@ -576,6 +574,25 @@ void onRenderScoreboard(CRules@ this)
 		}
 
 		topleft.y += 52;
+	}
+
+	float scoreboardHeight = topleft.y + scrollOffset;
+	float screenHeight = getScreenHeight();
+
+	if(scoreboardHeight > screenHeight) {
+		CControls@ controls = getControls();
+		Vec2f mousePos = controls.getMouseScreenPos();
+
+		float fullOffset = (scoreboardHeight + scoreboardMargin) - screenHeight;
+
+		if(scrollOffset < fullOffset && mousePos.y > screenHeight*0.75f) {
+			scrollOffset += scrollSpeed;
+		}
+		else if(scrollOffset > 0.0f && mousePos.y < screenHeight*0.25f) {
+			scrollOffset -= scrollSpeed;
+		}
+
+		scrollOffset = Maths::Clamp(scrollOffset, 0.0f, fullOffset);
 	}
 
 	drawPlayerCard(hoveredPlayer, hoveredPos);


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Do you have this problem
![problem](https://user-images.githubusercontent.com/2775830/53141410-a5b36300-3555-11e9-9975-7034b0ad044e.png)
because you play on default resolution and you're a freak like me? Then this PR should fix your problem by allowing the scoreboard to scroll when it's to big for the screen.

![solution](https://user-images.githubusercontent.com/2775830/53141440-c380c800-3555-11e9-8e6b-a5f27d7ea481.gif)

## Steps to Test or Reproduce
You can reproduce this issue by playing on the default resolution. And joining a server with more than ~16 people

Some useful information to include:
Also note I removed the server info shifting because there's no reason for it to make extra room now.
