### PR TITLE
[fixed] spawn immunity not being unset for joining players

### DIFF
--- a/Entities/Characters/Scripts/UnSpawnImmunity.as
+++ b/Entities/Characters/Scripts/UnSpawnImmunity.as
@@ -1,6 +1,7 @@
 void onInit(CBlob@ this)
 {
-	if(this.hasTag("invincibility done")) {
+	if(this.hasTag("invincibility done"))
+	{
 		return;
 	}
 	this.Tag("invincible");

--- a/Entities/Characters/Scripts/UnSpawnImmunity.as
+++ b/Entities/Characters/Scripts/UnSpawnImmunity.as
@@ -1,5 +1,8 @@
 void onInit(CBlob@ this)
 {
+	if(this.hasTag("invincibility done")) {
+		return;
+	}
 	this.Tag("invincible");
 
 	if (!this.exists("spawn immunity time"))
@@ -30,6 +33,9 @@ void onTick(CBlob@ this)
 	if (!immunity || this.getPlayer() is null)
 	{
 		this.Untag("invincible");
+		this.Tag("invincibility done");
+		this.Sync("invincibility done", true);
+
 		this.getCurrentScript().runFlags |= Script::remove_after_this;
 		this.getSprite().setRenderStyle(RenderStyle::normal);
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fix for this issue: https://github.com/transhumandesign/kag-base/issues/416 When joining UnSpawnImmunity.as would only call OnInit tagging blobs with invincible. However because it was removed earlier it would never get untagged for that client causing a few bugs.

## Steps to Test or Reproduce

Following the steps in the issue you can reproduce the bug. Then pull this fix and test the bug again to see that it does not happen any longer.