### PR TITLE
Block binding UI

### DIFF
--- a/Entities/Characters/Builder/Builder.cfg
+++ b/Entities/Characters/Builder/Builder.cfg
@@ -223,6 +223,7 @@ $name                                             = builder
                                                     BuilderAutoPickup.as;
                                                     BlobPlacement.as;
                                                     BlockPlacement.as;
+                                                    BuilderInventory.as;
                                                     IsFlammable.as;
                                                     EmoteHotkeys.as;
                                                     FleshHitEffects.as;

--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -216,7 +216,11 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 		{
 			BuildBlock@ block = @blocks[PAGE][i];
 
-			if (!canBuild(blob, @blocks[PAGE], i)) return;
+			if (!canBuild(blob, @blocks[PAGE], i))
+			{
+				Sound::Play("/NoAmmo");
+				return;
+			}
 
 			// put carried in inventory thing first
 			if (isServer)
@@ -343,21 +347,37 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 	}
 }
 
-void onTick(CBlob@ blob)
-{
-	CControls@ controls = getControls();
-	if (controls.isKeyPressed(KEY_LSHIFT))
-	{
-		if (controls.isKeyPressed(KEY_KEY_0))
-		{
-			blob.SendCommand(Builder::make_block + 9);
-		}
+u8[] blockBinds = {
+	0, 1, 2, 3, 4, 5, 6, 7, 8
+};
 
+void onInit(CBlob@ this)
+{
+	ConfigFile@ cfg = openBlockBindingsConfig();
+
+	for (uint i = 0; i < 9; i++)
+	{
+		blockBinds[i] = read_block(cfg, "block_" + (i + 1), blockBinds[i]);
+	}
+
+}
+
+void onTick(CBlob@ this)
+{
+	if (this.hasTag("reload blocks"))
+	{
+		this.Untag("reload blocks");
+		onInit(this);
+	}
+
+	CControls@ controls = getControls();
+	if (controls.isKeyPressed(KEY_LSHIFT) || controls.isKeyPressed(KEY_RSHIFT))
+	{
 		for (uint i = 0; i < 9; i++)
 		{
-			if (controls.isKeyPressed(KEY_KEY_1 + i))
+			if (controls.isKeyJustPressed(KEY_KEY_1 + i))
 			{
-				blob.SendCommand(Builder::make_block + i);
+				this.SendCommand(Builder::make_block + blockBinds[i]);
 			}
 		}
 

--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -343,6 +343,27 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 	}
 }
 
+void onTick(CBlob@ blob)
+{
+	CControls@ controls = getControls();
+	if (controls.isKeyPressed(KEY_LSHIFT))
+	{
+		if (controls.isKeyPressed(KEY_KEY_0))
+		{
+			blob.SendCommand(Builder::make_block + 9);
+		}
+
+		for (uint i = 0; i < 9; i++)
+		{
+			if (controls.isKeyPressed(KEY_KEY_1 + i))
+			{
+				blob.SendCommand(Builder::make_block + i);
+			}
+		}
+
+	}
+}
+
 void onRender(CSprite@ this)
 {
 	CMap@ map = getMap();

--- a/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -6,13 +6,13 @@
 
 // To add a new page;
 
-// 1) initialize a new BuildBlock array, 
+// 1) initialize a new BuildBlock array,
 // example:
 // BuildBlock[] my_page;
 // blocks.push_back(my_page);
 
-// 2) 
-// Add a new string to PAGE_NAME in 
+// 2)
+// Add a new string to PAGE_NAME in
 // BuilderInventory.as
 // this will be what you see in the caption
 // box below the menu
@@ -35,13 +35,21 @@
 const string blocks_property = "blocks";
 const string inventory_offset = "inventory offset";
 
-void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
+void addCommonBuilderBlocks(BuildBlock[][]@ blocks, const string&in gamemode_override = "")
 {
 	InitCosts();
 	CRules@ rules = getRules();
-	const bool CTF = rules.gamemode_name == "CTF";
-	const bool TTH = rules.gamemode_name == "TTH";
-	const bool SBX = rules.gamemode_name == "Sandbox";
+
+	string gamemode = rules.gamemode_name;
+	if (gamemode_override != "")
+	{
+		gamemode = gamemode_override;
+
+	}
+
+	const bool CTF = gamemode == "CTF";
+	const bool TTH = gamemode == "TTH";
+	const bool SBX = gamemode == "Sandbox";
 
 	BuildBlock[] page_0;
 	blocks.push_back(page_0);
@@ -267,4 +275,23 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 			blocks[3].push_back(b);
 		}
 	}
+}
+
+ConfigFile@ openBlockBindingsConfig()
+{
+	ConfigFile cfg = ConfigFile();
+	if (!cfg.loadFile("../Cache/BlockBindings.cfg"))
+	{
+		// write EmoteBinding.cfg to Cache
+		cfg.saveFile("BlockBindings.cfg");
+
+	}
+
+	return cfg;
+}
+
+u8 read_block(ConfigFile@ cfg, string name, u8 default_value)
+{
+	u8 read_val = cfg.read_u8(name, default_value);
+	return read_val;
 }

--- a/Entities/Common/Emotes/EmoteHotkeys.as
+++ b/Entities/Common/Emotes/EmoteHotkeys.as
@@ -73,6 +73,12 @@ void onTick(CBlob@ this)
 	}
 
 	CControls@ controls = getControls();
