### PR TITLE
Coins for healing teammates

### DIFF
--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -39,6 +39,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 					theBlob.add_f32("heal amount", theBlob.getHealth() - oldHealth);
 				}
 
+				//give coins for healing teammate
+				if (this.exists("healer"))
+				{
+					CPlayer@ player = theBlob.getPlayer();
+					u16 healerID = this.get_u16("healer");
+					CPlayer@ healer = getPlayerByNetworkId(healerID);
+
+					bool healerHealed = healer is player;
+					bool sameTeam = healer.getTeamNum() == player.getTeamNum();
+					if (healer !is null && !healerHealed && sameTeam)
+					{
+						int coins = this.getName() == "heart" ? 5 : 10;
+						healer.server_setCoins(healer.getCoins() + coins);
+					}
+				}
+
 				theBlob.Sync("heal amount", true);
 			}
 
@@ -66,6 +82,8 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	{
 		Heal(attached, this);
 	}
+
+	this.set_u16("healer", attached.getPlayer().getNetworkID());
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
@@ -74,5 +92,7 @@ void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 	{
 		Heal(detached, this);
 	}
+
+	this.set_u16("healer", detached.getPlayer().getNetworkID());
 }
 


### PR DESCRIPTION
## Status

**READY**

## Description

5 coins for healing a teammate with a heart and 10 coins for anything else

Picking up a teammate's food while on full health and then later healing yourself won't give the person coins

Resolves #629 

## Steps to Test or Reproduce

Get a teammate to heal themselves using food you once held
