### PR TITLE
Fixed issue with moderation accolade

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -1,5 +1,6 @@
 #include "ScoreboardCommon.as";
 #include "Accolades.as";
+#include "ColoredNameToggleCommon.as";
 
 CPlayer@ hoveredPlayer;
 Vec2f hoveredPos;
@@ -370,7 +371,7 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 					1 : 0),             5,     0,         0,
 				(acc.map_contributor ?
 					1 : 0),             6,     0,         0,
-				(acc.moderation_contributor && (!p.isRCON() || coloredNameEnabled(getRules(), p)) ? //ensure accolade is visible for past admins
+				(acc.moderation_contributor && (!isSpecial(p) || coloredNameEnabled(getRules(), p)) ? //ensure accolade is visible for past admins
 					1 : 0),             7,     0,         0,
 
 				//tourney badges


### PR DESCRIPTION
## Status

**READY**

## Description

I realised that regular admins don't have rcon perms so the moderation accolade was always visible even if the player disabled their name colour.

## Steps to Test or Reproduce

1. Be admin on a server
2. Disable your name colour
