### PR TITLE
Improve eat button

### DIFF
--- a/Entities/Characters/Scripts/EatFoodButton.as
+++ b/Entities/Characters/Scripts/EatFoodButton.as
@@ -15,22 +15,52 @@ void onTick(CBlob@ this)
 		this.getHealth() < this.getInitialHealth()
 	) {
 		CBlob @carried = this.getCarriedBlob();
-		if (carried !is null && canEat(carried))
+		if (carried !is null && canEat(carried)) // consume what is held
 		{
 			Heal(this, carried);
 		}
-		else // search in inv
+		else // search in inventory
 		{
 			CInventory@ inv = this.getInventory();
+
+			// build list of all eatables
+			CBlob@[] eatables;
 			for (int i = 0; i < inv.getItemsCount(); i++)
 			{
 				CBlob @blob = inv.getItem(i);
 				if (canEat(blob))
 				{
-					Heal(this, blob);
-					return;
+					eatables.insertLast(blob);
 				}
 			}
+
+			if (eatables.length() == 0) // nothing to eat
+			{
+				return;
+			}
+
+			// find the most appropriate food to eat
+			CBlob@ bestFood;
+			u8 bestHeal = 0;
+			for (int i = 0; i < eatables.length(); i++)
+			{
+				CBlob@ food = eatables[i];
+				u8 heal = getHealingAmount(food);
+				int missingHealth = int(Maths::Ceil(this.getInitialHealth() - this.getHealth()) * 4);
+
+				if (heal < missingHealth && (bestFood is null || bestHeal < heal ) )
+				{
+					@bestFood = food;
+					bestHeal = heal;
+				}
+				else if (heal >= missingHealth && (bestFood is null || bestHeal < missingHealth || bestHeal > heal))
+				{
+					@bestFood = food;
+					bestHeal = heal;
+				}
+			}
+
+			Heal(this, bestFood);
 		}
 	}
 }

--- a/Entities/Items/Food/EatCommon.as
+++ b/Entities/Items/Food/EatCommon.as
@@ -5,6 +5,22 @@ bool canEat(CBlob@ blob)
 	return blob.exists("eat sound");
 }
 
+// returns the healing amount of a certain food (in quarter hearts) or 0 for non-food
+u8 getHealingAmount(CBlob@ food)
+{
+	if (!canEat(food))
+	{
+		return 0;
+	}
+
+	if (food.getName() == "heart")	    // HACK
+	{
+		return 4; // 1 heart
+	}
+
+	return 255; // full healing
+}
+
 void Heal(CBlob@ this, CBlob@ food)
 {
 	bool exists = getBlobByNetworkID(food.getNetworkID()) !is null;
@@ -12,16 +28,7 @@ void Heal(CBlob@ this, CBlob@ food)
 	{
 		CBitStream params;
 		params.write_u16(this.getNetworkID());
-
-		u8 heal_amount = 255; //in quarter hearts, 255 means full hp
-
-		if (food.getName() == "heart")	    // HACK
-		{
-			heal_amount = 4;
-		}
-
-		params.write_u8(heal_amount);
-
+		params.write_u8(getHealingAmount(food));
 		food.SendCommand(food.getCommandID(heal_id), params);
 
 		food.Tag("healed");


### PR DESCRIPTION
## Status
**READY**

## Description

This pr makes the eat button calculate your missing hearts and choose an appropriate food. It prefers to overheal than to underheal. If you miss one heart and carry a heart and a burger, it will always choose to consume the heart, no matter the order in the inventory. If more food items(different healing amounts) are added in the future, this should be compatible.

## Steps to Test or Reproduce

- Start a sandbox game
- Spawn a burger and a heart
- Put the burger in your inventory first, then the heart
- Take one heart of damage
- Press V
- The heart should be consumed