### PR TITLE
[fix] Drill screen blur fix

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -430,11 +430,15 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	CPlayer@ player = attached.getPlayer();
 	if (player !is null)
 		this.set_u16("showHeatTo", player.getNetworkID());
+
+	this.getShape().server_SetActive(false); // stops sinking when its attached
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 {
 	this.set_u16("showHeatTo", 0);
+
+	this.getShape().server_SetActive(true);
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ blob)
@@ -474,7 +478,7 @@ void onRender(CSprite@ this)
 		u8 heat = blob.get_u8(heat_prop);
 		f32 percentage = Maths::Min(1.0, f32(heat) / f32(heat_max));
 
-		Vec2f pos = blob.getScreenPos() + Vec2f(-22, 16);
+		Vec2f pos = getDriver().getScreenPosFromWorldPos(holderBlob.getInterpolatedPosition() + (blob.getPosition() - holderBlob.getPosition())) + Vec2f(-22, 16);
 		Vec2f dimension = Vec2f(42, 4);
 		Vec2f bar = Vec2f(pos.x + (dimension.x * percentage), pos.y + dimension.y);
 


### PR DESCRIPTION
After hours of debugging, I figured this is the best way to fix this issue.

Currently, using engine side getInterp on an attached blob will not work correctly, due to the vars.oldpos being out of date, the same as getPosition or just completely wrong. This only happens on dedicated servers.

I have no clue currently why this happens, but for now this is a good solution since its a fairly small feature and I dont feel like its a big enough issue to spent more hours looking into it.

This PR makes it work script side. We use our player (holders) as the interp place, then work out the difference between that player and the blob to get the interp position of the drill.

This fixes issues #712 