+	if (controls.isKeyPressed(KEY_LSHIFT) || controls.isKeyPressed(KEY_RSHIFT))
+	{
+		return;
+	}
+
+
 	if (controls.isKeyJustPressed(KEY_KEY_1))
 	{
 		set_emote(this, emote_1);

--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -45,6 +45,8 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
+													BuilderBinderMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;

--- a/Rules/Challenge/gamemode.cfg
+++ b/Rules/Challenge/gamemode.cfg
@@ -34,6 +34,8 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
+                                         EmoteBinderMenu.as;
+                                         BuilderBinderMenu.as;
 										 TauntMenu.as;
 										 BindingsMenu.as;
 										 ColoredNameToggle.as;

--- a/Rules/CommonScripts/BindingsMenu.as
+++ b/Rules/CommonScripts/BindingsMenu.as
@@ -1,7 +1,6 @@
-#include "EmoteBinderMenu.as";
-
 void onMainMenuCreated(CRules@ this, CContextMenu@ menu)
 {
 	CContextMenu@ bindingsMenu = Menu::addContextMenu(menu, getTranslatedString("Bindings"));
 	Menu::addContextItem(bindingsMenu, getTranslatedString("Bind Emotes"), "EmoteBinderMenu.as", "void NewEmotesMenu()");
+	Menu::addContextItem(bindingsMenu, getTranslatedString("Bind Builder Blocks"), "BuilderBinderMenu.as", "void NewBuilderMenu()");
 }

--- a/Rules/CommonScripts/BuilderBinderMenu.as
+++ b/Rules/CommonScripts/BuilderBinderMenu.as
@@ -1,7 +1,7 @@
 #include "CommonBuilderBlocks.as"
 
 const u8 MENU_WIDTH = 9;
-const u8 MENU_HEIGHT  = 5;
+const u8 MENU_HEIGHT  = 4;
 const string SELECTED_PROP = "selected block: ";
 
 const string BUILD_CMD = "builder binder command";
@@ -96,22 +96,13 @@ void ShowBuilderMenu(CPlayer@ player)
 			read_block(cfg, "block_6", 5),
 			read_block(cfg, "block_7", 6),
 			read_block(cfg, "block_8", 7),
-			read_block(cfg, "block_9", 8),
-			read_block(cfg, "block_10", 9),
-			read_block(cfg, "block_11", 10),
-			read_block(cfg, "block_12", 0),
-			read_block(cfg, "block_13", 1),
-			read_block(cfg, "block_14", 2),
-			read_block(cfg, "block_15", 3),
-			read_block(cfg, "block_16", 4),
-			read_block(cfg, "block_17", 5),
-			read_block(cfg, "block_18", 6)
+			read_block(cfg, "block_9", 8)
 		};
 
 		string propname = SELECTED_PROP + player.getUsername();
 		u8 selected = rules.get_u8(propname);
 
