### PR TITLE
CSprite null checks for blob

### DIFF
--- a/Entities/Characters/Builder/BuilderAnim.as
+++ b/Entities/Characters/Builder/BuilderAnim.as
@@ -222,14 +222,7 @@ const string cursorTexture = "Entities/Characters/Sprites/TileCursor.png";
 void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
-	if (!blob.isMyPlayer())
-	{
-		return;
-	}
-	if (getHUD().hasButtons())
-	{
-		return;
-	}
+	if (blob is null || !blob.isMyPlayer() || getHud().hasButtons()) return;
 
 	// draw tile cursor
 

--- a/Entities/Characters/Builder/BuilderAnim.as
+++ b/Entities/Characters/Builder/BuilderAnim.as
@@ -222,7 +222,7 @@ const string cursorTexture = "Entities/Characters/Sprites/TileCursor.png";
 void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
-	if (blob is null || !blob.isMyPlayer() || getHud().hasButtons()) return;
+	if (blob is null || !blob.isMyPlayer() || getHUD().hasButtons()) return;
 
 	// draw tile cursor
 

--- a/Entities/Characters/Scripts/DazzleAnimation.as
+++ b/Entities/Characters/Scripts/DazzleAnimation.as
@@ -19,8 +19,10 @@ void onInit(CSprite@ this)
 void onTick(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
-
 	CSpriteLayer@ stars = this.getSpriteLayer("dazzle stars");
+
+	if (blob is null) return;
+	
 	if (blob.hasTag("dazzled") && !blob.hasTag("dead"))
 	{
 		stars.SetVisible(true);

--- a/Entities/Characters/Scripts/RunnerFootSteps.as
+++ b/Entities/Characters/Scripts/RunnerFootSteps.as
@@ -13,6 +13,7 @@ void onInit(CSprite@ this)
 void onTick(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
+	if (blob is null) return;
 
 	const bool left		= blob.isKeyPressed(key_left);
 	const bool right	= blob.isKeyPressed(key_right);

--- a/Entities/Characters/Scripts/RunnerHead.as
+++ b/Entities/Characters/Scripts/RunnerHead.as
@@ -216,10 +216,9 @@ void onGib(CSprite@ this)
 void onTick(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
-
 	ScriptData@ script = this.getCurrentScript();
-	if (script is null)
-		return;
+	
+	if (script is null || blob is null) return;
 
 	if (blob.getShape().isStatic())
 	{

--- a/Entities/Common/FireScripts/FireAnim.as
+++ b/Entities/Common/FireScripts/FireAnim.as
@@ -31,8 +31,12 @@ void onInit(CSprite@ this)
 void onTick(CSprite@ this)
 {
 	this.getCurrentScript().tickFrequency = 24; // opt
+
 	CBlob@ blob = this.getBlob();
 	CSpriteLayer@ fire = this.getSpriteLayer("fire_animation_large");
+
+	if (blob is null) return;
+
 	if (fire !is null)
 	{
 		//if we're burning


### PR DESCRIPTION
Sometimes blob can be null while CSprite onTick is called. This just add's a null check where needed.

Unsure how this happens, but it does. Somebody sent me their logs with it happening.