### PR TITLE
Assist changes

### DIFF
--- a/Entities/Common/HoverMessage/HoverMessage.as
+++ b/Entities/Common/HoverMessage/HoverMessage.as
@@ -1,6 +1,7 @@
 // Hover messages
 
 #include "TeamColour.as"
+#include "AssistCommon.as"
 
 // Linear interpolation
 // TODO: expose in engine
@@ -251,7 +252,7 @@ class AssistMessage : HoverMessage
 		GUI::GetTextDimensions(assist_counter, offset);
 		offset = Vec2f(offset.x + 12.0f, 0.0f);
 
-		tokens.push_back(MessageToken(assist_counter, SColor(255, 255, 255, 100)));
+		tokens.push_back(MessageToken(assist_counter, ASSIST_COLOR));
 
 		for (uint i = 0; i < victims.length; ++i)
 		{

--- a/Rules/CTF/Scripts/CTF_Trading.as
+++ b/Rules/CTF/Scripts/CTF_Trading.as
@@ -1,9 +1,11 @@
 //not server only so the client also gets the game event setup stuff
 
 #include "GameplayEvents.as"
+#include "AssistCommon.as"
 
 const int coinsOnDamageAdd = 5;
 const int coinsOnKillAdd = 10;
+const int coinsOnAssistAdd = 5;
 
 const int coinsOnDeathLosePercent = 20;
 const int coinsOnTKLose = 50;
@@ -105,6 +107,13 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customData)
 			else if (killer.getTeamNum() == victim.getTeamNum())
 			{
 				killer.server_setCoins(killer.getCoins() - coinsOnTKLose);
+			}
+
+			CPlayer@ assistPlayer = getAssistPlayer(victim, killer);
+			if (assistPlayer !is null)
+			{
+				assistPlayer.server_setCoins(assistPlayer.getCoins() + coinsOnAssistAdd);
+				print("assist coins " + assistPlayer.getUsername());
 			}
 		}
 

