### PR TITLE
No spectator team fix

### DIFF
--- a/Rules/CommonScripts/KickAFK.as
+++ b/Rules/CommonScripts/KickAFK.as
@@ -21,7 +21,7 @@ void onTick(CRules@ this)
 	CPlayer@ p = getLocalPlayer();
 	CControls@ controls = getControls();
 	if (p is null ||											//no player
-		controls is null ||										//no controls
+		controls is null ||										//no controls										
 		p.getTeamNum() == getRules().getSpectatorTeamNum() ||	//or spectator
 		getNet().isServer())								//or we're running the server
 	{
@@ -75,7 +75,18 @@ void onTick(CRules@ this)
 		}
 		else
 		{
-			p.client_ChangeTeam(this.getSpectatorTeamNum());
+			if(getRules().gamemode_name=="CTF"||getRules().gamemode_name=="TTH")
+			{
+				p.client_ChangeTeam(this.getSpectatorTeamNum());
+			}
+			else
+			{
+				client_AddToChat("You have been AFK way too long, this server may not have a spectator team to swap you to!",SColor(255,0,0,0));
+				client_AddToChat("[!] Please either:",SColor(255,0,0,0));
+				client_AddToChat("-Type !m in chat while being AFK, re-type it when you're back.",SColor(255,0,0,0));
+				client_AddToChat("-Leave the server and come back as soon as you're able to play.",SColor(255,0,0,0));
+			}
+			
 		}
 	}
 }

--- a/Rules/CommonScripts/Report.as
+++ b/Rules/CommonScripts/Report.as
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 //Report.as
 // report logic
 
@@ -354,3 +355,352 @@ void joinNewModTeam(CRules@ this,CPlayer@ player)
 	camera.setPosition(Vec2f(map.getMapDimensions().x / 2, map.getMapDimensions().y / 2));
 }
 
