### PR TITLE
Optmized FallOnNoSupport

### DIFF
--- a/Entities/Structures/Common/FallOnNoSupport.as
+++ b/Entities/Structures/Common/FallOnNoSupport.as
@@ -24,9 +24,14 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	}
 }
 
+void onDetach( CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint )
+{
+	this.set_u16("timePlaced",getGameTime());
+}
+
 void onBlobCollapse(CBlob@ this)
 {
-	if (!isServer() || getGameTime() < 60 || this.hasTag("fallen")) return;
+	if (!isServer() || getGameTime() - this.get_u16("timePlaced") < 3 || getGameTime() < 60 || this.hasTag("fallen")) return;
 
 	CShape@ shape = this.getShape();
 	if (shape.getCurrentSupport() < 0.001f)

--- a/Entities/Structures/Common/FallOnNoSupport.as
+++ b/Entities/Structures/Common/FallOnNoSupport.as
@@ -11,7 +11,7 @@ void onInit(CBlob@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point)
 {
-	if (getNet().isServer() && solid && !this.getShape().isStatic() && !this.isAttached())
+	if (isServer() && solid && !this.getShape().isStatic() && !this.isAttached())
 	{
 		if (this.getOldVelocity().y < 1.0f && !this.hasTag("can settle"))
 		{
@@ -24,10 +24,9 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	}
 }
 
-// TODO: make this on an event
-void onTick(CBlob@ this)
+void onBlobCollapse(CBlob@ this)
 {
-	if (!getNet().isServer() || getGameTime() < 60 || this.hasTag("fallen")) return;
+	if (!isServer() || getGameTime() < 60 || this.hasTag("fallen")) return;
 
 	CShape@ shape = this.getShape();
 	if (shape.getCurrentSupport() < 0.001f)


### PR DESCRIPTION
No longer uses onTick. Uses a new engine hook (requires Engine PR) to move it into an Event, saving server performance.

This effects ladders, shops, doors, platforms and mechanisms