--- a/Rules/CommonScripts/AssistCommon.as
+++ b/Rules/CommonScripts/AssistCommon.as
@@ -1,4 +1,8 @@
-//TODO: powerful items that insta-kill shouldnt have an assist (keg, mine)
+//TODO: powerful items that insta-kill shouldnt have an assist, or the assist should be given to the player who buys the item (keg, mine, saw)
+//		somehow include water stuns and shield knocks in assists
+
+const f32 ASSIST_DAMAGE = 0.0f; //victimBlob.getInitialHealth() / 2.0f;
+const SColor ASSIST_COLOR(255, 255, 255, 100);
 
 CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 {
@@ -14,9 +18,6 @@ CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 	{
 		return null;
 	}
-
-	//damage criteria for assist
-	f32 assistDamage = victimBlob.getInitialHealth() / 2.0f;
 
 	//get info used to determine assist
 	CPlayer@[] hitters;
@@ -61,10 +62,11 @@ CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 	for (uint i = 0; i < hitters.length; i++)
 	{
 		CPlayer@ origHitter = hitters[i];
-		if(origHitter is null)
+		if (origHitter is null)
 		{
 			continue;
 		}
+
 		f32 totalDamage = 0;
 
 		for (uint j = 0; j < hitters.length; j++)
@@ -86,13 +88,13 @@ CPlayer@ getAssistPlayer(CPlayer@ victim, CPlayer@ killer)
 		}
 
 		//check if damage is enough for assist
-		if (totalDamage >= assistDamage)
+		if (totalDamage >= ASSIST_DAMAGE)
 		{
 			//killer cannot assist their own kill
 			//helper needs to be from a different team
 			if (origHitter is killer || victim.getTeamNum() == origHitter.getTeamNum())
 			{
-				return null;
+				continue;
 			}
 
 			//so close, yet so far. give this player some recognition!

--- a/Rules/CommonScripts/KillMessages.as
+++ b/Rules/CommonScripts/KillMessages.as
@@ -132,7 +132,7 @@ class KillFeed
 				GUI::GetTextDimensions(message.helper_tag + " ", helper_tag_size);
 				Vec2f dim(getScreenWidth() - helper_name_size.x - max_username_size.x - max_clantag_size.x - single_space_size.x - 32, 0);
 				ul.Set(dim.x, (message_step + yOffset + assists + 1) * 16);
-				col = getTeamColor(message.attackerteam);
+				col = ASSIST_COLOR;
 				GUI::DrawText(message.helper, ul, col);
 
 				ul.x -= helper_tag_size.x;

--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -78,8 +78,8 @@ float drawScoreboard(CPlayer@ localplayer, CPlayer@[] players, Vec2f topleft, CT
 
 	topleft.y += stepheight * 2;
 
-	const int accolades_start = 740;
-	const int age_start = accolades_start + 80;
+	const int accolades_start = 760;
+	const int age_start = accolades_start + 70;
 
 	draw_age = false;
 	for(int i = 0; i < players.length; i++) {

--- a/Rules/TDM/Scripts/TDM_Trading.as
+++ b/Rules/TDM/Scripts/TDM_Trading.as
@@ -1,10 +1,12 @@
 #include "TradingCommon.as"
 #include "Descriptions.as"
+#include "AssistCommon.as"
 
 #define SERVER_ONLY
 
 int coinsOnDamageAdd = 2;
 int coinsOnKillAdd = 10;
+int coinsOnAssistAdd = 5;
 int coinsOnDeathLose = 10;
 int min_coins = 50;
 int max_coins = 100;
@@ -117,6 +119,7 @@ void Reset(CRules@ this)
 
 	coinsOnDamageAdd = cfg.read_s32("coinsOnDamageAdd", coinsOnDamageAdd);
 	coinsOnKillAdd = cfg.read_s32("coinsOnKillAdd", coinsOnKillAdd);
+	coinsOnAssistAdd = cfg.read_s32("coinsOnAssistAdd", coinsOnAssistAdd);
 	coinsOnDeathLose = cfg.read_s32("coinsOnDeathLose", coinsOnDeathLose);
 	min_coins = cfg.read_s32("minCoinsOnRestart", min_coins);
 	max_coins = cfg.read_s32("maxCoinsOnRestart", max_coins);
@@ -178,6 +181,13 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customData)
 			if (killer !is victim && killer.getTeamNum() != victim.getTeamNum())
 			{
 				killer.server_setCoins(killer.getCoins() + coinsOnKillAdd);
+			}
+
+			CPlayer@ assistPlayer = getAssistPlayer(victim, killer);
+			if (assistPlayer !is null)
+			{
+				assistPlayer.server_setCoins(assistPlayer.getCoins() + coinsOnAssistAdd);
+				print("assist coins " + assistPlayer.getUsername());
 			}
 		}
 

--- a/Rules/TDM/tdm_vars.cfg
+++ b/Rules/TDM/tdm_vars.cfg
@@ -62,6 +62,7 @@
 
 	coinsOnDamageAdd 	= 2
 	coinsOnKillAdd 		= 10
+	coinsOnAssistAdd 	= 5
 	coinsOnDeathLose 	= 20
 
 	# players get at least this amount of coins


### PR DESCRIPTION
## Status

**IN DEVELOPMENT**

## Description

- Assist players are coloured yellow in the killfeed
  - Matches the yellow +1 hover message
  - Makes it clearer that an assist occurred in the killfeed
- Any damage dealt can give you an assist
  - This removes the 'inconsistency' of assists
- Assists give you 5 coins
  - Might make it give coins depending on the damage given by the killer compared to the assister (e.g. assister damages 3h, killer damages 1h to kill victim, the assister should get more coins than the killer)
- Fixed accolades overlapping on the scoreboard

Spikes still don't give assists. I'm working to fix that...