### PR TITLE
Quarry balance

### DIFF
--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -13,7 +13,7 @@ namespace CTFCosts
 	s32 buildershop_wood, quarters_wood, knightshop_wood, archershop_wood,
 		boatshop_wood, boatshop_gold, vehicleshop_wood, vehicleshop_gold,
 		storage_stone, storage_wood, tunnel_stone, tunnel_wood, tunnel_gold,
-		quarry_stone, quarry_gold;
+		quarry_stone, quarry_gold, quarry_count;
 
 	//ArcherShop.as
 	s32 arrows, waterarrows, firearrows, bombarrows;
@@ -98,6 +98,7 @@ void InitCosts()
 	CTFCosts::tunnel_gold =                 ReadCost(cfg, "cost_tunnel_gold"        , 50);
 	CTFCosts::quarry_stone =				ReadCost(cfg, "cost_quarry_stone"       , 150);
 	CTFCosts::quarry_gold =					ReadCost(cfg, "cost_quarry_gold"        , 100);
+	CTFCosts::quarry_count =				ReadCost(cfg, "cost_quarry_count"       , 1);
 
 	//ArcherShop.as
 	CTFCosts::arrows =                      ReadCost(cfg, "cost_arrows"             , 15);

--- a/Entities/Industry/Building/Building.as
+++ b/Entities/Industry/Building/Building.as
@@ -70,6 +70,7 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Stone Quarry", "$stonequarry$", "quarry", Descriptions::quarry);
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::quarry_stone);
 		AddRequirement(s.requirements, "blob", "mat_gold", "Gold", CTFCosts::quarry_gold);
+		AddRequirement(s.requirements, "no more", "quarry", "Stone Quarry", CTFCosts::quarry_count);
 	}
 }
 

--- a/Entities/Industry/CTFShops/CTFCosts.cfg
+++ b/Entities/Industry/CTFShops/CTFCosts.cfg
@@ -16,6 +16,7 @@
 	cost_tunnel_gold                = 50
 	cost_quarry_stone               = 150
 	cost_quarry_gold                = 100
+	cost_quarry_count               = 1
 
 	#knight shop
 	cost_bomb                       = 25

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -107,7 +107,7 @@ void Blend(CBlob@ this, CBlob@ tobeblended)
 
 				blob.setPosition(this.getPosition() + Vec2f(0, 12));
 				blob.setVelocity(Vec2f(0, -4.0f));
-				blob.server_SetQuantity(blobname == "crate"? 100 : 50);
+				blob.server_SetQuantity(50);
 			}
 		}
 


### PR DESCRIPTION
## Status

**READY**

## Description

- Limit one quarry per team
- Reduced the amount of wood gained by sawing crates from 100 to 50 wood
  - Crates gave too much wood for its price which made it easy to keep quarries operating

Closes #328

## Steps to Test or Reproduce

Attempt to build more than one quarry
Throw a crate into a saw to get wood