### PR TITLE
[Bug fix] Removed ability for knights/archers to insta-slash/shoot when exiting crates

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -589,17 +589,17 @@ void onTick(CBlob@ this)
 		return;
 	}
 
-	if (getKnocked(this) > 0)
+	if (getKnocked(this) > 0 || this.isInInventory())
 	{
 		archer.grappling = false;
 		archer.charge_state = 0;
 		archer.charge_time = 0;
+		this.getSprite().SetEmitSoundPaused(true);
+		getHUD().SetCursorFrame(0);
 		return;
 	}
 
 	ManageGrapple(this, archer);
-
-	if (this.isInInventory()) return;
 
 	RunnerMoveVars@ moveVars;
 	if (!this.get("moveVars", @moveVars))

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -99,9 +99,6 @@ void onTick(CBlob@ this)
 {
 	u8 knocked = getKnocked(this);
 
-	if (this.isInInventory())
-		return;
-
 	//knight logic stuff
 	//get the vars to turn various other scripts on/off
 	RunnerMoveVars@ moveVars;
@@ -113,6 +110,13 @@ void onTick(CBlob@ this)
 	KnightInfo@ knight;
 	if (!this.get("knightInfo", @knight))
 	{
+		return;
+	}
+
+	if (this.isInInventory())
+	{
+		//prevent players from insta-slashing when exiting crates
+		knight.swordTimer = 0;
 		return;
 	}
 

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -116,7 +116,12 @@ void onTick(CBlob@ this)
 	if (this.isInInventory())
 	{
 		//prevent players from insta-slashing when exiting crates
+		knight.state = 0;
 		knight.swordTimer = 0;
+		knight.shieldTimer = 0;
+		knight.slideTime = 0;
+		knight.doubleslash = false;
+		getHUD().SetCursorFrame(0);
 		return;
 	}
 


### PR DESCRIPTION
## Status

**READY**

## Description

If a knight/archer charges a slash/bow before entering a crate, they are able to instantly slash/shoot upon exiting the crate. This used to work by sitting in vehicles but that was fixed ages ago, so I don't see why this shouldn't be fixed too.

Please don't say this is a mechanic since most people don't know about it, and the people who do most likely never use it.

## Steps to Test or Reproduce

1. Hold a crate
2. Charge a slash/bow
3. Press 'E' to enter the crate
4. Before exiting the crate, hold left mouse button
5. Exit the crate
6. Release left mouse button to slash/shoot
