### PR TITLE
[modified] killing yourself no longer reduces additional coins for TeamKilling.

### DIFF
--- a/Rules/CTF/Scripts/CTF_Trading.as
+++ b/Rules/CTF/Scripts/CTF_Trading.as
@@ -102,7 +102,7 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customData)
 			{
 				killer.server_setCoins(killer.getCoins() + coinsOnKillAdd);
 			}
-			else if (killer.getTeamNum() == victim.getTeamNum())
+			else if (killer !is victim && killer.getTeamNum() == victim.getTeamNum())
 			{
 				killer.server_setCoins(killer.getCoins() - coinsOnTKLose);
 			}


### PR DESCRIPTION
## Status

- **READY**

## Description
This PR resolves the issue stated in #605.
You no longer lose additional coins (for TK) after killing yourself.
## Steps to Test or Reproduce

- Host a server or runlocalhost.
- get some coins (!coins).
- Kill yourself with a keg.
- You only lose coins for dying, no additional 50 coins for teamkilling.
