### PR TITLE
Fixed missing moderation accolades

### DIFF
--- a/Rules/CommonScripts/Accolades.as
+++ b/Rules/CommonScripts/Accolades.as
@@ -55,7 +55,7 @@ shared class Accolades
 					community_contributor = true;
 				} else if (s1 == "map") {
 					map_contributor = true;
-				} else if (s1 == "moderator") {
+				} else if (s1 == "moderation") {
 					moderation_contributor = true;
 				}
 

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -370,7 +370,7 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 					1 : 0),             5,     0,         0,
 				(acc.map_contributor ?
 					1 : 0),             6,     0,         0,
-				(acc.moderation_contributor && redNameEnabled(getRules(), p) ?
+				(acc.moderation_contributor && (!p.isRCON() || redNameEnabled(getRules(), p)) ? //ensure accolade is visible for past admins
 					1 : 0),             7,     0,         0,
 
 				//tourney badges

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -370,7 +370,7 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 					1 : 0),             5,     0,         0,
 				(acc.map_contributor ?
 					1 : 0),             6,     0,         0,
-				(acc.moderation_contributor ?
+				(acc.moderation_contributor && redNameEnabled(getRules(), p) ?
 					1 : 0),             7,     0,         0,
 
 				//tourney badges

--- a/Rules/CommonScripts/accolade_data.cfg
+++ b/Rules/CommonScripts/accolade_data.cfg
@@ -360,6 +360,7 @@ Atheon =
 	silver 2;
 	bronze 1;
 	participation 4;
+	github;
 	# gold - OCE 1v1 archer tournament no. 1
 	# silver - OCE 2v2 knight tournament no. 1
 	# silver 2 - OCE 2v2 knight tournament no. 2
@@ -370,6 +371,7 @@ Atheon =
 	# participation 4 - OCE 2v2 knight tournament no. 1
 	# participation 5 - OCE 1v1 knight tournament no. 5
 	# participation 6 - OCE 2v2 knight tournament no. 2
+	# github - 'Reduced TDM warm up timer'
 
 AwesomeBudgies =
 	silver 1;
@@ -1446,7 +1448,7 @@ Sammm9 =
 	participation 1;
 	# participation - EU 2v2 knight tournament no. 2
 
-Sarius =
+Sarius6 =
 	participation 8;
 	# participation - OCE 1v1 archer tournament no. 1
 	# participation 2 - OCE 1v1 knight tournament no. 1

--- a/Rules/CommonScripts/accolade_data.cfg
+++ b/Rules/CommonScripts/accolade_data.cfg
@@ -1570,7 +1570,7 @@ tim-the-king-of-fire =
 	# participation - OCE 1v1 knight tournament no. 4
 	# participation 2 - OCE 1v1 knight tournament no. 5
 
-toblerone7 =
+Toblerone7 =
 	participation 2;
 	# participation - OCE 1v1 knight tournament no. 3
 	# participation 2 - OCE 2v2 knight tournament no. 2


### PR DESCRIPTION
## Status

**READY**

## Description

- Fixed typo which prevented moderation accolades from being detected and displayed
  - When admin on a server, the accolade is only shown when the player has a red name
  - When on any other server, the accolade is always visible
- Found Sarius and Toblerone's missing accolades
- Added Github badge for Atheon