### PR TITLE
Added admin red name toggle.

### DIFF
--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -47,6 +47,7 @@ scripts                                           = KAG.as;
 													EmoteMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
+													AdminRedToggle.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0

--- a/Rules/Challenge/gamemode.cfg
+++ b/Rules/Challenge/gamemode.cfg
@@ -36,6 +36,7 @@
 										 EmoteMenu.as;
 										 TauntMenu.as;
 										 BindingsMenu.as;
+                                         AdminRedToggle.as;
 
 no_shadowing                                      = 0
 

--- a/Rules/CommonScripts/AdminRedToggle.as
+++ b/Rules/CommonScripts/AdminRedToggle.as
@@ -1,0 +1,44 @@
+#include "AdminRedToggleCommon.as"
+
+void onInit(CRules@ this)
+{
+    this.addCommandID("toggle red name command");
+}
+
+void onNewPlayerJoin(CRules@ this, CPlayer@ player)
+{
+    InitRedName(this, player);
+    CBitStream params;
+    params.write_string(getToggleID(player));
+    params.write_bool(this.get_bool(getToggleID(player)));
+    this.SendCommand(this.getCommandID("toggle red name command"), params);
+}
+
+bool onServerProcessChat(CRules@ this, const string &in textIn, string &out textOut, CPlayer@ player)
+{
+    if (textIn == toggle_string && isAdmin(player))
+    {
+        string toggleID = getToggleID(player);
+        if (this.exists(toggleID))
+        {
+            bool visible = !this.get_bool(toggleID);
+            this.set_bool(toggleID, visible);
+            CBitStream params;
+            params.write_string(toggleID);
+            params.write_bool(visible);
+            this.SendCommand(this.getCommandID("toggle red name command"), params);
+            return false;
+        }
+    }
+    return true;
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
+{
+    if (cmd == this.getCommandID("toggle red name command"))
+    {
+        string toggleID = params.read_string();
+        bool visible = params.read_bool();
+        this.set_bool(toggleID, visible);
+    }
+}

--- a/Rules/CommonScripts/AdminRedToggleCommon.as
+++ b/Rules/CommonScripts/AdminRedToggleCommon.as
@@ -1,0 +1,34 @@
+const string toggle_id_string = " red name toggle";
+const string toggle_string = "!toggle redname";
+
+bool isAdmin(CPlayer@ player)
+{
+    return getSecurity().checkAccess_Feature(player, "admin_color") || player.isRCON();
+}
+
+string getToggleID(CPlayer@ player)
+{
+    return player.getUsername() + toggle_id_string;
+}
+
+void InitRedName(CRules@ rules, CPlayer@ player)
+{
+    if (isAdmin(player))
+    {
+        rules.set_bool(getToggleID(player), false);
+    }
+}
+
+bool redNameEnabled(CRules@ rules, CPlayer@ player)
+{
+    if (rules.exists(getToggleID(player)))
+    {
+        // return enabled
+        return rules.get_bool(getToggleID(player));
+    }
+    else
+    {
+        // not an admin??
+        return true;
+    }
+}

--- a/Rules/CommonScripts/ScoreboardCommon.as
+++ b/Rules/CommonScripts/ScoreboardCommon.as
@@ -1,3 +1,5 @@
+#include "AdminRedToggleCommon.as"
+
 f32 getKDR(CPlayer@ p)
 {
 	return p.getKills() / Maths::Max(f32(p.getDeaths()), 1.0f);
@@ -11,7 +13,7 @@ SColor getNameColour(CPlayer@ p)
         c = SColor(0xffb400ff); //dev
     } else if (p.isGuard()) {
         c = SColor(0xffa0ffa0); //guard
-    } else if (getSecurity().checkAccess_Feature(p, "admin_color") || p.isRCON()) {
+    } else if (isAdmin(p) && redNameEnabled(getRules(), p)) {
         c = SColor(0xfffa5a00); //admin
     } else if (p.isMyPlayer()) {
         c = SColor(0xffffEE44); //my player

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -47,6 +47,7 @@ scripts                                           = KAG.as;
 													EmoteMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
+                                        			AdminRedToggle.as;
 
 daycycle_speed                                    = 10
 daycycle_start                                    = 0.3

--- a/Rules/TDM/gamemode.cfg
+++ b/Rules/TDM/gamemode.cfg
@@ -46,6 +46,7 @@ scripts                                           = KAG.as;
 													EmoteMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
+                                        			AdminRedToggle.as;
 
 no_shadowing                                      = 1
 

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -45,6 +45,7 @@
 										 EmoteMenu.as;
 										 TauntMenu.as;
 										 BindingsMenu.as;
+                                         AdminRedToggle.as;
 
     daycycle_speed                     = 15			# 1 day = X minutes; / 0 no cycle
     daycycle_start                     = 0.5        # 0.0 midnight; 0.5 - midday; 1.0 midnight


### PR DESCRIPTION
Red names default to off.

## Status

- **READY**

## Description

Adds the ability for an admin to toggle their red name, with the red defaulting to off. The goal of this PR is to help admins punish bad players-- a lot of said players quit being bad when an admin joins.

## Steps to Test or Reproduce

- as admin, type `!toggle redname` in chat. no message should send to other clients, and your name should toggle red / not red