### PR TITLE
[Fixed] Wrong position of nobuild-zone

### DIFF
--- a/Entities/Structures/Common/DefaultNoBuild.as
+++ b/Entities/Structures/Common/DefaultNoBuild.as
@@ -38,8 +38,8 @@ void onTick(CBlob@ this)
 		}
 
 		this.getShape().getBoundingRect(ul, lr);
-		ul.x += 1.0f;
-		ul.y += 1.0f;
+		//ul.x += 1.0f;
+		//ul.y += 1.0f;
 
 		lr += extend;
 		this.getMap().server_AddSector(ul, lr, "no build", "", this.getNetworkID());
@@ -61,8 +61,8 @@ void onTick(CBlob@ this)
 		{
 			Vec2f ul, lr;
 			this.getShape().getBoundingRect(ul, lr);
-			ul.x += 1.0f;
-			ul.y += 1.0f;
+			//ul.x += 1.0f;
+			//ul.y += 1.0f;
 			CMap@ map = getMap();
 			const f32 tilesize = map.tilesize;
 


### PR DESCRIPTION
## Status

- **READY**: Working/Ready

## Description

- To fix the problem shown here: https://www.youtube.com/watch?v=CXXJQ_bPQZg

- Make the "nobuild extend" zone well aligned.

## Steps to Test or Reproduce

- Before the change:
![screen-19-03-05-18-03-46](https://user-images.githubusercontent.com/11915822/53825570-e27c5280-3f76-11e9-8b99-e8e684873fbc.png)
![screen-19-03-05-18-04-10](https://user-images.githubusercontent.com/11915822/53825571-e27c5280-3f76-11e9-8641-fd18311df450.png)

- After:
![screen-19-03-05-18-05-11](https://user-images.githubusercontent.com/11915822/53825606-f45df580-3f76-11e9-8aaf-c62b02744901.png)
![screen-19-03-05-18-05-27](https://user-images.githubusercontent.com/11915822/53825607-f4f68c00-3f76-11e9-884e-244c5614bf3e.png)

- To reproduce:

1. Join a singleplayer sandbox.

2. Try building a block inside the tent/[attempt to destroy the dirt block at the left side of the tent](https://www.youtube.com/watch?v=CXXJQ_bPQZg).
