### PR TITLE
Catapult improvements

### DIFF
--- a/Entities/Items/Boulder/Boulder.as
+++ b/Entities/Items/Boulder/Boulder.as
@@ -38,12 +38,6 @@ void onTick(CBlob@ this)
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
 {
-	if (detached.getName() == "catapult") // rock n' roll baby
-	{
-		this.getShape().getConsts().mapCollisions = false;
-		this.getShape().getConsts().collidable = false;
-		this.getCurrentScript().tickFrequency = 3;
-	}
 	this.set_u8("launch team", detached.getTeamNum());
 }
 
@@ -58,7 +52,6 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	{
 		this.getShape().getConsts().mapCollisions = true;
 		this.getShape().getConsts().collidable = true;
-		this.getCurrentScript().tickFrequency = 1;
 	}
 	this.set_u8("launch team", attached.getTeamNum());
 }

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -225,6 +225,12 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _charge
 		{
 			SetKnocked(bullet, 30);
 		}
+
+		if (bullet.getName() == "boulder") // rock n' roll baby
+		{
+			bullet.getShape().getConsts().mapCollisions = false;
+			bullet.getShape().getConsts().collidable = false;
+		}
 	}
 
 	// we override the default time because we want to base it on charge

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -134,8 +134,14 @@ void onTick(CBlob@ this)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
-	if (!Vehicle_AddFlipButton(this, caller) && this.getTeamNum() == caller.getTeamNum() && isOverlapping(this, caller) && !caller.isAttached())
-	{
+	CBlob@ occupiedBlob = this.getAttachments().getAttachmentPointByName("MAG").getOccupied();
+	if (
+		!Vehicle_AddFlipButton(this, caller) &&
+		this.getTeamNum() == caller.getTeamNum() &&
+		isOverlapping(this, caller) &&
+		!caller.isAttached() &&
+		(occupiedBlob is null || !occupiedBlob.hasTag("player"))
+	) {
 		Vehicle_AddLoadAmmoButton(this, caller);
 	}
 }

--- a/Entities/Vehicles/Common/Vehicle.as
+++ b/Entities/Vehicles/Common/Vehicle.as
@@ -153,7 +153,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			if (magBlob !is null)
 			{
 				magBlob.server_DetachFromAll();
-				this.server_PutInInventory(magBlob);
 			}
 			blob.server_DetachFromAll();
 			this.server_AttachTo(blob, "MAG");


### PR DESCRIPTION
## Status

**READY**

## Description

- Boulders no longer enter rock n' roll mode when swapped out of a catapult
- Players can no longer kick other players out of catapults while they're waiting to be fired
- Replacing an item with another item now drops the original item instead of 'deleting' it

## Steps to Test or Reproduce

Rock n' roll bug:
1. Load boulder into catapult
2. Replace the boulder with another item
3. The boulder shouldn't fall down through blocks like it used to

Kick out players:
1. Have a teamate sit in the bowl of a catapult
2. Attempt to put an item into the catapult
3. The button to add an item to the catapult shouldn't display

Replacing item with item bug:
1. Put item into catapult
2. Replace the item with another item
3. The original item should fall out