### PR TITLE
[WIP] Changes max stack on mats

### DIFF
--- a/Entities/Materials/Construction/MaterialGold.as
+++ b/Entities/Materials/Construction/MaterialGold.as
@@ -1,7 +1,7 @@
 
 void onInit(CBlob@ this)
 {
-  this.maxQuantity = 50;
+  this.maxQuantity = 100;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Materials/Construction/MaterialGold.cfg
+++ b/Entities/Materials/Construction/MaterialGold.cfg
@@ -71,4 +71,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1

--- a/Entities/Materials/Construction/MaterialStone.as
+++ b/Entities/Materials/Construction/MaterialStone.as
@@ -6,7 +6,7 @@ void onInit(CBlob@ this)
     this.set_u8('decay step', 14);
   }
 
-  this.maxQuantity = 250;
+  this.maxQuantity = 500;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Materials/Construction/MaterialStone.cfg
+++ b/Entities/Materials/Construction/MaterialStone.cfg
@@ -72,4 +72,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1

--- a/Entities/Materials/Construction/MaterialWood.as
+++ b/Entities/Materials/Construction/MaterialWood.as
@@ -6,7 +6,7 @@ void onInit(CBlob@ this)
     this.set_u8('decay step', 18);
   }
 
-  this.maxQuantity = 250;
+  this.maxQuantity = 500;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Materials/Construction/MaterialWood.cfg
+++ b/Entities/Materials/Construction/MaterialWood.cfg
@@ -72,4 +72,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1


### PR DESCRIPTION
Fixes issue #682 
Gold max stack is 100
Stone max stack is 500
Wood max stack is 500
Each take up 1 slot and one blob instead of being 2 blobs merged together, fix's this issue without having to change any engine inventory code
