### PR TITLE
Reset's SetGridMenuSize on joining any gamemode

### DIFF
--- a/Rules/CommonScripts/KAG.as
+++ b/Rules/CommonScripts/KAG.as
@@ -26,6 +26,9 @@ void onInit(CRules@ this)
 	driver.AddShader("hq2x", 1.0f);
 	driver.SetShader("hq2x", true);
 
+	//reset var if you came from another gamemode that edits it
+	SetGridMenusSize(24,2.0f,32);
+
 	//also restart stuff
 	onRestart(this);
 }


### PR DESCRIPTION
It isnt used anywhere engine side, easier to reset the values instead of doing this engine side so modders can see the default values.

Currently there's a problem with this when a user goes to join goldenguy's r/place mod, then join a vanilla or other modded server. This fixes it for vanilla gamemodes by resetting the base value back to normal, and also allow's modders to see what those values are.