### PR TITLE
CTF resupply works properly on nextmap

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -125,7 +125,7 @@ bool canGetSpawnmats(CRules@ this, CPlayer@ p, RulesCore@ core)
 
 	CTFPlayerInfo@ info = cast < CTFPlayerInfo@ > (core.getInfoFromPlayer(p));
 
-	if (gametime > next_items ||)		// timer expired
+	if (gametime > next_items)		// timer expired
 	{
 		info.items_collected = 0; //reset available class items
 		return true;

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -276,11 +276,7 @@ void onRender(CRules@ this)
 	if (b !is null && this.exists(propname))
 	{
 		s32 next_items = this.get_s32(propname);
-		if (getGameTime() < next_items - materials_wait * getTicksASecond() * 2)
-		{
-			this.set_s32(propname, 0); //clear residue
-		}
-		else if (next_items > getGameTime())
+		if (next_items > getGameTime())
 		{
 			string action = (b.getName() == "builder" ? "Go Build" : "Go Fight");
 			if (this.isWarmup())

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -125,8 +125,7 @@ bool canGetSpawnmats(CRules@ this, CPlayer@ p, RulesCore@ core)
 
 	CTFPlayerInfo@ info = cast < CTFPlayerInfo@ > (core.getInfoFromPlayer(p));
 
-	if (gametime > next_items ||		//timer expired
-	        gametime < next_items - materials_wait * getTicksASecond() * 4) //residual prop
+	if (gametime > next_items ||)		// timer expired
 	{
 		info.items_collected = 0; //reset available class items
 		return true;
@@ -200,7 +199,7 @@ void Reset(CRules@ this)
 {
 	//restart everyone's timers
 	for (uint i = 0; i < getPlayersCount(); ++i)
-		SetCTFTimer(this, getPlayer(i), materials_wait_warmup);//this used to be set to 0, but now its not
+		SetCTFTimer(this, getPlayer(i), 0);
 }
 
 void onRestart(CRules@ this)


### PR DESCRIPTION
## Status

**READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Currently, when CTF is nextmapped, if the game has been going on for less than a certain amount of time, the resupply doesn't give mats until the second resupply time.
Additionally, the resupply text doesn't appear at first.

These changes address both of these issues.

## Steps to Test or Reproduce

1. Start CTF
2. Switch to builder
3. Get resupply
4. Nextmap
5. Assert that resupply mats are in your inventory after nextmap and resupply text appears.