### PR TITLE
Fireplace fixes and minor improvements

### DIFF
--- a/Entities/Characters/Builder/BuilderHittable.as
+++ b/Entities/Characters/Builder/BuilderHittable.as
@@ -6,7 +6,7 @@ const string[] builder_alwayshit =
 {
 	//handmade
 	"workbench",
-	//"fireplace",
+	"fireplace",
 	"ladder",
 
 	//faketiles

--- a/Entities/Industry/Fireplace/Fireplace.as
+++ b/Entities/Industry/Fireplace/Fireplace.as
@@ -8,8 +8,6 @@
 
 void onInit(CBlob@ this)
 {
-	// this.getShape().getConsts().mapCollisions = false;
-	this.getShape().getConsts().rotates = false;
 	this.getCurrentScript().tickFrequency = 9;
 	this.getSprite().SetEmitSound("CampfireSound.ogg");
 	this.getSprite().SetAnimation("fire");
@@ -67,7 +65,7 @@ void onInit(CSprite@ this)
 	if (fire !is null)
 	{
 		fire.SetRelativeZ(1);
-		fire.SetOffset(Vec2f(-2.0f, -4.0f));
+		fire.SetOffset(Vec2f(-2.0f, -6.0f));
 		{
 			Animation@ anim = fire.addAnimation("fire", 6, true);
 			anim.AddFrame(1);
@@ -101,6 +99,7 @@ void Extinguish(CBlob@ this)
 void Ignite(CBlob@ this)
 {
 	if (this.getSprite().isAnimation("fire")) return;
+
 	this.SetLight(true);
 	this.Tag("fire source");
 

--- a/Entities/Industry/Fireplace/Fireplace.cfg
+++ b/Entities/Industry/Fireplace/Fireplace.cfg
@@ -11,7 +11,7 @@ $sprite_texture                            = Fireplace.png
 s32_sprite_frame_width                     = 16
 s32_sprite_frame_height                    = 16
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = -3
+f32 sprite_offset_y                        = -4.5
 
 	$sprite_gibs_start                     = *start*
 
@@ -44,25 +44,28 @@ f32 sprite_offset_y                        = -3
 $shape_factory                             = box2d_shape
 
 @$shape_scripts                            = 
-f32 shape_mass                             = 10.0
+f32 shape_mass                             = 40.0
 f32 shape_radius                           = 8.0
-f32 shape_friction                         = 0.0
-f32 shape_elasticity                       = 0.0
+f32 shape_friction                         = 0.6
+f32 shape_elasticity                       = 0.2
 f32 shape_buoyancy                         = 0.0
-f32 shape_drag                             = 0.0
+f32 shape_drag                             = 0.5
 bool shape_collides                        = no
 bool shape_ladder                          = no
 bool shape_platform                        = no
  #block_collider
-@f32 verticesXY                            = 0.0; 0.0;
-                                             16.0; 0.0;
-                                             16.0; 8.0;
-                                             0.0; 8.0;
+@f32 verticesXY                            = 5.0; 2.0;
+											 11.0; 2.0;
+                                             15.0; 6.0;
+                                             13.0; 8.0;
+                                             3.0; 8.0;
+                                             1.0; 6.0;
+											 
 
 u8 block_support                           = 0
 bool block_background                      = no
 bool block_lightpasses                     = no
-bool block_snaptogrid                      = yes
+bool block_snaptogrid                      = no
 
 $movement_factory                          =
 $brain_factory                             =	
@@ -72,13 +75,12 @@ $inventory_factory                         =
 # general
 
 $name                                      = fireplace
-@$scripts                                  = DefaultNoBuild.as;
-											 Settle.as;
-											 DecayInWater.as;
+@$scripts                                  = DecayInWater.as;
 											 Wooden.as;
 											 Fireplace.as;
 											 WoodStructureHit.as;
-f32_health                                 = 6.0
+											 GenericHit.as;
+f32_health                                 = 4.0
 # looks & behaviour inside inventory
 $inventory_name                            = Fireplace
 $inventory_icon                            = -

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -312,6 +312,12 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 		return false;
 	}
 
+	//collide so normal arrows can be ignited
+	if (blob.getName() == "fireplace")
+	{
+		return true;
+	}
+
 	//anything to always hit
 	if (specialArrowHit(blob))
 	{

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -269,7 +269,7 @@ class PNGLoader
 			case map_colors::research:        autotile(offset); spawnBlob(map, "research",    offset); break;
 
 			case map_colors::workbench:       autotile(offset); spawnBlob(map, "workbench",   offset, 255, true); break;
-			case map_colors::campfire:        autotile(offset); spawnBlob(map, "fireplace",   offset, 255, true, Vec2f(0.0f, -4.0f)); break;
+			case map_colors::campfire:        autotile(offset); spawnBlob(map, "fireplace",   offset, 255); break;
 			case map_colors::saw:             autotile(offset); spawnBlob(map, "saw",         offset); break;
 
 			// Flora


### PR DESCRIPTION
## Status

**READY**

## Description

This PR excludes the stuff to do with adding fireplaces to CTF/TTH

- Fireplaces rotate so they don't look like they are levitating when put on the edge of a block
- Modified fireplace hitbox which makes it sit properly on the ground when upside down. It also makes it slightly harder for it to roll upside down
- Builders can hit fireplaces
- Bombs / water bombs knock around fireplaces now that fireplaces no longer become static
- Fireplaces no longer become static, especially when the map loads which caused them to float

## Steps to Test or Reproduce

- Load maps where fireplaces used to float
  - Niiiiii_Watery
  - FG_SpaceInvader
- Hit fireplaces as builder
- Knock fireplaces around with explosives
