### PR TITLE
Dead bodies disable saws of the same team

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -120,8 +120,11 @@ void Blend(CBlob@ this, CBlob@ tobeblended)
 
 	tobeblended.Tag("sawed");
 
-	// on saw player - disable the saw
-	if (tobeblended.getPlayer() !is null && tobeblended.getTeamNum() == this.getTeamNum())
+	// on saw player or dead body - disable the saw
+	if (
+		(tobeblended.getPlayer() !is null || //player
+		(tobeblended.hasTag("flesh") && tobeblended.hasTag("flesh"))) && //dead body
+		tobeblended.getTeamNum() == this.getTeamNum()) //same team as saw
 	{
 		CBitStream params;
 		params.write_netid(tobeblended.getNetworkID());
@@ -144,8 +147,6 @@ void Blend(CBlob@ this, CBlob@ tobeblended)
 
 bool canSaw(CBlob@ this, CBlob@ blob)
 {
-	if (blob.hasTag("saw")) return true; //destroy saws in close proximity
-
 	if (blob.getRadius() >= this.getRadius() * 0.99f || blob.getShape().isStatic() ||
 	        blob.hasTag("sawed") || blob.hasTag("invincible"))
 	{


### PR DESCRIPTION
## Status

**READY**

## Description

- Dead bodies disable saws of the same team
  - Gives knights and archers a way of 'disarming' saw traps without needing a builder to block it off / destroy it
  - Mines have similar behaviour which works really well
  - This gives bodies more uses other than for taunting with ;)
  - If alive teammates disable saws, shouldn't their dead bodies also do the same?
- Saws no longer destroy other saws
  - Why was this even a thing? Most of the time you accidentally destroy your own saws and get called out for griefing

## Steps to Test or Reproduce

- Throw a dead body into top of a saw of the same team
- Throw a saw into another saw