### PR TITLE
Fixed outdated function name

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -370,7 +370,7 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 					1 : 0),             5,     0,         0,
 				(acc.map_contributor ?
 					1 : 0),             6,     0,         0,
-				(acc.moderation_contributor && (!p.isRCON() || redNameEnabled(getRules(), p)) ? //ensure accolade is visible for past admins
+				(acc.moderation_contributor && (!p.isRCON() || coloredNameEnabled(getRules(), p)) ? //ensure accolade is visible for past admins
 					1 : 0),             7,     0,         0,
 
 				//tourney badges


### PR DESCRIPTION
## Status

**READY**

## Description

Changed `redNameEnabled`  to `coloredNameEnabled` when checking whether it should display a player's moderaction accolade.

## Steps to Test or Reproduce

Join sandbox without getting an error in console