### PR TITLE
Pickup menu

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -47,11 +47,18 @@ void onInit(CBlob@ this)
 		menu.add_entry(PickupWheelMenuEntry("Stone", "$mat_stone$", array<string>(1, "mat_stone"), Vec2f(0, -6.0f)));
 		menu.add_entry(PickupWheelMenuEntry("Wood", "$mat_wood$", array<string>(1, "mat_wood"), Vec2f(0, -6.0f)));
 		menu.add_entry(PickupWheelMenuEntry("Drill", "$drill$", array<string>(1, "drill"), Vec2f(-16.0f, 0.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Saw", "$saw$", array<string>(1, "saw"), Vec2f(-16.0f, -16.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Trampoline", "$trampoline$", array<string>(1, "trampoline"), Vec2f(-16.0f, -8.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Boulder", "$boulder$", array<string>(1, "boulder")));
+		menu.add_entry(PickupWheelMenuEntry("Sponge", "$sponge$", array<string>(1, "sponge"), Vec2f(0, 8.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Seed", "$seed$", array<string>(1, "seed"), Vec2f(8.0f, 8.0f)));
 
 		// misc
+		menu.add_entry(PickupWheelMenuEntry("Log", "$log$", array<string>(1, "log")));
 		const string[] food_options = {"food", "heart", "fishy", "grain", "steak", "egg", "flowers"};
 		menu.add_entry(PickupWheelMenuEntry("Food", "$food$", food_options));
 		menu.add_entry(PickupWheelMenuEntry("Ballista Ammo", "$mat_bolts$", array<string>(1, "mat_bolts")));
+		menu.add_entry(PickupWheelMenuEntry("Crate", "$crate$", array<string>(1, "crate"), Vec2f(-16.0f, 0)));
 	}
 
 }

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -29,24 +29,24 @@ void onInit(CBlob@ this)
 		menu.add_entry(PickupWheelMenuEntry("Keg", "$keg$", array<string>(1, "keg")));
 
 		const string[] bomb_options = {"bomb", "mat_bombs"};
-		menu.add_entry(PickupWheelMenuEntry("Bomb", "$mat_bombs$", bomb_options));
+		menu.add_entry(PickupWheelMenuEntry("Bomb", "$mat_bombs$", bomb_options, Vec2f(0, -8.0f)));
 
 		const string[] waterbomb_options = {"waterbomb", "mat_waterbombs"};
-		menu.add_entry(PickupWheelMenuEntry("Water Bomb", "$mat_waterbombs$", waterbomb_options));
+		menu.add_entry(PickupWheelMenuEntry("Water Bomb", "$mat_waterbombs$", waterbomb_options, Vec2f(0, -6.0f)));
 
 		menu.add_entry(PickupWheelMenuEntry("Mine", "$mine$", array<string>(1, "mine")));
 
 		// archer stuff
-		menu.add_entry(PickupWheelMenuEntry("Arrows", "$mat_arrows$", array<string>(1, "mat_arrows")));
-		menu.add_entry(PickupWheelMenuEntry("Water Arrows", "$mat_waterarrows$", array<string>(1, "mat_waterarrows")));
-		menu.add_entry(PickupWheelMenuEntry("Fire Arrows", "$mat_firearrows$", array<string>(1, "mat_firearrows")));
+		menu.add_entry(PickupWheelMenuEntry("Arrows", "$mat_arrows$", array<string>(1, "mat_arrows"), Vec2f(0, -8.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Water Arrows", "$mat_waterarrows$", array<string>(1, "mat_waterarrows"), Vec2f(0, 2.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Fire Arrows", "$mat_firearrows$", array<string>(1, "mat_firearrows"), Vec2f(0, -6.0f)));
 		menu.add_entry(PickupWheelMenuEntry("Bomb Arrows", "$mat_bombarrows$", array<string>(1, "mat_bombarrows")));
 
 		// builder stuff
-		menu.add_entry(PickupWheelMenuEntry("Gold", "$mat_gold$", array<string>(1, "mat_gold")));
-		menu.add_entry(PickupWheelMenuEntry("Stone", "$mat_stone$", array<string>(1, "mat_stone")));
-		menu.add_entry(PickupWheelMenuEntry("Wood", "$mat_wood$", array<string>(1, "mat_wood")));
-		menu.add_entry(PickupWheelMenuEntry("Drill", "$drill$", array<string>(1, "drill")));
+		menu.add_entry(PickupWheelMenuEntry("Gold", "$mat_gold$", array<string>(1, "mat_gold"), Vec2f(0, -6.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Stone", "$mat_stone$", array<string>(1, "mat_stone"), Vec2f(0, -6.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Wood", "$mat_wood$", array<string>(1, "mat_wood"), Vec2f(0, -6.0f)));
+		menu.add_entry(PickupWheelMenuEntry("Drill", "$drill$", array<string>(1, "drill"), Vec2f(-16.0f, 0.0f)));
 
 		// misc
 		const string[] food_options = {"food", "heart", "fishy", "grain", "steak", "egg", "flowers"};

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -75,7 +75,7 @@ void onTick(CBlob@ this)
 	CControls@ controls = getControls();
 
 	// drop / pickup / throw
-	if (controls.isKeyPressed(KEY_LSHIFT))
+	if (controls.isKeyPressed(KEY_LSHIFT) || controls.isKeyPressed(KEY_RSHIFT))
 	{
 		WheelMenu@ menu = get_wheel_menu("pickup");
 		if (this.isKeyPressed(key_pickup) && menu !is get_active_wheel_menu())
@@ -162,7 +162,7 @@ void onTick(CBlob@ this)
 	else
 	{
 		WheelMenu@ menu = get_wheel_menu("pickup");
-		if ((this.isKeyJustReleased(key_pickup) || controls.isKeyJustReleased(KEY_LSHIFT))
+		if ((this.isKeyJustReleased(key_pickup) || controls.isKeyJustReleased(KEY_LSHIFT) || controls.isKeyJustReleased(KEY_RSHIFT))
 			&&  get_active_wheel_menu() is menu)
 		{
 			PickupWheelMenuEntry@ selected = cast<PickupWheelMenuEntry>(menu.get_selected());

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -71,7 +71,7 @@ void onTick(CBlob@ this)
 	if (controls.isKeyPressed(KEY_LSHIFT))
 	{
 		WheelMenu@ menu = get_wheel_menu("pickup");
-		if (this.isKeyJustPressed(key_pickup))
+		if (this.isKeyPressed(key_pickup) && menu !is get_active_wheel_menu())
 		{
 			set_active_wheel_menu(@menu);
 

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -5,8 +5,6 @@
 #include "ThrowCommon.as"
 #include "WheelMenuCommon.as"
 
-string[] pickup_items = {"keg", "bomb", "mat_gold", "mat_wood", "mat_stone"};
-
 const u32 PICKUP_ERASE_TICKS = 80;
 
 void onInit(CBlob@ this)
@@ -595,6 +593,13 @@ void onRender(CSprite@ this)
 					hover = true;
 					Vec2f dimensions;
 					GUI::SetFont("menu");
+
+					GUI::DrawCircle(
+						getDriver().getScreenPosFromWorldPos(b.getPosition()),
+						32.0f,
+						SColor(255, 255, 255, 255)
+					);
+
 					GUI::GetTextDimensions(b.getInventoryName(), dimensions);
 					GUI::DrawText(getTranslatedString(b.getInventoryName()), getDriver().getScreenPosFromWorldPos(b.getPosition() - Vec2f(0, -b.getHeight() / 2)) - Vec2f(dimensions.x / 2, -8.0f), color_white);
 

--- a/Entities/Common/GUI/WheelMenuCommon.as
+++ b/Entities/Common/GUI/WheelMenuCommon.as
@@ -90,30 +90,33 @@ class IconWheelMenuEntry : WheelMenuEntry
 	}
 };
 
-class IconTokenWheelMenuEntry : WheelMenuEntry
+class PickupWheelMenuEntry : WheelMenuEntry
 {
 	// Visual parameters
 	string icon_name;
 	float scale;
 	bool disabled;
+	string[] options;
 
-	IconTokenWheelMenuEntry(const string&in p_name)
+	PickupWheelMenuEntry(const string&in p_name, const string&in p_icon_name, string[] p_options)
 	{
 		super(p_name);
+		visible_name = p_name;
+		icon_name = p_icon_name;
+		options = p_options;
 		scale = 1.0f;
 		disabled = false;
 	}
 
 	void render() override
 	{
-		string icon = icon_name;
 		if (disabled)
 		{
-			icon = "$DISABLED$";
+			return;
 		}
 
 		GUI::DrawIconByName(
-			icon,
+			icon_name,
 			position,
 			scale
 		);

--- a/Entities/Common/GUI/WheelMenuCommon.as
+++ b/Entities/Common/GUI/WheelMenuCommon.as
@@ -115,6 +115,14 @@ class PickupWheelMenuEntry : WheelMenuEntry
 			return;
 		}
 
+		GUI::DrawIcon(
+			"InteractionIconsBackground.png",
+			0,
+			Vec2f(32, 32),
+			position - Vec2f(32, 32),
+			1.5f
+		);
+
 		GUI::DrawIconByName(
 			icon_name,
 			position,

--- a/Entities/Common/GUI/WheelMenuCommon.as
+++ b/Entities/Common/GUI/WheelMenuCommon.as
@@ -97,8 +97,9 @@ class PickupWheelMenuEntry : WheelMenuEntry
 	float scale;
 	bool disabled;
 	string[] options;
+	Vec2f offset;
 
-	PickupWheelMenuEntry(const string&in p_name, const string&in p_icon_name, string[] p_options)
+	PickupWheelMenuEntry(const string&in p_name, const string&in p_icon_name, string[] p_options, Vec2f p_offset = Vec2f(0, 0))
 	{
 		super(p_name);
 		visible_name = p_name;
@@ -106,6 +107,7 @@ class PickupWheelMenuEntry : WheelMenuEntry
 		options = p_options;
 		scale = 1.0f;
 		disabled = false;
+		offset = p_offset;
 	}
 
 	void render() override
@@ -125,7 +127,7 @@ class PickupWheelMenuEntry : WheelMenuEntry
 
 		GUI::DrawIconByName(
 			icon_name,
-			position,
+			position + offset,
 			scale
 		);
 	}

--- a/Entities/Common/GUI/WheelMenuCommon.as
+++ b/Entities/Common/GUI/WheelMenuCommon.as
@@ -90,6 +90,36 @@ class IconWheelMenuEntry : WheelMenuEntry
 	}
 };
 
+class IconTokenWheelMenuEntry : WheelMenuEntry
+{
+	// Visual parameters
+	string icon_name;
+	float scale;
+	bool disabled;
+
+	IconTokenWheelMenuEntry(const string&in p_name)
+	{
+		super(p_name);
+		scale = 1.0f;
+		disabled = false;
+	}
+
+	void render() override
+	{
+		string icon = icon_name;
+		if (disabled)
+		{
+			icon = "$DISABLED$";
+		}
+
+		GUI::DrawIconByName(
+			icon,
+			position,
+			scale
+		);
+	}
+};
+
 class WheelMenu
 {
 	WheelMenuEntry@[] entries;


### PR DESCRIPTION
PR to implement: https://github.com/transhumandesign/kag-base/issues/613

This implements a wheel menu for picking up nearby items, that will be less ambiguous. The PR also includes fixes for all pickup that should hopefully make it less frustrating.

A few things need to be finalized:
~~* What items should be on the wheel.~~
~~* If any items on the wheel should be combined (bomb/water bomb, special arrows, etc.)~~
~~* Where on the wheel the items should be~~

Bugfixes:
~~* Doesn't quite work on dedicated servers because of not syncing shift button~~
~~* funkyness with press c then shift~~