-		for (int i = 0; i < 18; i++)
+		for (int i = 0; i < 9; i++)
 		{
 			CBitStream params;
 			params.write_u8(SELECT_KEYBIND);
@@ -169,11 +160,11 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 
 		string key = "block_" + (selected + 1);
 
-		//get emote bindings cfg file
+		//get block bindings cfg file
 		ConfigFile@ cfg = openBlockBindingsConfig();
 
-		//bind emote
-		cfg.add_u8(key, block);
+		//bind block
+		cfg.add_string(key, "" + block);
 		cfg.saveFile("BlockBindings.cfg");
 
 		//update keybinds in menu
@@ -190,5 +181,11 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 	else if (subcmd == CLOSE_MENU)
 	{
 		getHUD().ClearMenus(true);
+	}
+
+	CBlob@ blob = caller.getBlob();
+	if (blob !is null)
+	{
+		blob.Tag("reload blocks");
 	}
 }

--- a/Rules/CommonScripts/BuilderBinderMenu.as
+++ b/Rules/CommonScripts/BuilderBinderMenu.as
@@ -1,0 +1,194 @@
+#include "CommonBuilderBlocks.as"
+
+const u8 MENU_WIDTH = 9;
+const u8 MENU_HEIGHT  = 5;
+const string SELECTED_PROP = "selected block: ";
+
+const string BUILD_CMD = "builder binder command";
+
+enum BUILD_SUBCMD {
+	BIND_BLOCK,
+	SELECT_KEYBIND,
+	CLOSE_MENU,
+	BUILD_SUBCMD_COUNT
+};
+
+BuildBlock[][] blocks;
+
+void onInit(CRules@ this)
+{
+	this.addCommandID(BUILD_CMD);
+	addCommonBuilderBlocks(blocks, "CTF");
+
+}
+
+void NewBuilderMenu()
+{
+	CPlayer@ player = getLocalPlayer();
+	if (player !is null && player.isMyPlayer())
+	{
+		//select first keybind to begin with
+		string propname = SELECTED_PROP + player.getUsername();
+		getRules().set_u8(propname, 0);
+		ShowBuilderMenu(player);
+	}
+
+}
+
+void ShowBuilderMenu(CPlayer@ player)
+{
+	//hide main menu and other gui
+	Menu::CloseAllMenus();
+	getHUD().ClearMenus(true);
+
+	CRules@ rules = getRules();
+	Vec2f center = getDriver().getScreenCenterPos();
+	string description = getTranslatedString("Builder Block Hotkey Binder");
+
+	CGridMenu@ menu = CreateGridMenu(center, null, Vec2f(MENU_WIDTH, MENU_HEIGHT), description);
+	if (menu !is null)
+	{
+		menu.deleteAfterClick = false;
+
+		CBitStream params;
+
+		params.write_u8(CLOSE_MENU);
+		params.write_string(player.getUsername());
+
+		menu.AddKeyCommand(KEY_ESCAPE, rules.getCommandID(BUILD_CMD), params);
+		menu.SetDefaultCommand(rules.getCommandID(BUILD_CMD), params);
+
+		for (uint i = 0; i < blocks[0].length; i++)
+		{
+			BuildBlock@ b = blocks[0][i];
+			string block_desc = getTranslatedString(b.description);
+
+			CBitStream params;
+			params.write_u8(BIND_BLOCK);
+			params.write_string(player.getUsername());
+			params.write_u8(i);
+
+			CGridButton@ button = menu.AddButton(b.icon, block_desc, rules.getCommandID(BUILD_CMD), Vec2f(1, 1), params);
+
+		}
+
+		if (menu.getButtonsCount() % MENU_WIDTH != 0)
+		{
+			menu.FillUpRow();
+		}
+
+		CGridButton@ separator = menu.AddTextButton(getTranslatedString("Select a keybind below, then select the block you want"), Vec2f(MENU_WIDTH, 1));
+		if (separator !is null)
+		{
+			separator.clickable = false;
+			separator.SetEnabled(false);
+		}
+
+		//get current block keybinds
+		ConfigFile@ cfg = openBlockBindingsConfig();
+
+		array<u8> blockBinds = {
+			read_block(cfg, "block_1", 0),
+			read_block(cfg, "block_2", 1),
+			read_block(cfg, "block_3", 2),
+			read_block(cfg, "block_4", 3),
+			read_block(cfg, "block_5", 4),
+			read_block(cfg, "block_6", 5),
+			read_block(cfg, "block_7", 6),
+			read_block(cfg, "block_8", 7),
+			read_block(cfg, "block_9", 8),
+			read_block(cfg, "block_10", 9),
+			read_block(cfg, "block_11", 10),
+			read_block(cfg, "block_12", 0),
+			read_block(cfg, "block_13", 1),
+			read_block(cfg, "block_14", 2),
+			read_block(cfg, "block_15", 3),
+			read_block(cfg, "block_16", 4),
+			read_block(cfg, "block_17", 5),
+			read_block(cfg, "block_18", 6)
+		};
+
+		string propname = SELECTED_PROP + player.getUsername();
+		u8 selected = rules.get_u8(propname);
+
+		for (int i = 0; i < 18; i++)
+		{
+			CBitStream params;
+			params.write_u8(SELECT_KEYBIND);
+			params.write_string(player.getUsername());
+			params.write_u8(i);
+
+			BuildBlock@ b = blocks[0][blockBinds[i]];
+
+			CGridButton@ button = menu.AddButton(b.icon, getTranslatedString("Select key {KEY_NUM}").replace("{KEY_NUM}", (i + 1) + ""), rules.getCommandID(BUILD_CMD), Vec2f(1, 1), params);
+			button.selectOneOnClick = true;
+
+			if (selected == i)
+			{
+				button.SetSelected(1);
+			}
+		}
+
+	}
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
+{
+	if (cmd != this.getCommandID(BUILD_CMD))
+	{
+		return;
+	}
+
+	string name;
+	u8 subcmd;
+
+	if(!params.saferead_u8(subcmd)) return;
+	if(!params.saferead_string(name)) return;
+
+	CPlayer@ caller = getPlayerByUsername(name);
+
+	//check validity so far
+	if (caller is null || !caller.isMyPlayer() || subcmd >= BUILD_SUBCMD_COUNT)
+	{
+		return;
+	}
+
+	if (subcmd == BIND_BLOCK)
+	{
+		string propname = SELECTED_PROP + caller.getUsername();
+		u8 selected = this.get_u8(propname);
+
+		//must select keybind first
+		if (selected == -1)
+		{
+			return;
+		}
+
+		u8 block;
+		if(!params.saferead_u8(block)) return;
+
+		string key = "block_" + (selected + 1);
+
+		//get emote bindings cfg file
+		ConfigFile@ cfg = openBlockBindingsConfig();
+
+		//bind emote
+		cfg.add_u8(key, block);
+		cfg.saveFile("BlockBindings.cfg");
+
+		//update keybinds in menu
+		ShowBuilderMenu(caller);
+	}
+	else if (subcmd == SELECT_KEYBIND)
+	{
+		u8 block;
+		if(!params.saferead_u8(block)) return;
+
+		string propname = SELECTED_PROP + caller.getUsername();
+		this.set_u8(propname, block);
+	}
+	else if (subcmd == CLOSE_MENU)
+	{
+		getHUD().ClearMenus(true);
+	}
+}

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -45,6 +45,8 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
+													BuilderBinderMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;

--- a/Rules/SmallCTF/gamemode.cfg
+++ b/Rules/SmallCTF/gamemode.cfg
@@ -46,6 +46,8 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
+													BuilderBinderMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;

--- a/Rules/TDM/gamemode.cfg
+++ b/Rules/TDM/gamemode.cfg
@@ -44,6 +44,8 @@ scripts                                           = KAG.as;
 													MarkPlayers.as;
 													WheelMenu.as;
 													EmoteMenu.as;
+													EmoteBinderMenu.as;
+													BuilderBinderMenu.as;
 													TauntMenu.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -43,6 +43,8 @@
                                          MarkPlayers.as;
 										 WheelMenu.as;
 										 EmoteMenu.as;
+                                         EmoteBinderMenu.as;
+                                         BuilderBinderMenu.as;
 										 TauntMenu.as;
 										 BindingsMenu.as;
 										 ColoredNameToggle.as;


### PR DESCRIPTION
Implements: https://github.com/transhumandesign/kag-base/issues/622

* Allows builders to switch blocks using `shift + (1-9)` key.
* Adds a binding menu like the emotes binding menu but for blocks.

![image](https://user-images.githubusercontent.com/2775830/74487098-46481480-4e84-11ea-9bea-10512c489f27.png)
