### PR TITLE
Item isnt picked up when 'c' is released if one was picked up by clicking

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -90,6 +90,7 @@ void onTick(CBlob@ this)
 				if (this.isKeyJustPressed(key_action1))	// pickup
 				{
 					server_Pickup(this, this, closest);
+					this.set_bool("release click", false);
 				}
 			}
 


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #636 

## Steps to Test or Reproduce

1. Hold 'c'
2. Click to pick up a highlighted item
3. Release 'c' (another item should not be picked up)