### PR TITLE
Assists fix

### DIFF
--- a/Rules/CommonScripts/AssistCommon.as
+++ b/Rules/CommonScripts/AssistCommon.as
@@ -3,7 +3,7 @@
 CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 {
 	//no assist if teamkill
-	if (victim is null || killer is null || victim.getTeamNum() === killer.getTeamNum())
+	if (victim is null || killer is null || victim.getTeamNum() == killer.getTeamNum())
 	{
 		return null;
 	}
@@ -86,7 +86,7 @@ CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 		{
 			//killer cannot assist their own kill
 			//helper needs to be from a different team
-			if (origHitter is killer || victim.getTeamNum() === origHitter.getTeamNum())
+			if (origHitter is killer || victim.getTeamNum() == origHitter.getTeamNum())
 			{
 				return null;
 			}

--- a/Rules/CommonScripts/AssistCommon.as
+++ b/Rules/CommonScripts/AssistCommon.as
@@ -2,7 +2,8 @@
 
 CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 {
-	if (victim is null || killer is null)
+	//no assist if teamkill
+	if (victim is null || killer is null || victim.getTeamNum() === killer.getTeamNum())
 	{
 		return null;
 	}
@@ -84,7 +85,8 @@ CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 		if (totalDamage >= assistDamage)
 		{
 			//killer cannot assist their own kill
-			if (origHitter is killer)
+			//helper needs to be from a different team
+			if (origHitter is killer || victim.getTeamNum() === origHitter.getTeamNum())
 			{
 				return null;
 			}

--- a/Rules/CommonScripts/KillMessages.as
+++ b/Rules/CommonScripts/KillMessages.as
@@ -276,7 +276,7 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customdata)
 			CPlayer@ helper = getAssistPlayer(victim, killer);
 
 			bool kill = killerblob !is null && victimblob !is null && killerblob.isMyPlayer() && killerblob !is victimblob;
-			bool assist = helper !is null;
+			bool assist = helper !is null && helper.isMyPlayer();
 			if (kill)
 			{
 				add_message(KillSpreeMessage(victim));


### PR DESCRIPTION
## Status

**READY**

## Description

- Assist hover messages are no longer shown to everyone
- Assists are not given if the victim is on the same team as the killer or the assist player

## Steps to Test or Reproduce

- Have an assist occur with other players on the server to see if only the assist player gets the hover message
- Have red player damage blue player and then have another blue player teamkill the damaged player
- Have blue player damage another blue player and then have a red player kill the damaged player