### PR TITLE
Admins always see other admins' name colour and moderation accolade

### DIFF
--- a/Rules/CommonScripts/ScoreboardCommon.as
+++ b/Rules/CommonScripts/ScoreboardCommon.as
@@ -8,7 +8,8 @@ f32 getKDR(CPlayer@ p)
 SColor getNameColour(CPlayer@ p)
 {
     SColor c;
-    bool showColor = coloredNameEnabled(getRules(), p);
+	CPlayer@ localplayer = getLocalPlayer();
+    bool showColor = (p !is localplayer && isSpecial(localplayer)) || coloredNameEnabled(getRules(), p);
 
     if (p.isDev() && showColor) {
         c = SColor(0xffb400ff); //dev

--- a/Rules/CommonScripts/ScoreboardCommon.as
+++ b/Rules/CommonScripts/ScoreboardCommon.as
@@ -8,7 +8,7 @@ f32 getKDR(CPlayer@ p)
 SColor getNameColour(CPlayer@ p)
 {
     SColor c;
-	CPlayer@ localplayer = getLocalPlayer();
+    CPlayer@ localplayer = getLocalPlayer();
     bool showColor = (p !is localplayer && isSpecial(localplayer)) || coloredNameEnabled(getRules(), p);
 
     if (p.isDev() && showColor) {

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -53,7 +53,7 @@ string[] tier_description = {
 };
 
 //returns the bottom
-float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emblem)
+float drawScoreboard(CPlayer@ localplayer, CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emblem)
 {
 	if (players.size() <= 0 || team is null)
 		return topleft.y;
@@ -371,7 +371,11 @@ float drawScoreboard(CPlayer@[] players, Vec2f topleft, CTeam@ team, Vec2f emble
 					1 : 0),             5,     0,         0,
 				(acc.map_contributor ?
 					1 : 0),             6,     0,         0,
-				(acc.moderation_contributor && (!isSpecial(p) || coloredNameEnabled(getRules(), p)) ? //ensure accolade is visible for past admins
+				(acc.moderation_contributor && (
+					(p !is localplayer && isSpecial(localplayer)) || //always show accolade of others if local player is special
+					!isSpecial(p) || //always show accolade for ex-admins
+					coloredNameEnabled(getRules(), p) //show accolade only if colored name is visible
+				) ?
 					1 : 0),             7,     0,         0,
 
 				//tourney badges
@@ -526,16 +530,16 @@ void onRenderScoreboard(CRules@ this)
 	//draw the scoreboards
 
 	if (localTeam == 0)
-		topleft.y = drawScoreboard(blueplayers, topleft, this.getTeam(0), Vec2f(0, 0));
+		topleft.y = drawScoreboard(localPlayer, blueplayers, topleft, this.getTeam(0), Vec2f(0, 0));
 	else
-		topleft.y = drawScoreboard(redplayers, topleft, this.getTeam(1), Vec2f(32, 0));
+		topleft.y = drawScoreboard(localPlayer, redplayers, topleft, this.getTeam(1), Vec2f(32, 0));
 
 	topleft.y += 52;
 
 	if (localTeam == 1)
-		topleft.y = drawScoreboard(blueplayers, topleft, this.getTeam(0), Vec2f(0, 0));
+		topleft.y = drawScoreboard(localPlayer, blueplayers, topleft, this.getTeam(0), Vec2f(0, 0));
 	else
-		topleft.y = drawScoreboard(redplayers, topleft, this.getTeam(1), Vec2f(32, 0));
+		topleft.y = drawScoreboard(localPlayer, redplayers, topleft, this.getTeam(1), Vec2f(32, 0));
 
 	topleft.y += 52;
 


### PR DESCRIPTION
## Status

**READY**

## Description

- Admins always see other admins' name colour and moderation accolade
- You are still able to see whether your name colour is hidden or not

Resolves #475

## Steps to Test or Reproduce

1. Be admin on a server with other admins
2. Ask other admins to toggle their name colour
   - You should always be able to see their name colour and moderation accolade
3. Toggle your own name colour
   - Should work like usual - only see moderation accolade when name colour is visible