### PR TITLE
Vehicles give coins based on damage dealt

### DIFF
--- a/Entities/Vehicles/Common/WoodVehicleDamages.as
+++ b/Entities/Vehicles/Common/WoodVehicleDamages.as
@@ -50,7 +50,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		{
 			if (damageowner.getTeamNum() != this.getTeamNum())
 			{
-				SendGameplayEvent(createVehicleDamageEvent(damageowner, damage));
+				SendGameplayEvent(createVehicleDamageEvent(damageowner, dmg));
 			}
 		}
 	}

--- a/Entities/Vehicles/Common/WoodVehicleDamages.as
+++ b/Entities/Vehicles/Common/WoodVehicleDamages.as
@@ -50,7 +50,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		{
 			if (damageowner.getTeamNum() != this.getTeamNum())
 			{
-				SendGameplayEvent(createVehicleDamageEvent(damageowner, false));
+				SendGameplayEvent(createVehicleDamageEvent(damageowner, damage));
 			}
 		}
 	}
@@ -66,7 +66,7 @@ void onDie(CBlob@ this)
 		CBlob@ b = p.getBlob();
 		if (b !is null && b.getTeamNum() != this.getTeamNum())
 		{
-			SendGameplayEvent(createVehicleDamageEvent(this.getPlayerOfRecentDamage(), true));
+			SendGameplayEvent(createVehicleDestroyEvent(this.getPlayerOfRecentDamage()));
 		}
 	}
 }

--- a/Rules/CTF/Scripts/CTF_Trading.as
+++ b/Rules/CTF/Scripts/CTF_Trading.as
@@ -11,7 +11,7 @@ const int coinsOnTKLose = 50;
 const int coinsOnRestartAdd = 0;
 const bool keepCoinsOnRestart = false;
 
-const int coinsOnHitSiege = 5;
+const int coinsOnHitSiege = 2; //per heart of damage
 const int coinsOnKillSiege = 20;
 
 const int coinsOnCapFlag = 100;
@@ -202,8 +202,14 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 				break;
 
 				case GE_hit_vehicle:
-					coins = coinsOnHitSiege;
-					break;
+
+				{
+					g.params.ResetBitIndex();
+					f32 damage = g.params.read_f32();
+					coins = coinsOnHitSiege * damage;
+				}
+
+				break;
 
 				case GE_kill_vehicle:
 					coins = coinsOnKillSiege;

--- a/Rules/CTF/Scripts/CTF_Trading.as
+++ b/Rules/CTF/Scripts/CTF_Trading.as
@@ -11,7 +11,7 @@ const int coinsOnTKLose = 50;
 const int coinsOnRestartAdd = 0;
 const bool keepCoinsOnRestart = false;
 
-const int coinsOnHitSiege = 2; //per heart of damage
+const int coinsOnHitSiege = 5; //per heart of damage
 const int coinsOnKillSiege = 20;
 
 const int coinsOnCapFlag = 100;

--- a/Rules/CommonScripts/GameplayEvents.as
+++ b/Rules/CommonScripts/GameplayEvents.as
@@ -156,9 +156,17 @@ GameplayEvent@ createBuiltBlobEvent(CPlayer@ by, string name)
 }
 
 //create a vehicle damage event
-GameplayEvent@ createVehicleDamageEvent(CPlayer@ by, bool kill)
+GameplayEvent@ createVehicleDamageEvent(CPlayer@ by, f32 damage)
 {
-	return GameplayEvent(kill ? GE_kill_vehicle : GE_hit_vehicle , by);
+	GameplayEvent g(GE_hit_vehicle, by);
+	g.params.write_f32(damage);
+	return g;
+}
+
+//create a vehicle destroy event
+GameplayEvent@ createVehicleDestroyEvent(CPlayer@ by)
+{
+	return GameplayEvent(GE_kill_vehicle, by);
 }
 
 //create a flag capture event


### PR DESCRIPTION
## Status

**READY**

## Description

The number of coins given when damaging vehicles is based on damage dealt instead of it being a fixed amount. This also makes kegging enemy vehicles a bit more worthwhile since it gives back a fair bit of coins.

5 coins are given per heart of damage dealt (jabs and fully charged arrows do 1 heart, and slashes do 2 hearts).

## Steps to Test or Reproduce

Damage enemy vehicles using various methods