### PR TITLE
[modified] the way saws affect mines

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -159,7 +159,8 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 	    name == "wooden_door" ||
 	    name == "mat_wood" ||
 	    name == "tree_bushy" ||
-	    name == "tree_pine")
+	    name == "tree_pine"||
+	    name == "mine")
 	{
 		return false;
 	}

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -160,13 +160,13 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 	    name == "mat_wood" ||
 	    name == "tree_bushy" ||
 	    name == "tree_pine"||
-	    name == "mine")
+	    (name == "mine"&&blob.getTeamNum()==this.getTeamNum()))
 	{
 		return false;
 	}
 
 	//flesh blobs have to be fed into the saw part
-	if (blob.hasTag("flesh"))
+	if (blob.hasTag("flesh")||(name=="mine"))
 	{
 		Vec2f pos = this.getPosition();
 		Vec2f bpos = blob.getPosition();

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -159,14 +159,14 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 	    name == "wooden_door" ||
 	    name == "mat_wood" ||
 	    name == "tree_bushy" ||
-	    name == "tree_pine"||
-	    (name == "mine"&&blob.getTeamNum()==this.getTeamNum()))
+	    name == "tree_pine" ||
+	    (name == "mine" && blob.getTeamNum() == this.getTeamNum()))
 	{
 		return false;
 	}
 
 	//flesh blobs have to be fed into the saw part
-	if (blob.hasTag("flesh")||(name=="mine"))
+	if (blob.hasTag("flesh") || (name=="mine"))
 	{
 		Vec2f pos = this.getPosition();
 		Vec2f bpos = blob.getPosition();

--- a/Entities/Items/Explosives/Mine/Mine.as
+++ b/Entities/Items/Explosives/Mine/Mine.as
@@ -29,7 +29,7 @@ void onInit(CBlob@ this)
 	this.set_u8("custom_hitter", Hitters::mine);
 
 	this.Tag("ignore fall");
-
+	this.Tag("ignore_saw");
 	this.Tag(MINE_PRIMING);
 
 	if (this.exists(MINE_STATE))


### PR DESCRIPTION
## Status

- **READY**
## Description

- This PR modifies the way saws affect mines in two ways:

1. Saws no longer destroy same team's mines (avoid griefing/destroying your teammates mines by mistake).
2. Saws only destroy enemy mines if fed directly to the saw (the same way it works for killing players); to avoid abusing saws to clear the field (see: someone running with a saw throwing it into bushes to neutralize enemy mines).

- **How it used to work:**
[Having your mines destroyed by mistake.]
[Having an enemy using the saw as an anti-mine shield.]
![old_1](https://user-images.githubusercontent.com/11915822/54120449-05d05300-43f8-11e9-8949-e76ad8d819da.gif)
[Clearing mines on the field in a matter of seconds.]
![old_2](https://user-images.githubusercontent.com/11915822/54120466-0d8ff780-43f8-11e9-8973-d30e394adfb7.gif)

- **How it should be working after this PR:**
[Saws no longer waste your hard-earned mines.]
![new_1](https://user-images.githubusercontent.com/11915822/54120667-9c9d0f80-43f8-11e9-9054-593f3839d779.gif)
[Enemies can't use saws as shields.]
[In order to eliminate an incoming enemy mine, you should position/throw the saw correctly.]
[Enemies falling into a saw loose the mines they have hidden in their inventories.]
![new_2](https://user-images.githubusercontent.com/11915822/54120676-a1fa5a00-43f8-11e9-8548-86a0275d1fe0.gif)

## Steps to Test or Reproduce

1. Join any gamemode.
2. Spawn/buy a mine and a saw, being in the same team.
3. throw the mine into/towards the saw.
4. Try throwing a mine of a different team into/towards the saw.