### PR TITLE
Fluid interaction between boats

### DIFF
--- a/Entities/Vehicles/Boats/Dinghy.cfg
+++ b/Entities/Vehicles/Boats/Dinghy.cfg
@@ -115,6 +115,7 @@ $name                                      = dinghy
 										 VehicleConvert.as;
 										 SinkOnLowHealth.as;
 										# RunOverPeople.as;
+										FakeBoatCollision.as;
 										 BoatCommon.as;   # put last for rowing sounds
 										 IsFlammable.as;
 										 RandomExitVelocity.as;

--- a/Entities/Vehicles/Common/FakeBoatCollision.as
+++ b/Entities/Vehicles/Common/FakeBoatCollision.as
@@ -41,17 +41,13 @@ void onTick(CBlob@ this)
 	//	}
 	//}
 
-	if (vellen < 0.2f)
-	{
-		return;
-	}
 
 	CBlob@[] blobsInRadius;
 	this.getMap().getBlobsInRadius(pos, this.getRadius() + buffer, @blobsInRadius);
 	for (uint i = 0; i < blobsInRadius.length; i++)
 	{
 		CBlob @blob = blobsInRadius[i];
-		if (blob !is this && vellen > blob.getShape().vellen && blob.hasTag("fake boat collision"))
+		if (blob !is this && vellen > blob.getShape().vellen && blob.hasTag("fake boat collision") && blob.getTeamNum() != this.getTeamNum())
 		{
 			Vec2f other_tl, other_br;
 			CShape@ other_shape = blob.getShape();


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Current interaction between boats, known as collison aren't good or fluid. With this update I offer you new solution:
team boats do not collide with each other, sailing will be much more easier.
team boats collide with enemy boats, thats good thing right? of course it is

oh right needed add FakeBoatCollision.as to dinghy.cfg. dinghy is boat.

## Steps to Test or Reproduce
do I really need write that you should use boats in water not on land?

![boats](https://user-images.githubusercontent.com/18226874/57503329-fa15e580-72ef-11e9-84ac-2e5bc5b172f9.png)

