### PR TITLE
Drill changes part2

### DIFF
--- a/Entities/Common/Includes/Requirements.as
+++ b/Entities/Common/Includes/Requirements.as
@@ -69,25 +69,7 @@ string getButtonRequirementsText(CBitStream& inout bs, bool missing)
 			text += "At least " + quantity + " " + friendlyName + " required. \n";
 			text += quantityColor;
 		}
-		else if (requiredType == "limit" && missing)
-		{
-			CRules@ rules = getRules();
-			if (rules is null) { continue; }
 
-			u32 matchTime = rules.get_u32("match_time");
-
-			text += quantityColor;
-			if (rules.isMatchRunning())
-			{
-				text += "Must wait " + (timestamp( (parseInt(friendlyName) - matchTime) / 30)) + "until the drill is available\n";
-			}
-			else
-			{
-				text += "Must wait until the match begins and the time reaches " + (timestamp( (parseInt(friendlyName)) / 30 )) + "to unlock \n";
-			}
-			text += quantityColor;
-
-		}
 	}
 
 	return text;
@@ -213,24 +195,6 @@ bool hasRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &inout bs, C
 				has = false;
 			}
 		}
-		else if (req == "limit")
-		{
-			CRules@ rules = getRules();
-			if (rules is null) { has = false; }
-
-			if (rules.gamemode_name == "CTF")
-			{
-				u32 matchTime = rules.get_u32("match_time");
-
-				f32 timeRequired = parseInt(friendlyName);
-
-				if (!(matchTime > timeRequired))
-				{
-					AddRequirement(missingBs, req, blobName, friendlyName, quantity);
-					has = false;
-				}
-			}
-		}
 	}
 
 	missingBs.ResetBitIndex();
@@ -295,28 +259,4 @@ void server_TakeRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &ino
 void server_TakeRequirements(CInventory@ inv, CBitStream &inout bs)
 {
 	server_TakeRequirements(inv, null, bs);
-}
-
-
-string timestamp(uint s)
-{
-	string ret;
-	int hours = s/60/60;
-	if (hours > 0)
-		ret += hours + getTranslatedString("h ");
-
-	int minutes = s/60%60;
-	if (minutes < 10 && minutes > 0)
-		ret += "0";
-	
-	if (minutes > 0)
-		ret += minutes + getTranslatedString("m ");
-
-	int seconds = s%60;
-	if (seconds < 10)
-		ret += "0";
-
-	ret += seconds + getTranslatedString("s ");
-
-	return ret;
 }

--- a/Entities/Common/Includes/Requirements.as
+++ b/Entities/Common/Includes/Requirements.as
@@ -69,7 +69,25 @@ string getButtonRequirementsText(CBitStream& inout bs, bool missing)
 			text += "At least " + quantity + " " + friendlyName + " required. \n";
 			text += quantityColor;
 		}
+		else if (requiredType == "limit" && missing)
+		{
+			CRules@ rules = getRules();
+			if (rules is null) { continue; }
 
+			u32 matchTime = rules.get_u32("match_time");
+
+			text += quantityColor;
+			if (rules.isMatchRunning())
+			{
+				text += "Must wait " + (timestamp( (parseInt(friendlyName) - matchTime) / 30)) + "until the drill is available\n";
+			}
+			else
+			{
+				text += "Must wait until the match begins and the time reaches " + (timestamp( (parseInt(friendlyName)) / 30 )) + "to unlock \n";
+			}
+			text += quantityColor;
+
+		}
 	}
 
 	return text;
@@ -195,6 +213,24 @@ bool hasRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &inout bs, C
 				has = false;
 			}
 		}
+		else if (req == "limit")
+		{
+			CRules@ rules = getRules();
+			if (rules is null) { has = false; }
+
+			if (rules.gamemode_name == "CTF")
+			{
+				u32 matchTime = rules.get_u32("match_time");
+
+				f32 timeRequired = parseInt(friendlyName);
+
+				if (!(matchTime > timeRequired))
+				{
+					AddRequirement(missingBs, req, blobName, friendlyName, quantity);
+					has = false;
+				}
+			}
+		}
 	}
 
 	missingBs.ResetBitIndex();
@@ -259,4 +295,28 @@ void server_TakeRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &ino
 void server_TakeRequirements(CInventory@ inv, CBitStream &inout bs)
 {
 	server_TakeRequirements(inv, null, bs);
+}
+
+
+string timestamp(uint s)
+{
+	string ret;
+	int hours = s/60/60;
+	if (hours > 0)
+		ret += hours + getTranslatedString("h ");
+
+	int minutes = s/60%60;
+	if (minutes < 10 && minutes > 0)
+		ret += "0";
+	
+	if (minutes > 0)
+		ret += minutes + getTranslatedString("m ");
+
+	int seconds = s%60;
+	if (seconds < 10)
+		ret += "0";
+
+	ret += seconds + getTranslatedString("s ");
+
+	return ret;
 }

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -61,6 +61,7 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Drill", "$drill$", "drill", Descriptions::drill, false);
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::drill_stone);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::drill);
+		AddRequirement(s.requirements, "limit", "drill", "7200‬", CTFCosts::drill);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Saw", "$saw$", "saw", Descriptions::saw, false);

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -1,4 +1,4 @@
-﻿// BuilderShop.as
+// BuilderShop.as
 
 #include "Requirements.as"
 #include "ShopCommon.as"
@@ -61,7 +61,6 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Drill", "$drill$", "drill", Descriptions::drill, false);
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::drill_stone);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::drill);
-		AddRequirement(s.requirements, "limit", "drill", "7200‬", CTFCosts::drill);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Saw", "$saw$", "saw", Descriptions::saw, false);

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -4,6 +4,7 @@
 #include "BuilderHittable.as";
 #include "ParticleSparks.as";
 #include "MaterialCommon.as";
