### PR TITLE
[Bug fix] Fixed minor issues with builder block placement preview

### DIFF
--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -173,7 +173,7 @@ void onRender(CSprite@ this)
 			if (bc.cursorClose && bc.hasReqs && bc.buildable)
 			{
 				SColor color;
-				Vec2f aimpos = bc.tileAimPos + getCamera().getInterpolationOffset();
+				Vec2f aimpos = bc.tileAimPos;
 
 				if (bc.buildable && bc.supported)
 				{

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -107,16 +107,13 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 		}
 	}
 
-//printf("c");
-	bool canPlaceOnBackground = ((blob is null) || (blob.getShape().getConsts().support > 0));   // if this is a blob it has to do support - so spikes cant be placed on back
-
 	if (
-		(!canPlaceOnBackground || !map.isTileBackgroundNonEmpty(backtile)) &&      // can put against background
+		!map.isTileBackgroundNonEmpty(backtile) &&      // can put against background
 		!(                                              // can put sticking next to something
-			canPlaceNextTo(map, left) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(left) && !map.isTileGrass(left.type))  ||
-			canPlaceNextTo(map, right) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(right) && !map.isTileGrass(right.type)) ||
-			canPlaceNextTo(map, up)   || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(up) && !map.isTileGrass(up.type))    ||
-			canPlaceNextTo(map, down) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(down) && !map.isTileGrass(down.type))
+			canPlaceNextTo(map, left) ||
+			canPlaceNextTo(map, right) ||
+			canPlaceNextTo(map, up) ||
+			canPlaceNextTo(map, down)
 		)
 	)
 	{

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -113,10 +113,10 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 	if (
 		(!canPlaceOnBackground || !map.isTileBackgroundNonEmpty(backtile)) &&      // can put against background
 		!(                                              // can put sticking next to something
-			canPlaceNextTo(map, left) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(left))  ||
-			canPlaceNextTo(map, right) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(right)) ||
-			canPlaceNextTo(map, up)   || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(up))    ||
-			canPlaceNextTo(map, down) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(down))
+			canPlaceNextTo(map, left) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(left) && !map.isTileGrass(left.type))  ||
+			canPlaceNextTo(map, right) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(right) && !map.isTileGrass(right.type)) ||
+			canPlaceNextTo(map, up)   || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(up) && !map.isTileGrass(up.type))    ||
+			canPlaceNextTo(map, down) || (canPlaceOnBackground && map.isTileBackgroundNonEmpty(down) && !map.isTileGrass(down.type))
 		)
 	)
 	{


### PR DESCRIPTION
## Status

**READY**

## Description

- Fixed block placement preview showing that you can place blocks next to grass when you actually can't
- Fixed jittery tile preview when you're about to place a block while moving

## Steps to Test or Reproduce

- Attempt to place a block next to grass
- Move around with a block in your hand while hovering your cursor over a single tile
