### PR TITLE
[modified] kills, deaths and assists only count when the round is on; no coin loss and no killfeed mention, if suicided during warm-up.

### DIFF
--- a/Rules/CTF/Scripts/CTF_Trading.as
+++ b/Rules/CTF/Scripts/CTF_Trading.as
@@ -107,15 +107,17 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customData)
 				killer.server_setCoins(killer.getCoins() - coinsOnTKLose);
 			}
 		}
+		if (!this.isWarmup())	//only reduce coins if the round is on.
+		{
+			s32 lost = victim.getCoins() * (coinsOnDeathLosePercent * 0.01f);
 
-		s32 lost = victim.getCoins() * (coinsOnDeathLosePercent * 0.01f);
+			victim.server_setCoins(victim.getCoins() - lost);
 
-		victim.server_setCoins(victim.getCoins() - lost);
-
-		//drop coins
-		CBlob@ blob = victim.getBlob();
-		if (blob !is null)
-			server_DropCoins(blob.getPosition(), XORRandom(lost));
+			//drop coins
+			CBlob@ blob = victim.getBlob();
+			if (blob !is null)
+				server_DropCoins(blob.getPosition(), XORRandom(lost));
+		}
 	}
 }
 

--- a/Rules/CommonScripts/DefaultScoreboard.as
+++ b/Rules/CommonScripts/DefaultScoreboard.as
@@ -13,29 +13,30 @@ void onBlobDie(CRules@ this, CBlob@ blob)
 			CPlayer@ victim = blob.getPlayer();
 			CPlayer@ helper = getAssistPlayer(victim, killer);
 
-		if (helper !is null)
-		{
-			helper.setAssists(helper.getAssists() + 1);
-		}
-
-		if (victim !is null)
-		{
-			victim.setDeaths(victim.getDeaths() + 1);
-			// temporary until we have a proper score system
-			victim.setScore(100 * (f32(victim.getKills()) / f32(victim.getDeaths() + 1)));
-
-			if (killer !is null) //requires victim so that killing trees matters
+			if (helper !is null)
 			{
-				if (killer.getTeamNum() != blob.getTeamNum())
+				helper.setAssists(helper.getAssists() + 1);
+			}
+
+			if (victim !is null)
+			{
+				victim.setDeaths(victim.getDeaths() + 1);
+				// temporary until we have a proper score system
+				victim.setScore(100 * (f32(victim.getKills()) / f32(victim.getDeaths() + 1)));
+
+				if (killer !is null) //requires victim so that killing trees matters
 				{
-					killer.setKills(killer.getKills() + 1);
-					// temporary until we have a proper score system
-					killer.setScore(100 * (f32(killer.getKills()) / f32(killer.getDeaths() + 1)));
+					if (killer.getTeamNum() != blob.getTeamNum())
+					{
+						killer.setKills(killer.getKills() + 1);
+						// temporary until we have a proper score system
+						killer.setScore(100 * (f32(killer.getKills()) / f32(killer.getDeaths() + 1)));
+					}
 				}
+
 			}
 
 		}
-	}
 
 	}
 	

--- a/Rules/CommonScripts/DefaultScoreboard.as
+++ b/Rules/CommonScripts/DefaultScoreboard.as
@@ -13,29 +13,29 @@ void onBlobDie(CRules@ this, CBlob@ blob)
 			CPlayer@ victim = blob.getPlayer();
 			CPlayer@ helper = getAssistPlayer(victim, killer);
 
-		if (helper !is null)
-		{
-			helper.setAssists(helper.getAssists() + 1);
-		}
-
-		if (victim !is null)
-		{
-			victim.setDeaths(victim.getDeaths() + 1);
-			// temporary until we have a proper score system
-			victim.setScore(100 * (f32(victim.getKills()) / f32(victim.getDeaths() + 1)));
-
-			if (killer !is null) //requires victim so that killing trees matters
+			if (helper !is null)
 			{
-				if (killer.getTeamNum() != blob.getTeamNum())
-				{
-					killer.setKills(killer.getKills() + 1);
-					// temporary until we have a proper score system
-					killer.setScore(100 * (f32(killer.getKills()) / f32(killer.getDeaths() + 1)));
-				}
+				helper.setAssists(helper.getAssists() + 1);
 			}
 
+			if (victim !is null)
+			{
+				victim.setDeaths(victim.getDeaths() + 1);
+				// temporary until we have a proper score system
+				victim.setScore(100 * (f32(victim.getKills()) / f32(victim.getDeaths() + 1)));
+
+				if (killer !is null) //requires victim so that killing trees matters
+				{
+					if (killer.getTeamNum() != blob.getTeamNum())
+					{
+						killer.setKills(killer.getKills() + 1);
+						// temporary until we have a proper score system
+						killer.setScore(100 * (f32(killer.getKills()) / f32(killer.getDeaths() + 1)));
+					}
+				}
+
+			}
 		}
-	}
 
 	}
 	

