### PR TITLE
Reduced TDM warm up timer

### DIFF
--- a/Rules/TDM/tdm_vars.cfg
+++ b/Rules/TDM/tdm_vars.cfg
@@ -37,7 +37,7 @@
 	dying_counts		= true
 
 	# how long before the game
-	warmUpTimeSeconds 	= 5
+	warmUpTimeSeconds 	= 1
 
 	# how long the game runs for
 	gameDurationMinutes = 2.5


### PR DESCRIPTION
## Status

**READY**

## Description

TDM warm up timer is reduced from 5 seconds to 1 second in order to stop players from re-spawning that die before the warm up timer is finished.

## Steps to Test or Reproduce

Attempt to kill an enemy quickly in TDM 

or 

Quickly press esc and then suicide 