+#include "ShieldCommon.as";
 
 const f32 speed_thresh = 2.4f;
 const f32 speed_hard_thresh = 2.6f;
@@ -176,7 +177,6 @@ void onTick(CBlob@ this)
 	sprite.SetEmitSoundPaused(true);
 	if (this.isAttached())
 	{
-		this.getCurrentScript().runFlags &= ~(Script::tick_not_sleeping);
 		AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
 		CBlob@ holder = point.getOccupied();
 
@@ -296,7 +296,7 @@ void onTick(CBlob@ this)
 										attack_dam += 0.5f;
 									}
 
-									if (b.hasTag("shielded")) // are they shielding? reduce damage!
+									if (b.hasTag("shielded") && blockAttack(b, attackVel, 0.0f)) // are they shielding? reduce damage!
 									{
 										attack_dam /= 2;
 									}
@@ -439,7 +439,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	if (shape !is null)
 	{
 		shape.server_SetActive(false); // stops sinking when its attached
-		shape.SetRotationsAllowed(false); // stops rotation
+		shape.SetRotationsAllowed(true); // stops rotation
 	}
 }
 

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -553,14 +553,4 @@ void AimAtMouse(CBlob@ this, CBlob@ holder)
 	if (!this.isFacingLeft()) mouseAngle += 180;
 
 	this.setAngleDegrees(-mouseAngle);
-
-	AttachmentPoint@ hands = this.getAttachments().getAttachmentPointByName("PICKUP");
-
-	aim_vec *= 1.0f;
-
-	if (hands !is null)
-	{
-		hands.offset.x = 0 + (aim_vec.x * 2 * (this.isFacingLeft() ? 1.0f : -1.0f)); // if blob config has offset other than 0,0 there is a desync on client, dont know why
-		hands.offset.y = -(aim_vec.y * (1.0f < 0 ? 1.0f : 1.0f));
-	}
 }

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -552,5 +552,6 @@ void AimAtMouse(CBlob@ this, CBlob@ holder)
 
 	if (!this.isFacingLeft()) mouseAngle += 180;
 
-	this.setAngleDegrees(-mouseAngle);
+	//this.setAngleDegrees(-mouseAngle); // weirdly locks it self to 90/260 degrees if mouse goes to a certain angle
+	this.getShape().SetAngleDegrees(-mouseAngle);
 }

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -442,7 +442,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	{
 		this.setPosition(attached.getPosition()); // required to stop the first tick to be out of position
 
-		shape.server_SetActive(false); // stops sinking when its attached
+		shape.SetGravityScale(0); // this stops the shape from 'falling' when its attached to something, (helps the heat bar from looking bad above 30 fps)
 	}
 }
 
@@ -453,7 +453,7 @@ void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 	CShape@ shape = this.getShape();
 	if (shape !is null)
 	{
-		shape.server_SetActive(true);
+		shape.SetGravityScale(1);
 	}
 }
 

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -59,9 +59,12 @@ void onInit(CBlob@ this)
 	}*/
 
 	this.set_u32("hittime", 0);
-	//this.Tag("place45");
+	this.Tag("place norotate"); // required to prevent drill from locking in place (blame builder code :kag_angry:)
+	
+	//this.Tag("place45"); // old 45 degree angle lock
 	//this.set_s8("place45 distance", 1);
 	//this.Tag("place45 perp");
+
 	this.set_u8(heat_prop, 0);
 	this.set_u16("showHeatTo", 0);
 	this.set_u16("harvestWoodDoorCap", 4);
@@ -183,7 +186,6 @@ void onTick(CBlob@ this)
 		if (holder is null) return;
 
 		AimAtMouse(this, holder); // aim at our mouse pos
-
 
 		// cool faster if holder is moving
 		if (heat > 0 && holder.getShape().vellen > 0.01f && getGameTime() % 3 == 0)
@@ -438,8 +440,9 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	CShape@ shape = this.getShape();
 	if (shape !is null)
 	{
+		this.setPosition(attached.getPosition()); // required to stop the first tick to be out of position
+
 		shape.server_SetActive(false); // stops sinking when its attached
-		shape.SetRotationsAllowed(true); // stops rotation
 	}
 }
 
@@ -451,7 +454,6 @@ void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 	if (shape !is null)
 	{
 		shape.server_SetActive(true);
-		shape.SetRotationsAllowed(true);
 	}
 }
 
@@ -552,6 +554,5 @@ void AimAtMouse(CBlob@ this, CBlob@ holder)
 
 	if (!this.isFacingLeft()) mouseAngle += 180;
 
-	//this.setAngleDegrees(-mouseAngle); // weirdly locks it self to 90/260 degrees if mouse goes to a certain angle
-	this.getShape().SetAngleDegrees(-mouseAngle);
+	this.setAngleDegrees(-mouseAngle); // set aim pos
 }


### PR DESCRIPTION
**What has changed**
- Drill UI is no longer blurry when moving apart of #757 
- Drill can no longer be used until the game has lasted more then 4 mins
- Drill now freely follow's your mouse, instead of being locked at 45 degrees near your mouse
- Drills deal half damage to shielded people

**Why did you change x**
Drills can no longer be used until game reaches 4 mins to help prevent flag rush early game, which most people agree on is not fun what so ever.

Drill follows your mouse instead of being at a 45 degree angle near your mouse because it use to lead to issues where you would dig a tile, but would do no damamge. This lets you move it freely, and just feels much better.

Drill now deals half damage to shielded people. This might change if people would rather have something different happen when you shield a drill.


**I dont like x**
Please talk about it down below, at very least the UI fix will be put in, but the rest are up to you guys to talk about. 