+=======
+//Report.as
+// report logic
+
+//time (in seconds) between repeated reports
+const u32 reportRepeatTime = 1 * 60;
+u8 nonModTeam=0;	//Sandbox' default team.
+
+const SColor reportMessageColor(255, 255, 0, 0);
+
+void onInit(CRules@ this)
+{
+	this.addCommandID("notify");
+	this.addCommandID("report");
+	this.addCommandID("mod_team");
+}
+
+bool onClientProcessChat(CRules@ this, const string& in text_in, string& out text_out, CPlayer@ player)
+{
+	if((text_in == "!moderate" || text_in == "!m") && player.isMod())
+	{
+		if(this.gamemode_name=="CTF"||this.gamemode_name=="TTH")
+		{
+			moderate(this, player);
+		}
+		else
+		{
+			if(player.getTeamNum()==200)
+			{
+				this.set_bool(player.getUsername() + "_moderator", false);
+				makeModTeam(this,player,nonModTeam,true);
+			}
+			else
+			{
+				joinNewModTeam(this,player);
+			}
+
+		}
+		
+		//false so it doesn't show as normal public chat
+		return false;
+	}
+	else if(text_in.substr(0, 1) == "!")
+	{
+		string[]@ tokens = text_in.split(" ");
+
+		//check if we have tokens
+		if(tokens.length > 1)
+		{
+			if(tokens[0] == "!report" || tokens[0] == "!r")
+			{
+				if(player is getLocalPlayer())
+				{
+					string p_name = player.getUsername();
+					string b_name = tokens[1];
+					CPlayer@ baddie = getReportedPlayer(b_name);
+
+					if(baddie !is null)
+					{
+						string baddie_name = baddie.getUsername();
+						if(reportAllowed(this, player, baddie))
+						{
+							//if he exists start more reporting logic
+							report(this, player, baddie);
+							client_AddToChat("You have reported: " + baddie.getCharacterName() + " (" + baddie_name + ")", reportMessageColor);
+						}
+						else if(this.get_u32(p_name + "_reported_at") > 0)
+						{
+							client_AddToChat("You have already reported a player recently.", reportMessageColor);
+						}
+					}
+					else
+					{
+						client_AddToChat("Player not found", reportMessageColor);
+					}
+				}
+
+				//false for everyone so it doesn't show as normal chat
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+//on new player join we must initialize the required variables
+void onNewPlayerJoin(CRules@ this, CPlayer@ player)
+{
+	if(isServer())
+	{
+		string p_name = player.getUsername();
+
+		if(!this.exists(p_name + "_report_count"))
+		{
+			this.set_u8(p_name + "_report_count", 0);
+		}
+		if(!this.exists(p_name + "_reported_at"))
+		{
+			this.set_u32(p_name + "_reported_at", 0);
+		}
+
+		this.set_bool(p_name + "_moderator", false);
+
+		this.Sync(p_name + "_report_count", true);
+		this.Sync(p_name + "_reported_at", true);
+		this.Sync(p_name + "_moderator", true);
+	}
+	
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream @params){
+	if(getNet().isServer()&&this.getCommandID("mod_team")==cmd)
+	{
+		string p_name=params.read_string();
+		bool on_spec=params.read_bool();
+		u8 previousTeam=params.read_u8();
+		CPlayer@ player=getPlayerByUsername(p_name);
+		if(on_spec)
+		{
+			player.server_setTeamNum(previousTeam);
+			this.server_PlayerDie(player);
+			this.set_bool(p_name + "_moderator", false);
+		}
+		else
+		{
+			CBlob@ corpse=player.getBlob();
+			player.server_setTeamNum(200);
+			if(corpse !is null)
+			{
+			corpse.server_SetPlayer(null);
+			corpse.server_Die();
+			}
+			this.set_bool(p_name + "_moderator", true);
+		}
+
+	}
+    if (isClient() && this.getCommandID("report") == cmd)
+    {
+        if (getLocalPlayer().isMod())
+        {
+            string p_name = params.read_string();
+            string b_name = params.read_string();
+
+            CPlayer@ baddie = getPlayerByUsername(b_name);
+
+            if(baddie !is null){
+                client_AddToChat("Report has been made of: " + baddie.getCharacterName() + " (" + b_name + ")", reportMessageColor);
+                Sound::Play("ReportSound.ogg");
+            }
+        }
+    }
+	else if (isServer() && this.getCommandID("report") == cmd)
+	{
+		string p_name = params.read_string();
+        string b_name = params.read_string();
+
+        CPlayer@ player = getPlayerByUsername(p_name);
+        CPlayer@ baddie = getPlayerByUsername(b_name);
+
+		//server gets info from client and decides if it will report baddie
+		if(player !is baddie)
+		{
+			//initialise report_count if it's missing
+			if(!this.exists(b_name + "_report_count"))
+			{
+				this.set_u8(b_name + "_report_count", 0);
+			}
+
+			//initialise reported timer if it's missing
+			if(!this.exists(p_name + "_reported_at"))
+			{
+				this.set_u32(p_name + "_reported_at", 0);
+			}
+
+			//initialise x reported y if it's missing, this will forbid a plyer from reporting another player multiple times
+			if(!this.exists(p_name + "_reported_" + b_name))
+			{
+				this.set_bool(p_name + "_reported_" + b_name, true);
+			}
+
+			//set time at which player reported baddie
+			this.set_u32(p_name + "_reported_at", Time());
+			//increment baddie's report count
+			this.add_u8(b_name + "_report_count", 1);
+
+			//sync props to clients
+			this.Sync(p_name + "_reported_at", true);
+			this.Sync(b_name + "_report_count", true);
+			this.Sync(p_name + "_reported_" + b_name, true);
+
+			tcpr("*REPORT " + p_name + " " + b_name + " " + this.get_u8(b_name + "_report_count")+ " " + getNet().joined_servername);
+		}
+	}
+}
+
+bool reportAllowed(CRules@ this, CPlayer@ player, CPlayer@ baddie)
+{
+	if (player is null or baddie is null) return false;
+
+	string p_name = player.getUsername();
+	string b_name = baddie.getUsername();
+
+	//unique player can not report another unique player more than once
+	if (this.get_bool(p_name + "_reported_" + b_name))
+	{
+		return false;
+	}
+	
+	//hasn't reported in a while
+	bool allowed = s32(Time() - this.get_u32(p_name + "_reported_at")) > reportRepeatTime;
+
+	return allowed;
+}
+
+void report(CRules@ this, CPlayer@ player, CPlayer@ baddie)
+{
+		string playerUsername = player.getUsername();
+		string baddieUsername = baddie.getUsername();
+		string baddieCharacterName = baddie.getCharacterName();
+
+		//send report information to server
+        CBitStream report_params;
+        report_params.write_string(player.getUsername());
+        report_params.write_string(baddie.getUsername());
+        this.SendCommand(this.getCommandID("report"), report_params);
+}
+
+//moderation logic
+void moderate(CRules@ this, CPlayer@ player)
+{
+	if(player !is null && player is getLocalPlayer())
+	{
+		if(isClient())
+		{
+			string p_name = player.getUsername();
+			CCamera@ camera = getCamera();
+			CMap@ map = getMap();
+
+			//change to spectator cam
+			player.client_ChangeTeam(this.getSpectatorTeamNum());
+			getHUD().ClearMenus();
+			camera.setPosition(Vec2f(map.getMapDimensions().x / 2, map.getMapDimensions().y / 2));
+
+			//so the interface is drawn
+			this.set_bool(p_name + "_moderator", true);
+		}
+	}
+}
+
+void onPlayerChangedTeam(CRules@ this, CPlayer@ player, u8 oldteam, u8 newteam)
+{
+	string p_name = player.getUsername();
+
+	//remove moderator tag for people re-joining play
+	if(oldteam == this.getSpectatorTeamNum())
+	{
+		if(this.get_bool(p_name + "_moderator"))
+		{
+			this.set_bool(p_name + "_moderator", false);
+		}
+	}
+}
+
+CPlayer@ getReportedPlayer(string name)
+{
+	//search for exact matches
+	for(int i = 0; i < getPlayerCount(); i++)
+	{
+		CPlayer@ p = getPlayer(i);
+		if(p.getCharacterName() == name || p.getUsername() == name)
+		{
+			return p;
+		}
+	}
+
+	//search for partial matches
+	CPlayer@[] matches;
+	for(int i = 0; i < getPlayerCount(); i++)
+	{
+		CPlayer@ p = getPlayer(i);
+		if( //partial match on
+			//char name
+			p.getCharacterName().toLower().findFirst(name.toLower(), 0) >= 0
+			//or username
+			|| p.getUsername().toLower().findFirst(name.toLower(), 0) >= 0
+		) {
+			matches.push_back(p);
+		}
+	}
+
+	//found any matches?
+	if(matches.length() > 0)
+	{
+		//only one? great!
+		if(matches.length() == 1)
+		{
+			return matches[0];
+		}
+		//otherwise ambiguous
+		else
+		{
+			client_AddToChat("Closest options are:");
+			for(int i = 0; i < matches.length(); i++)
+			{
+				client_AddToChat("- " + matches[i].getCharacterName() + " (" + matches[i].getUsername() + ")");
+			}
+		}
+	}
+
+	return null;
+}
+
+CPlayer@ getPlayerByCharactername(string name)
+{
+	for(int i = 0; i < getPlayerCount(); i++)
+	{
+		CPlayer@ p = getPlayer(i);
+		if(name == p.getCharacterName())
+		{
+			return p;
+		}
+	}
+
+	return null;
+}
+
+void makeModTeam(CRules@ this, CPlayer@ player,u8 team, bool isPlayerOnSpec)
+{
+	string playerUsername=player.getUsername();
+
+	CBitStream report_params;
+	report_params.write_string(playerUsername);
+	report_params.write_bool(isPlayerOnSpec);
+	report_params.write_u8(team);
+	this.SendCommand(this.getCommandID("mod_team"), report_params);
+}
+
+void joinNewModTeam(CRules@ this,CPlayer@ player)
+{
+	this.set_bool(player.getUsername() + "_moderator", true);
+	nonModTeam=player.getTeamNum();
+	makeModTeam(this,player,nonModTeam,false);
+	CCamera@ camera = getCamera();
+	CMap@ map = getMap();
+	getHUD().ClearMenus();
+	camera.setPosition(Vec2f(map.getMapDimensions().x / 2, map.getMapDimensions().y / 2));
+}
+>>>>>>> 597f852120620d3169cd7026b62211ba4996f5c7


### PR DESCRIPTION
## Status

- **READY**
## Description

- This PR helps solve this issue. https://github.com/transhumandesign/kag-base/issues/430

- Basically the same old behavior of !m when it comes to CTF and TTH servers.

- When on any other gamemode, using !m switches you to the spectator team (even if it doesn't _officially exist_ for the gamemode itself).

- The visual moderation stuff is **supposed to be working** [don't know what it's supposed to look like, and didn't happen to test it properly].

- If the gamemode contains lots of teams, after using !m for the second time, you get swapped back to whatever the color of your initial team was.

- To switch back from spectator to your old team, you should type !m, since using the "change team" button doesn't work.

- The KickAFK script no longer attempts to switch admins/mods to spectator (unless it's a CTF/TTH server), instead it shows in the chat a reminder that you can either use !m on servers without spectator teams to avoid being AFK, or simply leave and come back later.

## Steps to Test or Reproduce

- **AFK kick:**

1. Join a server and remain AFK.

2. You should get this: 
_(PS: the screenshot shows me being in the spectator team after using !m)_
![screen-19-03-06-15-23-49](https://user-images.githubusercontent.com/11915822/53892663-000bf380-402d-11e9-94c1-d4a51e2ce225.png)

- **About the !m feature:**

1. Join a server having a gamemode that doesn't include a spectator team. (eg: sandbox)

2. Type !m in chat, you should be switched to spectators team.

3. Type !m when you're done, you should be back to your old team.