### PR TITLE
Ruleral accolade fix

### DIFF
--- a/Rules/CommonScripts/accolade_data.cfg
+++ b/Rules/CommonScripts/accolade_data.cfg
@@ -2155,8 +2155,11 @@ RivetSpawn =
 Ruleral =
 	gold 1;
 	participation 1;
+	moderation;
+	# moderation - Royal Guard
 	# gold - OCE 2v2 mixed tournament no. 1
-	# participation 1; OCE 2v2 mixed tournament no. 1
+	# participation 1 - OCE 2v2 mixed tournament no. 1
+	# moderation - Royal Guard
 
 rymcd =
 	moderation;
@@ -2312,10 +2315,6 @@ Yagger =
 	# moderation - Royal Guard
 
  Raron =
-	moderation;
-	# moderation - Royal Guard
-
- Ruleral =
 	moderation;
 	# moderation - Royal Guard
 

--- a/Rules/CommonScripts/accolade_data.cfg
+++ b/Rules/CommonScripts/accolade_data.cfg
@@ -2156,9 +2156,8 @@ Ruleral =
 	gold 1;
 	participation 1;
 	moderation;
-	# moderation - Royal Guard
 	# gold - OCE 2v2 mixed tournament no. 1
-	# participation 1 - OCE 2v2 mixed tournament no. 1
+	# participation - OCE 2v2 mixed tournament no. 1
 	# moderation - Royal Guard
 
 rymcd =


### PR DESCRIPTION
## Status

**READY**

## Description

Ruleral's moderation accolade isn't showing in-game because he's listed twice in `accolade_data.cfg`.
I missed this when resolving merge conflicts between #468 and #472.