### PR TITLE
Extra taunt settings

### DIFF
--- a/Entities/Common/Taunts/TauntMenu.as
+++ b/Entities/Common/Taunts/TauntMenu.as
@@ -158,7 +158,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("display taunt"))
 	{
-		CBlob@ blob = getLocalPlayerBlob();
+		CPlayer@ player = getLocalPlayer();
 		CBlob@ caller = getBlobByNetworkID(params.read_u16());
 		string taunt = params.read_string();
 		bool globalTaunt = params.read_bool();
@@ -169,7 +169,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 		}
 
 		//only show team taunts to teammates
-		if (globalTaunt || (blob !is null && blob.getTeamNum() == caller.getTeamNum()))
+		if (globalTaunt || (player !is null && player.getTeamNum() == caller.getTeamNum()))
 		{
 			caller.Chat(taunt);
 		}

--- a/Entities/Common/Taunts/TauntMenu.as
+++ b/Entities/Common/Taunts/TauntMenu.as
@@ -6,6 +6,8 @@
 const int GLOBAL_COOLDOWN = 120;
 const int TEAM_COOLDOWN = 60;
 const bool CAN_REPEAT_TAUNT = true;
+const bool CLICK_CATEGORY = false;
+const bool SHOW_IN_CHAT = true;
 
 string menu_selected = "CATEGORIES";
 string last_taunt;
@@ -13,6 +15,8 @@ int cooldown_time = 0;
 
 void onInit(CRules@ rules)
 {
+	rules.addCommandID("display taunt");
+
 	string filename = "TauntEntries.cfg";
 	string cachefilename = "../Cache/" + filename;
 	ConfigFile cfg;
@@ -110,9 +114,21 @@ void onTick(CRules@ rules)
 				if (CAN_REPEAT_TAUNT || selected.visible_name != last_taunt)
 				{
 					bool globalTaunt = isGlobalTauntCategory(menu_selected);
-					client_SendChat(selected.visible_name, globalTaunt ? 0 : 1);
 					last_taunt = selected.visible_name;
 					cooldown_time = globalTaunt ? GLOBAL_COOLDOWN : TEAM_COOLDOWN;
+
+					if (SHOW_IN_CHAT)
+					{
+						client_SendChat(selected.visible_name, globalTaunt ? 0 : 1);
+					}
+					else
+					{
+						CBitStream params;
+						params.write_u16(blob.getNetworkID());
+						params.write_string(selected.visible_name);
+						params.write_bool(globalTaunt);
+						rules.SendCommand(rules.getCommandID("display taunt"), params, true);
+					}
 				}
 				else
 				{
@@ -124,14 +140,38 @@ void onTick(CRules@ rules)
 		menu_selected = "CATEGORIES";
 		set_active_wheel_menu(null);
 	}
-	else if (get_active_wheel_menu() is menu && menu_selected == "CATEGORIES") //category selected
-	{
+	else if ( //select category
+		get_active_wheel_menu() is menu && menu_selected == "CATEGORIES" &&
+		(!CLICK_CATEGORY || blob.isKeyJustPressed(key_action1))
+	) {
 		WheelMenuEntry@ selected = menu.get_selected();
 		if (selected !is null)
 		{
 			menu_selected = selected.name;
 			WheelMenu@ submenu = get_wheel_menu(menu_selected);
 			set_active_wheel_menu(@submenu);
+		}
+	}
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream @params)
+{
+	if (cmd == this.getCommandID("display taunt"))
+	{
+		CBlob@ blob = getLocalPlayerBlob();
+		CBlob@ caller = getBlobByNetworkID(params.read_u16());
+		string taunt = params.read_string();
+		bool globalTaunt = params.read_bool();
+
+		if (caller is null || !cl_chatbubbles)
+		{
+			return;
+		}
+
+		//only show team taunts to teammates
+		if (globalTaunt || (blob !is null && blob.getTeamNum() == caller.getTeamNum()))
+		{
+			caller.Chat(taunt);
 		}
 	}
 }


### PR DESCRIPTION
## Status

**READY**

## Description

These settings might be needed in case taunts are spammed in f2p or if people change their opinions of taunts.
- Click to select category bool
- Show taunts in chat bool (depends on `cl_chatbubbles` setting)
