### PR TITLE
Lanterns only collide with static blobs

### DIFF
--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -49,3 +49,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	}
 
 }
+
+bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
+{
+    return blob.getShape().isStatic();
+}


### PR DESCRIPTION
## Status

**READY**

## Description

In maps like Niiiiii_GetisArena, water bombs tend to collide with the static floating lanterns. This PR only makes lanterns collide with static blobs like doors and platforms.

## Steps to Test or Reproduce

Throw a water bomb at a lantern.