### PR TITLE
Disabled Quarry's

### DIFF
--- a/Entities/Industry/Building/Building.as
+++ b/Entities/Industry/Building/Building.as
@@ -11,7 +11,7 @@ const bool builder_only = false;
 
 void onInit(CBlob@ this)
 {
-	AddIconToken("$stonequarry$", "../Mods/Entities/Industry/CTFShops/Quarry/Quarry.png", Vec2f(40, 24), 4);
+	//AddIconToken("$stonequarry$", "../Mods/Entities/Industry/CTFShops/Quarry/Quarry.png", Vec2f(40, 24), 4);
 	this.set_TileType("background tile", CMap::tile_wood_back);
 	//this.getSprite().getConsts().accurateLighting = true;
 
@@ -23,7 +23,7 @@ void onInit(CBlob@ this)
 
 	// SHOP
 	this.set_Vec2f("shop offset", Vec2f(0, 0));
-	this.set_Vec2f("shop menu size", Vec2f(4, 5));
+	this.set_Vec2f("shop menu size", Vec2f(4, 4));
 	this.set_string("shop description", "Construct");
 	this.set_u8("shop icon", 12);
 	this.Tag(SHOP_AUTOCLOSE);
@@ -66,12 +66,12 @@ void onInit(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_gold", "Gold", CTFCosts::tunnel_gold);
 	}
 
-	{
+	/*{
 		ShopItem@ s = addShopItem(this, "Stone Quarry", "$stonequarry$", "quarry", Descriptions::quarry);
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::quarry_stone);
 		AddRequirement(s.requirements, "blob", "mat_gold", "Gold", CTFCosts::quarry_gold);
 		AddRequirement(s.requirements, "no more", "quarry", "Stone Quarry", CTFCosts::quarry_count);
-	}
+	}*/
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)


### PR DESCRIPTION
Contains a disabled quarry
Why:
Currently quarry's are disliked by the community, and are extremely OP. (Even after all its balance changes)
It grants you access to basically unlimited stone, which is good and all, but leads to more stalemate matches, and easy coin farms.

To fix this, we should disable the quarry for a few days, and see if matches improve, see if we have shorter or longer matches, people approve of this or dislike this and so on.

If this however does not provide good results, we should look into nerfing it more, like having it require coins instead of wood for example.

