### PR TITLE
Food null error fix

### DIFF
--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -78,23 +78,33 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	}
 }
 
+
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
-	if (getNet().isServer())
+	if(this is null || attached is null) {return;}
+
+	if (isServer())
 	{
 		Heal(attached, this);
 	}
+
+	CPlayer@ p = attached.getPlayer();
+	if(p is null){return;}
 
 	this.set_u16("healer", attached.getPlayer().getNetworkID());
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 {
-	if (getNet().isServer())
+	if(this is null || detached is null) {return;}
+
+	if (isServer())
 	{
 		Heal(detached, this);
 	}
+	
+	CPlayer@ p = detached.getPlayer();
+	if(p is null){return;}
 
-	this.set_u16("healer", detached.getPlayer().getNetworkID());
+	this.set_u16("healer", p.getNetworkID());
 }
-

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -91,7 +91,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	CPlayer@ p = attached.getPlayer();
 	if(p is null){return;}
 
-	this.set_u16("healer", attached.getPlayer().getNetworkID());
+	this.set_u16("healer", p.getNetworkID());
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)


### PR DESCRIPTION
Caused by CPlayer being invalid if the blob is holding food and dies.

I've added extra null checks just in case as well

Thanks @bunniewormy for giving logs