--- a/Rules/CommonScripts/DefaultScoreboard.as
+++ b/Rules/CommonScripts/DefaultScoreboard.as
@@ -5,11 +5,13 @@
 
 void onBlobDie(CRules@ this, CBlob@ blob)
 {
-	if (blob !is null)
+	if (!this.isGameOver() && !this.isWarmup())	//Only count kills, deaths and assists when the game is on
 	{
-		CPlayer@ killer = blob.getPlayerOfRecentDamage();
-		CPlayer@ victim = blob.getPlayer();
-		CPlayer@ helper = getAssistPlayer(victim, killer);
+		if (blob !is null)
+		{
+			CPlayer@ killer = blob.getPlayerOfRecentDamage();
+			CPlayer@ victim = blob.getPlayer();
+			CPlayer@ helper = getAssistPlayer(victim, killer);
 
 		if (helper !is null)
 		{
@@ -34,4 +36,7 @@ void onBlobDie(CRules@ this, CBlob@ blob)
 
 		}
 	}
+
+	}
+	
 }

--- a/Rules/CommonScripts/DefaultScoreboard.as
+++ b/Rules/CommonScripts/DefaultScoreboard.as
@@ -13,29 +13,29 @@ void onBlobDie(CRules@ this, CBlob@ blob)
 			CPlayer@ victim = blob.getPlayer();
 			CPlayer@ helper = getAssistPlayer(victim, killer);
 
-			if (helper !is null)
-			{
-				helper.setAssists(helper.getAssists() + 1);
-			}
-
-			if (victim !is null)
-			{
-				victim.setDeaths(victim.getDeaths() + 1);
-				// temporary until we have a proper score system
-				victim.setScore(100 * (f32(victim.getKills()) / f32(victim.getDeaths() + 1)));
-
-				if (killer !is null) //requires victim so that killing trees matters
-				{
-					if (killer.getTeamNum() != blob.getTeamNum())
-					{
-						killer.setKills(killer.getKills() + 1);
-						// temporary until we have a proper score system
-						killer.setScore(100 * (f32(killer.getKills()) / f32(killer.getDeaths() + 1)));
-					}
-				}
-
-			}
+		if (helper !is null)
+		{
+			helper.setAssists(helper.getAssists() + 1);
 		}
+
+		if (victim !is null)
+		{
+			victim.setDeaths(victim.getDeaths() + 1);
+			// temporary until we have a proper score system
+			victim.setScore(100 * (f32(victim.getKills()) / f32(victim.getDeaths() + 1)));
+
+			if (killer !is null) //requires victim so that killing trees matters
+			{
+				if (killer.getTeamNum() != blob.getTeamNum())
+				{
+					killer.setKills(killer.getKills() + 1);
+					// temporary until we have a proper score system
+					killer.setScore(100 * (f32(killer.getKills()) / f32(killer.getDeaths() + 1)));
+				}
+			}
+
+		}
+	}
 
 	}
 	

--- a/Rules/CommonScripts/KillMessages.as
+++ b/Rules/CommonScripts/KillMessages.as
@@ -263,8 +263,12 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customdata)
 		KillFeed@ feed;
 		if (this.get("KillFeed", @feed) && feed !is null)
 		{
-			KillMessage message(victim, killer, customdata);
-			feed.killMessages.push_back(message);
+			//Hide suicides from killfeed, during warm-up.
+			if (!(killer is null && this.isWarmup()))
+			{
+				KillMessage message(victim, killer, customdata);
+				feed.killMessages.push_back(message);
+			}
 		}
 
 		// hover message
@@ -276,7 +280,7 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customdata)
 			CPlayer@ helper = getAssistPlayer(victim, killer);
 
 			bool kill = killerblob !is null && victimblob !is null && killerblob.isMyPlayer() && killerblob !is victimblob;
-			bool assist = helper !is null;
+			bool assist = helper !is null && helper.isMyPlayer();
 			if (kill)
 			{
 				add_message(KillSpreeMessage(victim));


### PR DESCRIPTION
## Status

- **READY**

## Description

This PR makes the modifications suggested here #506 and closes #522 .
In other words: 

1.  in competitive gamemodes kills, deaths and assists no longer get counted if:

- It's the warm-up phase.
- One team won and the game is ended.
When it comes to sandbox, KDA should work the same way they used to be.

2. You can now suicide during the building/warm-up phase without:

- Having your name showing or spamming the kill-feed. (after the warm-up your suicides revert to being visible by everyone).
- You no longer loose a percentage of your coins. (again, only during the warm-up).
- Increasing your death count on the scoreboard.
These changes should encourage using the suicide button, to help with getting back to base and refilling without being afraid of affecting your KDR or wasting your hard-earned coins.

These modifications were tested on CTF, TTH, TDM and sandbox and they should be working as intended.
## Steps to Test or Reproduce

1. Join/host a CTF/TTH/TDM server.
2. Build some stone blocks to gain some coins, then suicide. => **Death doesn't count!** + **no coins loss!** + **kill-feed doesn't mention you suiciding!**
3. Try killing someone during warm-up. => **Doesn't count!**
4. Try suiciding/killing someone when the game starts/the round is on. => **_Counts!_ + _if suicided: coin loss! + the kill-feed mentions your suicide!_**
5. Try suiciding/killing someone when some team wins and the game ends. => **Doesn't count! + _if suicided: coin loss! + the kill-feed mentions you!_**