### PR TITLE
Remove quick swap class from CTF

### DIFF
--- a/Entities/Special/Tent/TentLogic.as
+++ b/Entities/Special/Tent/TentLogic.as
@@ -1,7 +1,6 @@
 // Tent logic
 
 #include "StandardRespawnCommand.as"
-#include "StandardControlsCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -20,23 +19,6 @@ void onInit(CBlob@ this)
 
 	// defaultnobuild
 	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 8.0f));
-}
-
-void onTick(CBlob@ this)
-{
-	//quick switch class
-	CBlob@ blob = getLocalPlayerBlob();
-	if (blob !is null && blob.isMyPlayer())
-	{
-		if (
-			canChangeClass(this, blob) && blob.getTeamNum() == this.getTeamNum() && //can change class
-			blob.isKeyJustReleased(key_use) && //just released e
-			isTap(blob, 4) && //tapped e
-			blob.getTickSinceCreated() > 1 //prevents infinite loop of swapping class
-		) {
-			CycleClass(this, blob);
-		}
-	}
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)


### PR DESCRIPTION
## Status

**READY**

## Description

- Removes the quick swap class feature from CTF. 

Followup to issue #373 and PR #382.

## Rationale

- Current implementation breaks the expected flow for many experienced players
  - Many players press 'e' and expect the menu to appear regardless of cursor position (i.e. cursor doesn't have to be over the icon)
- Current implementation is not intuitive for new players
  - Mainly due to its not being consistent with the rest of KAG's UI interactions
- Feature was implemented without community feedback
  - Change is somewhat controversial and did not go through the normal vetting process for new features

I propose we leave the quick swap class feature out of CTF for the time being. We should get community feedback to see if the feature would be welcome. Voting in the #democracy channel of the official KAG Discord server seems like a good way to do this. If the feature gains significant support, alternative implementations that do not break the old flow (tap 'e' to bring up the class menu) should be discussed.

Quick swap class for TDM seems less controversial, so it was not touched in this PR (there are only two classes in TDM, so the class menu is less useful). More discussion needed.

## Steps to Test or Reproduce

Tap the use key ('e') while in front of a tent. The class change menu appears and the player's class is not quick-swapped.
