### PR TITLE
[Improvement] Ability to fall through ladders + ladder footstep sounds

### DIFF
--- a/Entities/Common/Scripts/DetectLadder.as
+++ b/Entities/Common/Scripts/DetectLadder.as
@@ -9,6 +9,8 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
+	const bool fallThrough = !this.wasOnLadder() && this.isKeyPressed(key_down);
+
 	ShapeVars@ vars = this.getShape().getVars();
 	vars.onladder = false;
 
@@ -22,7 +24,7 @@ void onTick(CBlob@ this)
 			CBlob@ overlap = overlapping[i];
 			//printf("overlap "  + overlap.getName() );
 
-			if (overlap.isLadder() && !overlap.isAttachedTo(this))
+			if (overlap.isLadder() && !overlap.isAttachedTo(this) && !fallThrough)
 			{
 				vars.onladder = true;
 				return;

--- a/Entities/Common/Scripts/DetectLadder.as
+++ b/Entities/Common/Scripts/DetectLadder.as
@@ -2,14 +2,14 @@
 
 void onInit(CBlob@ this)
 {
-	this.getCurrentScript().tickFrequency = 5; // opt
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().runFlags |= Script::tick_not_onground;
 }
 
 void onTick(CBlob@ this)
 {
-	const bool fallThrough = !this.wasOnLadder() && this.isKeyPressed(key_down);
+	const bool pressingKey = this.isKeyPressed(key_up) || this.isKeyPressed(key_down);
+	const bool climbLadder = this.isOnLadder() || (!this.wasOnLadder() && pressingKey);
 
 	ShapeVars@ vars = this.getShape().getVars();
 	vars.onladder = false;
@@ -24,7 +24,7 @@ void onTick(CBlob@ this)
 			CBlob@ overlap = overlapping[i];
 			//printf("overlap "  + overlap.getName() );
 
-			if (overlap.isLadder() && !overlap.isAttachedTo(this) && !fallThrough)
+			if (overlap.isLadder() && !overlap.isAttachedTo(this) && climbLadder)
 			{
 				vars.onladder = true;
 				return;


### PR DESCRIPTION
## Status

**READY**

## Description

This adds the ability for players to fall through ladders by holding S before colliding with ladders. If they let go of S while colliding with a ladder, they will climb the ladder like usual. Pressing S while climbing the ladder won’t make the player fall through it until they stop colliding with the ladder.

The only issue I see with this is that players wanting to immediately climb down ladders will most likely fall through them. They would need to not press S until they have collided with the ladder, then they can climb down without falling through.

Even with this issue, I believe the benefits this will bring to movement will outweigh the issues it may cause.

I added footstep sounds when climbing ladders to make it clearer if you are actually climbing the ladder.

I also increased the tick rate from 5 to 30 to make ladders catch you more often. I'm not sure if this will impact performance at all. I don't even know why it was even reduced in the first place...

## Steps to Test or Reproduce

- Fall through a ladder while not holding W or S (you should fall through the ladder)
- Fall through a ladder while holding W or S (you should begin climbing the ladder)
- Let go of W or S while climbing a ladder (you should stay on the ladder)