### PR TITLE
Fireplaces in CTF/TTH

### DIFF
--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -24,7 +24,7 @@ namespace CTFCosts
 	//BuilderShop.as
 	s32 lantern_wood, bucket_wood, filled_bucket, sponge, boulder_stone,
 		trampoline_wood, saw_wood, saw_stone, drill_stone, drill,
-		crate_wood, crate;
+		crate_wood, crate, fireplace_wood, fireplace_stone;
 
 	//BoatShop.as
 	s32 dinghy, dinghy_wood, longboat, longboat_wood, warboat;
@@ -124,6 +124,8 @@ void InitCosts()
 	CTFCosts::drill =                       ReadCost(cfg, "cost_drill"              , 25);
 	CTFCosts::crate_wood =                  ReadCost(cfg, "cost_crate_wood"         , 150);
 	CTFCosts::crate =                       ReadCost(cfg, "cost_crate"              , 20);
+	CTFCosts::fireplace_wood =              ReadCost(cfg, "cost_fireplace_wood"     , 100);
+	CTFCosts::fireplace_stone =             ReadCost(cfg, "cost_fireplace_stone"    , 100);
 
 	//BoatShop.as
 	CTFCosts::dinghy =                      ReadCost(cfg, "cost_dinghy"             , 25);

--- a/Entities/Common/Includes/Descriptions.as
+++ b/Entities/Common/Includes/Descriptions.as
@@ -38,6 +38,7 @@ namespace Descriptions
 	saw                        = getTranslatedString("A circular saw that turns tree logs into wood material."),
 	drill                      = getTranslatedString("A mining drill. Increases speed of digging and gathering resources, but gains only half the possible resources."),
 	crate                      = getTranslatedString("An empty wooden crate for storing and transporting inventory."),
+	fireplace                  = getTranslatedString("A log-powered fireplace which ignites arrows that pass through its flames."),
 	food                       = getTranslatedString("For healing. Don't think about this too much."),
 
 	tradingpost                = getTranslatedString("A trading post. Requires a trader to reside inside."),

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -19,7 +19,7 @@ void onInit(CBlob@ this)
 
 	// SHOP
 	this.set_Vec2f("shop offset", Vec2f_zero);
-	this.set_Vec2f("shop menu size", Vec2f(4, 4));
+	this.set_Vec2f("shop menu size", Vec2f(4, 5));
 	this.set_string("shop description", "Buy");
 	this.set_u8("shop icon", 25);
 
@@ -76,6 +76,14 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Crate (coins)", "$crate$", "crate", Descriptions::crate, false);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::crate);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Fireplace", "$fireplace$", "fireplace", Descriptions::fireplace, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::fireplace_wood);
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::fireplace_stone);
 	}
 }
 

--- a/Entities/Industry/Fireplace/Fireplace.cfg
+++ b/Entities/Industry/Fireplace/Fireplace.cfg
@@ -69,7 +69,11 @@ bool block_snaptogrid                      = no
 
 $movement_factory                          =
 $brain_factory                             =	
-$attachment_factory                        =
+
+$attachment_factory                        = box2d_attachment
+@$attachment_scripts                       =
+@$attachment_points                        = PICKUP; 0; 0; 1; 0; 0;
+
 $inventory_factory                         =
 
 # general
@@ -80,13 +84,14 @@ $name                                      = fireplace
 											 Fireplace.as;
 											 WoodStructureHit.as;
 											 GenericHit.as;
+											 SetTeamToCarrier.as;
 f32_health                                 = 4.0
 # looks & behaviour inside inventory
 $inventory_name                            = Fireplace
 $inventory_icon                            = -
 u8 inventory_icon_frame                    = 0
-u8 inventory_icon_frame_width          = 0
-u8 inventory_icon_frame_height         = 0
-u8 inventory_used_width                    = 0
-u8 inventory_used_height                   = 0
-u8 inventory_max_stacks                    = 0
+u8 inventory_icon_frame_width              = 0
+u8 inventory_icon_frame_height             = 0
+u8 inventory_used_width                    = 1
+u8 inventory_used_height                   = 1
+u8 inventory_max_stacks                    = 1

