### PR TITLE
Drill yields all materials when mining tiles/blobs

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -290,6 +290,10 @@ void onTick(CBlob@ this)
 								{
 									for (uint i = 0; i < 2; i++)
 									{
+										//tile destroyed last hit
+										if (map.getTile(hi.hitpos).type != tile)
+											break;
+
 										map.server_DestroyTile(hi.hitpos, 1.0f, this);
 										Material::fromTile(holder, tile, 1.0f);
 									}

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -273,8 +273,7 @@ void onTick(CBlob@ this)
 
 									this.server_Hit(hi.blob, hi.hitpos, attackVel, attack_dam, Hitters::drill);
 
-									// Yield half
-									Material::fromBlob(holder, hi.blob, attack_dam * 0.5f);
+									Material::fromBlob(holder, hi.blob, attack_dam);
 								}
 
 								hitsomething = true;
@@ -289,10 +288,11 @@ void onTick(CBlob@ this)
 
 								if (getNet().isServer())
 								{
-									map.server_DestroyTile(hi.hitpos, 1.0f, this);
-									map.server_DestroyTile(hi.hitpos, 1.0f, this);
-
-									Material::fromTile(holder, tile, 1.0f);
+									for (uint i = 0; i < 2; i++)
+									{
+										map.server_DestroyTile(hi.hitpos, 1.0f, this);
+										Material::fromTile(holder, tile, 1.0f);
+									}
 								}
 
 								if (getNet().isClient())

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -238,7 +238,7 @@ void onTick(CBlob@ this)
 				if (map !is null)
 				{
 					HitInfo@[] hitInfos;
-					if (map.getHitInfosFromArc((this.getPosition() - attackVel), -attackVel.Angle(), 30, distance, this, false, @hitInfos))
+					if (map.getHitInfosFromArc((this.getPosition() - attackVel), -attackVel.Angle(), 30, distance, this, true, @hitInfos))
 					{
 						bool hit_ground = false;
 						for (uint i = 0; i < hitInfos.length; i++)
@@ -291,7 +291,7 @@ void onTick(CBlob@ this)
 									for (uint i = 0; i < 2; i++)
 									{
 										//tile destroyed last hit
-										if (map.getTile(hi.hitpos).type != tile)
+										if (!map.isTileSolid(map.getTile(hi.hitpos)))
 											break;
 
 										map.server_DestroyTile(hi.hitpos, 1.0f, this);


### PR DESCRIPTION
## Status

**READY**

## Description

Increased from 50% to 100%
Fixed raycast issue in preparation for engine-side fix

Resolves #618 

## Steps to Test or Reproduce

Drill tiles/blobs for their materials and compare to the amount given when mining by hand
