### PR TITLE
New players drop hearts when killed by new players

### DIFF
--- a/Entities/Items/Heart/DropHeartOnDeath.as
+++ b/Entities/Items/Heart/DropHeartOnDeath.as
@@ -3,23 +3,23 @@
 
 #define SERVER_ONLY
 
+const u32 NEW_AGE = 14;
+
 const f32 probability = 1.0f; //between 0 and 1
 
 void dropHeart(CBlob@ this)
 {
-	// newb handicap - dont drop hearts from newbs
-	if (this.getPlayer() != null)
-	{
-		if (Time_DaysSince(this.getPlayer().getRegistrationTime()) <= 14)
-			return;
-	}
-
 	if (!this.hasTag("dropped heart")) //double check
 	{
 		CPlayer@ killer = this.getPlayerOfRecentDamage();
 		CPlayer@ myplayer = this.getDamageOwnerPlayer();
 
-		if (killer is null || ((myplayer !is null) && killer.getUsername() == myplayer.getUsername())) { return; }
+		if (killer is null || myplayer is null || killer.getUsername() == myplayer.getUsername()) { return; }
+
+		// newb handicap - dont drop hearts from newbs
+		bool newVictim = Time_DaysSince(myplayer.getRegistrationTime()) <= NEW_AGE;
+		bool newKiller = Time_DaysSince(killer.getRegistrationTime()) <= NEW_AGE;
+		if (newVictim && !newKiller) { return; }
 
 		this.Tag("dropped heart");
 


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #523

- New player kills new player (heart is dropped)
- New player kills old player (heart is dropped)
- Old player kills new player (heart isn't dropped)
- Old player kills old player  (heart is dropped)

## Steps to Test or Reproduce

I tested by overriding the `newVictim` and `newKiller` bools in code to replicate the scenarios above