--- a/Entities/Industry/Workbench/Workbench.as
+++ b/Entities/Industry/Workbench/Workbench.as
@@ -21,6 +21,8 @@ void InitWorkshop(CBlob@ this)
 {
 	InitCosts(); //read from cfg
 
+	AddIconToken("$_buildershop_filled_bucket$", "Bucket.png", Vec2f(16, 16), 1);
+
 	this.set_Vec2f("shop offset", Vec2f_zero);
 	this.set_Vec2f("shop menu size", Vec2f(4, 5));
 
@@ -33,16 +35,25 @@ void InitWorkshop(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::bucket_wood);
 	}
 	{
+		ShopItem@ s = addShopItem(this, "Filled Bucket", "$_buildershop_filled_bucket$", "filled_bucket", Descriptions::filled_bucket, false);
+		s.spawnNothing = true;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::bucket_wood);
+		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::filled_bucket);
+	}
+	{
 		ShopItem@ s = addShopItem(this, "Sponge", "$sponge$", "sponge", Descriptions::sponge, false);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::sponge_wood);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Trampoline", "$trampoline$", "trampoline", Descriptions::trampoline, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::trampoline_wood);
+		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", WARCosts::boulder_stone);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Crate", "$crate$", "crate", Descriptions::crate, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::crate_wood);
+		ShopItem@ s = addShopItem(this, "Trampoline", "$trampoline$", "trampoline", Descriptions::trampoline, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::trampoline_wood);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Drill", "$drill$", "drill", Descriptions::drill, false);
@@ -51,17 +62,35 @@ void InitWorkshop(CBlob@ this)
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Saw", "$saw$", "saw", Descriptions::saw, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::saw_wood);
 		AddRequirement(s.requirements, "tech", "saw", "Saw Technology");
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Dinghy", "$dinghy$", "dinghy", Descriptions::dinghy, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::dinghy_wood);
-		AddRequirement(s.requirements, "tech", "dinghy", "Dinghy Technology");
+		ShopItem@ s = addShopItem(this, "Crate (wood)", "$crate$", "crate", Descriptions::crate, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::crate_wood);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
-		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", WARCosts::boulder_stone);
+		ShopItem@ s = addShopItem(this, "Crate (coins)", "$crate$", "crate", Descriptions::crate, false);
+		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::crate);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Fireplace", "$fireplace$", "fireplace", Descriptions::fireplace, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::fireplace_wood);
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::fireplace_stone);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Dinghy", "$dinghy$", "dinghy", Descriptions::dinghy, false);
+		s.customButton = true;
+		s.buttonwidth = 2;
+		s.buttonheight = 1;
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", WARCosts::dinghy_wood);
+		AddRequirement(s.requirements, "tech", "dinghy", "Dinghy Technology");
 	}
 }
 
@@ -79,6 +108,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		bool producing = params.read_bool();
 		string blobName = params.read_string();
 		u8 s_index = params.read_u8();
+
+		CBlob@ callerBlob = getBlobByNetworkID(callerID);
+		if (callerBlob is null)
+		{
+			return;
+		}
+
+		if (blobName == "filled_bucket")
+		{
+			CBlob@ b = server_CreateBlobNoInit("bucket");
+			b.setPosition(callerBlob.getPosition());
+			b.server_setTeamNum(callerBlob.getTeamNum());
+			b.Tag("_start_filled");
+			b.Init();
+			callerBlob.server_Pickup(b);
+		}
 
 		// check spam
 		//if (blobName != "factory" && isSpammed( blobName, this.getPosition(), 12 ))


### PR DESCRIPTION
## Status

**READY**

## Description

This PR is the stuff from #378 that need a #democracy vote. The other stuff were already merged in #425

- Fireplaces are log-powered, except those spawned in with the map (or spawned in using commands when your team is -1)
  - The burn rate may need to be tweaked. I forsee it being a bit too quick considering how long it takes  to get logs, unless you have a teammate helping you out while you shoot
- Added fireplace to builder shop (CTF) and workbench (TTH)
  - Currently costs 100 wood and 100 stone but I didn't put much thought into it. This needs to be voted on in #democracy
- Unlit fireplaces can be picked up and put in your inventory (1x1 slot size)
  - I'm a bit unsure whether being able to put fireplaces in your inventory is really needed. Maybe let people vote on it in #democracy
- Added missing shop items to workbench and reorganised them to match builder shop layout