### PR TITLE
Fixed polish translation

### DIFF
--- a/Locales/Polish_pl.json
+++ b/Locales/Polish_pl.json
@@ -1,4 +1,4 @@
-KING ARTHUR'S GOLD TRANSLATION FILE
+// KING ARTHUR'S GOLD TRANSLATION FILE
 // This file contains translation for various text in the game.
 
 // INSTRUCTIONS:


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Missing slashes in beginning of file causes polish translation not to work.

## Steps to Test or Reproduce

Try changing language to polish. Language doesn't change.
