### PR TITLE
Fixed camera jumping when zooming out while holding 'e' or 'c'

### DIFF
--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -332,10 +332,6 @@ void AdjustCamera(CBlob@ this, bool is_in_render)
 	f32 minZoom = 0.5f; // TODO: make vars
 	f32 maxZoom = 2.0f;
 
-	if (zoomLevel == 1 && (this.wasKeyPressed(key_use) || this.wasKeyPressed(key_pickup)))
-	{
-		zoom = 1.0f;
-	}
 	f32 zoom_target = 1.0f;
 	switch (zoomLevel) {
 		case 0: zoom_target = 0.5f; break;


### PR DESCRIPTION
## Status

**READY**

## Description

If you zoom out from the closest zoom while holding 'e' or 'c', the camera instantly zooms out. I'm not sure why this is a thing... please let me know if this is important for anything.

## Steps to Test or Reproduce

1. Zoom in fully
2. Hold 'e' or 'c' (or press it while zooming out)
3. Zoom out