### PR TITLE
Shop keybinds

### DIFF
--- a/Entities/Common/Emotes/EmoteHotkeys.as
+++ b/Entities/Common/Emotes/EmoteHotkeys.as
@@ -18,6 +18,8 @@ void onInit(CBlob@ this)
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
 
+	this.addCommandID("prevent emotes");
+
 	string cachefilename = "../Cache/" + emote_config_file;
 	ConfigFile cfg = ConfigFile();
 
@@ -43,6 +45,14 @@ void onInit(CBlob@ this)
 		emote_7 = read_emote(cfg, "emote_7", Emotes::troll);
 		emote_8 = read_emote(cfg, "emote_8", Emotes::disappoint);
 		emote_9 = read_emote(cfg, "emote_9", Emotes::ladder);
+	}
+}
+
+void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
+{
+	if (cmd == this.getCommandID("prevent emotes"))
+	{
+		set_emote(this, Emotes::off);
 	}
 }
 

--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -102,6 +102,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		bool producing = params.read_bool();
 		string blobName = params.read_string();
 		u8 s_index = params.read_u8();
+		bool hotkey = params.read_bool();
 
 		CBlob@ caller = getBlobByNetworkID(callerID);
 		if (caller is null) { return; }
@@ -111,6 +112,11 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		{
 			caller.ClearMenus();
 			return;
+		}
+
+		if (hotkey)
+		{
+			caller.SendCommand(caller.getCommandID("prevent emotes"));
 		}
 
 		if (inv !is null && isInRadius(this, caller))
@@ -312,6 +318,7 @@ void addShopItemsToMenu(CBlob@ this, CGridMenu@ menu, CBlob@ caller)
 			params.write_bool(s_item.producing);
 			params.write_string(s_item.blobName);
 			params.write_u8(u8(i));
+			params.write_bool(false); //used hotkey?
 
 
 			CGridButton@ button;
@@ -398,6 +405,24 @@ void BuildShopMenu(CBlob@ this, CBlob @caller, string description, Vec2f offset,
 		if (!this.hasTag(SHOP_AUTOCLOSE))
 			menu.deleteAfterClick = false;
 		addShopItemsToMenu(this, menu, caller);
+
+		//keybinds
+		array<EKEY_CODE> numKeys = { KEY_KEY_1, KEY_KEY_2, KEY_KEY_3, KEY_KEY_4, KEY_KEY_5, KEY_KEY_6, KEY_KEY_7, KEY_KEY_8, KEY_KEY_9 };
+		uint keybindCount = Maths::Min(shopitems.length(), numKeys.length());
+
+		for (uint i = 0; i < keybindCount; i++)
+		{
+			CBitStream params;
+			params.write_u16(caller.getNetworkID());
+			params.write_bool(shopitems[i].spawnToInventory);
+			params.write_bool(shopitems[i].spawnInCrate);
+			params.write_bool(shopitems[i].producing);
+			params.write_string(shopitems[i].blobName);
+			params.write_u8(i);
+			params.write_bool(true); //used hotkey?
+
+			menu.AddKeyCommand(numKeys[i], this.getCommandID("shop buy"), params);
+		}
 	}
 
 }

--- a/Entities/Industry/Building/Building.as
+++ b/Entities/Industry/Building/Building.as
@@ -95,6 +95,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			this.getSprite().PlaySound("/Construct.ogg");
 			this.getSprite().getVars().gibbed = true;
 			this.server_Die();
+			caller.ClearMenus();
 
 			// open factory upgrade menu immediately
 			if (item.getName() == "factory")


### PR DESCRIPTION
## Status

**READY**

## Description

This adds the ability to buy items from shops by pressing a number key. The keybinds match shop buttons from left to right, top to bottom. This only works once you've clicked 'e' on a shop to prevent accidental purchases. If a shop has more than nine items (which none do at the moment), there will only be keybinds for the first nine items. This also works on the buildings which allow you to choose the shop you want.

Closes #240

## Steps to Test or Reproduce

Press 'e' on a shop and press a number key for the item you want