### PR TITLE
[Bug fix] Removed ability to climb arrows while stunned

### DIFF
--- a/Entities/Characters/Archer/ClimbArrows.as
+++ b/Entities/Characters/Archer/ClimbArrows.as
@@ -1,4 +1,5 @@
 #include "RunnerCommon.as"
+#include "Knocked.as"
 
 void onInit(CBlob@ this)
 {
@@ -11,7 +12,7 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
-	if (!this.isKeyPressed(key_up)) { return; }
+	if (!this.isKeyPressed(key_up) || isKnocked(this)) { return; }
 
 	CBlob@[] overlapping;
 	if (this.getOverlapping(@overlapping))


### PR DESCRIPTION
## Status

**READY**

## Description

Removed the ability for players to climb arrows while stunned

## Steps to Test or Reproduce

1. Shoot a bunch of arrows into a wall
2. Stand next to the wall
3. Jump then immediately stun yourself with water
4. Attempt to climb the arrows