### PR TITLE
End Game Map Votes

### DIFF
--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -25,7 +25,7 @@ scripts                                           = KAG.as;
 													Report.as;
 													ReportRender.as;
 													TimeToEnd.as;
-													RestartAfterShortPostGame.as;
+													PostGameMapVotes.as; #RestartAfterShortPostGame.as;
 													FanfareOnWin.as;
 													PlayerCamera.as;
 													DefaultScoreboard.as;

--- a/Rules/CTF/mapcycle.cfg
+++ b/Rules/CTF/mapcycle.cfg
@@ -43,8 +43,8 @@ mapcycle =
 			Maps/CTF/Skinney_Crypt.png;
 			Maps/CTF/Skinney_Descent.png;
 			Maps/CTF/Skinney_Glitch.png;
-			Maps/CTF/Skinney_Typhoon.png
-			Maps/CTF/Skinney_Bluff.png
+			Maps/CTF/Skinney_Typhoon.png;
+			Maps/CTF/Skinney_Bluff.png;
 				#Biurza
 			Maps/CTF/Biurza_Rule_Lawyering.png;	
 				#Redshadow6

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -60,6 +60,11 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 		CPlayer@ bot = AddBot("Henry"); //when there are multiple "Henry" bots, they'll be differentiated by a number (i.e. Henry2)
 		return true;
 	}
+	else if (text_in == "!endgame" && player.isMod())
+	{
+		this.SetCurrentState(GAME_OVER); //go to map vote
+		return true;
+	}
 	else if (text_in == "!debug" && player.isMod())
 	{
 		// print all blobs

--- a/Rules/CommonScripts/DefaultVotes.as
+++ b/Rules/CommonScripts/DefaultVotes.as
@@ -214,7 +214,8 @@ class VoteNextmapFunctor : VoteFunctor
 		{
 			if (getNet().isServer())
 			{
-				LoadNextMap();
+				CRules@ rules = getRules();
+				rules.SetCurrentState(GAME_OVER);
 			}
 		}
 		else

--- a/Rules/CommonScripts/DefaultVotes.as
+++ b/Rules/CommonScripts/DefaultVotes.as
@@ -214,8 +214,7 @@ class VoteNextmapFunctor : VoteFunctor
 		{
 			if (getNet().isServer())
 			{
-				CRules@ rules = getRules();
-				rules.SetCurrentState(GAME_OVER);
+				getRules().SetCurrentState(GAME_OVER);
 			}
 		}
 		else

--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -57,15 +57,15 @@ class MapVotesMenu
 
 		button1.RefreshButton( MenuSize.x, ButtonSize);
 		MenuSize.x += ButtonSize.x+30;
-		MenuSize.y = (ButtonSize.y+100) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
+		MenuSize.y = (ButtonSize.y+95) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
 
 		button2.RefreshRandomButton( MenuSize.x, ButtonSize);
 		MenuSize.x += ButtonSize.x+30;
-		MenuSize.y = (ButtonSize.y+100) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
+		MenuSize.y = (ButtonSize.y+95) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
 		
 		button3.RefreshButton( MenuSize.x, ButtonSize);
 		MenuSize.x += ButtonSize.x+30;
-		MenuSize.y = (ButtonSize.y+100) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
+		MenuSize.y = (ButtonSize.y+95) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
 	}
 
 	void Update(CControls@ controls, u8 &out NewSelectedNum)
@@ -121,7 +121,7 @@ class MapVotesMenu
 			button1.State = button1.State != ButtonStates::Selected ? ButtonStates::None : ButtonStates::Selected; 
 			button2.State = button2.State != ButtonStates::Selected ? ButtonStates::None : ButtonStates::Selected;
 			button3.State = button3.State != ButtonStates::Selected ? ButtonStates::None : ButtonStates::Selected;
-		}		
+		}
 	}
 
 	void RenderGUI()
@@ -151,26 +151,24 @@ class MapVotesMenu
 					case 3:	winner = button3.shortname; break;
 					default: winner = "A Random Map"; break;
 				}
-			 	GUI::DrawText("Map Vote Has Ended.. Loading : "+winner, TL_Position+Vec2f(20,8), color_white);
+			 	GUI::DrawText("Map Voting Has Ended.. Loading: "+ winner, TL_Position+Vec2f(22,10), color_white);
 			}
 			else
 			{
-			 	GUI::DrawText("Map Vote Ends In : "+ VoteTimeLeft +" Secs", TL_Position+Vec2f(20,8), color_white);
-			}			
+			 	GUI::DrawText("Map Voting Ends In: "+ VoteTimeLeft, TL_Position+Vec2f(22,10), color_white);
+			}
 
-			const Vec2f NameMid1 = button1.Pos+Vec2f((button1.Size.x/2)-2, button1.Size.y + 36);
-			const Vec2f NameMid2 = button2.Pos+Vec2f((button2.Size.x/2)-2, button2.Size.y + 36);
-			const Vec2f NameMid3 = button3.Pos+Vec2f((button3.Size.x/2)-2, button3.Size.y + 36);
-			
-			//GUI::SetFont("AveriaSerif-Bold_20");
-			GUI::DrawTextCentered(""+ Votes1.length(), NameMid1, color_white);
-			GUI::DrawTextCentered(""+ Votes2.length(), NameMid2, color_white);
-			GUI::DrawTextCentered(""+ Votes3.length(), NameMid3, color_white);
-			
-			GUI::SetFont("menu");
 			button1.RenderGUI();
 			button2.RenderGUI();
 			button3.RenderGUI();
+
+			const Vec2f CountMid1 = button1.Pos+Vec2f((button1.Size.x/2)-2, button1.Size.y + 38);
+			const Vec2f CountMid2 = button2.Pos+Vec2f((button2.Size.x/2)-2, button2.Size.y + 38);
+			const Vec2f CountMid3 = button3.Pos+Vec2f((button3.Size.x/2)-2, button3.Size.y + 38);
+			GUI::SetFont("AveriaSerif-Bold_22");
+			GUI::DrawTextCentered(""+Votes1.length(), CountMid1, color_white);
+			GUI::DrawTextCentered(""+Votes2.length(), CountMid2, color_white);
+			GUI::DrawTextCentered(""+Votes3.length(), CountMid3, color_white);
 		}
 	}
 	void RenderRaw()
@@ -221,7 +219,7 @@ class MapVoteButton
 
 	void RefreshButton( u16 MenuWidth, Vec2f &out ButtonSize)
 	{		
-		State = 0;	
+		State = 0;
 		if(Texture::exists(shortname))
 		{
 			ImageData@ edit = Texture::data(shortname);
@@ -281,11 +279,11 @@ class MapVoteButton
 		const Vec2f Padding_outline = Vec2f(8,8);
 		const Vec2f TL_outline = Pos-Padding_outline;
 		const Vec2f BR_outline = Pos+Size+Padding_outline;
-		const Vec2f Padding_window = Vec2f(4,4);		
+		const Vec2f Padding_window = Vec2f(4,4);
 		const Vec2f TL_window = Pos-Padding_window;
 		const Vec2f BR_window = Pos+Size+Padding_window;
 		GUI::DrawPane(TL_outline, BR_outline, col);
-		GUI::DrawWindow(TL_window, BR_window);	
+		GUI::DrawWindow(TL_window, BR_window);
 //
 		const Vec2f NameMid = Pos+Vec2f((Size.x/2)-2, Size.y+16);
 		GUI::DrawTextCentered(displayname, NameMid, color_white);
@@ -418,16 +416,16 @@ void CreateMapTexture(string shortname, string filename)
 
 				SColor editcol = colors::minimap_open;
 				
-				if ( type(PixelCol) == 0  )      			
+				if ( type(PixelCol) == 0  )
 				{
 					editcol = colors::minimap_open;
 				}
-				else if ( type(PixelCol) == 1  )       			
-    			{				
+				else if ( type(PixelCol) == 1  )
+    			{
     				// Foreground	
 					editcol = colors::minimap_solid;
 					
-					if ((type(PixelCol_u) != 1 ) || 
+					if ((type(PixelCol_u) != 1 ) ||
 					    (type(PixelCol_l) != 1 ) ||
 						(type(PixelCol_d) != 1 ) ||
 					    (type(PixelCol_r) != 1 ) ) 
@@ -448,21 +446,21 @@ void CreateMapTexture(string shortname, string filename)
 					{
 						editcol = colors::minimap_gold_edge;
 					}
-				}										
+				}
 				else if (type(PixelCol) == 3)
 				{
 					//Background
 					editcol = colors::minimap_back;
 
 					//Edge
-					if(( type(PixelCol_u) == 0 ) || 
+					if(( type(PixelCol_u) == 0 ) ||
 					   ( type(PixelCol_l) == 0 ) ||
-				 	   ( type(PixelCol_d) == 0 ) || 
+				 	   ( type(PixelCol_d) == 0 ) ||
 					   ( type(PixelCol_r) == 0 )  )
 					{
 						editcol = colors::minimap_back_edge;
 					}
-				}							
+				}
 				else 
 				{
 					editcol = PixelCol_u;
@@ -475,8 +473,8 @@ void CreateMapTexture(string shortname, string filename)
 					editcol = editcol.getInterpolated( colors::minimap_water, 0.5f);
 				}
 
-				edit[offset] = editcol;	
-			}				
+				edit[offset] = editcol;
+			}
 
 			if(!Texture::update(shortname, edit))
 			{

--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -37,9 +37,8 @@ class MapVotesMenu
 		VotedCount1 = VotedCount2 = VotedCount3 = 0;
 		Selected = -1;
 
-		_random.Reset(getGameTime());
 		//Refresh button names, textures and size
-		RandomizeButtonNames();
+		//RandomizeButtonNames();
 		RefreshButtons();
 
 		//Refresh menu pos/size after getting button sizes
@@ -54,111 +53,6 @@ class MapVotesMenu
 		button1.Pos.y = button2.Pos.y = button3.Pos.y = TL_Position.y+40;
 
 		isSetup = true;
-	}
-
-	void RandomizeButtonNames()
-	{
-		string mapcycle = sv_mapcycle;
-		if (mapcycle == "")
-		{
-			string mode_name = sv_gamemode;
-			if (mode_name == "Team Deathmatch") mode_name = "TDM";
-			mapcycle =  "Rules/"+mode_name+"/mapcycle.cfg";
-		}
-
-		ConfigFile cfg;	
-		bool loaded = false;
-		if (CFileMatcher(mapcycle).getFirst() == mapcycle && cfg.loadFile(mapcycle)) loaded = true;
-		else if (cfg.loadFile(mapcycle)) loaded = true;
-		if (!loaded) { warn( mapcycle+ " not found!"); return; }
-
-		string[] map_names;
-		if (cfg.readIntoArray_string(map_names, "mapcycle"))
-		{
-			int arrayleng = map_names.length();	
-
-			if (arrayleng <= 1)
-			{
-				LoadNextMap(); // we don't care about voting, get me out
-			}
-			else if (arrayleng == 2)
-			{
-				button1.filename = map_names[0];
-				button3.filename = map_names[1];
-			}
-			else // more than 2 maps left
-			{
-				//remove the current map first
-				const string currentMap = getMap().getMapName();	
-				const int currentMapNum = map_names.find(currentMap);
-				if (currentMapNum != -1)
-				{
-					map_names.removeAt(currentMapNum);
-				}
-
-				//check again
-				arrayleng = map_names.length();
-				if (arrayleng == 2)
-				{
-					button1.filename = map_names[0];
-					button3.filename = map_names[1];
-				}
-				else if (button1.filename != currentMap) // remove the old button 1
-				{
-					const int oldMap1Num = map_names.find(button1.filename);
-					if (oldMap1Num != -1)
-					{
-						map_names.removeAt(oldMap1Num);
-					}
-				}
-				else if (button3.filename != currentMap) // remove the old button 3
-				{
-					const int oldMap3Num = map_names.find(button3.filename);
-					if (oldMap3Num != -1)
-					{
-						map_names.removeAt(oldMap3Num);
-					}
-				}				
-				
-				// random based on what's left
-				arrayleng = map_names.length();
-				if (arrayleng > 2)
-				{
-					button1.filename = map_names[_random.NextRanged(arrayleng)];
-					map_names.removeAt(map_names.find(button1.filename));
-					button3.filename = map_names[_random.NextRanged(arrayleng)];
-				}
-				else if (arrayleng == 2)
-				{
-					button1.filename = map_names[0];
-					button3.filename = map_names[1];
-				}
-				else //if (arrayleng <= 1)
-				{
-					LoadNextMap(); // we don't care about voting, get me out
-				}
-			}			
-
-			//test to see if the map filename is inside parentheses and cut it out
-			//incase someone wants to add map votes to a gamemode that loads maps via scripts, eg. Challenge/mapcycle.cfg				 
-			string temptest = button1.filename.substr(button1.filename.length() - 1, button1.filename.length() - 1);
-			if (temptest == ")")
-			{
-				string[] name = button1.filename.split(' (');
-				string mapName = name[name.length() - 1];
-				button1.filename = mapName.substr(0,mapName.length() - 1);
-			}
-			temptest = button3.filename.substr(button3.filename.length() - 1, button3.filename.length() - 1);
-			if (temptest == ")")
-			{
-				string[] name = button1.filename.split(' (');
-				string mapName = name[name.length() - 1];
-				button3.filename = mapName.substr(0,mapName.length() - 1);
-			}
-
-			button1.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(button1.filename));
-			button3.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(button3.filename));
-		}
 	}
 
 	void RefreshButtons()

--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -1,0 +1,610 @@
+//-- Written by Monkey_Feats 22/2/2020 --//
+#include "LoaderColors.as";
+
+class MapVotesMenu
+{
+	bool isSetup;
+
+	MapVoteButton@ button1;
+	MapVoteButton@ button2;
+	MapVoteButton@ button3;
+
+	int Selected;
+	int VotedCount1;
+	int VotedCount2;
+	int VotedCount3;
+	u8 MostVoted;
+
+	Vec2f TL_Position;
+	Vec2f BR_Pos;
+	Vec2f MenuSize;
+
+	s32 VoteTimeLeft;
+
+	MapVotesMenu()
+	{
+		isSetup = false;
+
+		@button1 = MapVoteButton(false);
+		@button2 = MapVoteButton(true);
+		@button3 = MapVoteButton(false);
+	}
+
+	void Refresh()
+	{
+		VotedCount1 = VotedCount2 = VotedCount3 = 0;
+		Selected = -1;
+
+		//Refresh button names, textures and size
+		RandomizeButtonNames();
+		RefreshButtons();
+
+		//Refresh menu pos/size after getting button sizes
+		Vec2f screenCenter = getDriver().getScreenDimensions()/2;
+		TL_Position = screenCenter-(MenuSize/2);
+		BR_Pos = screenCenter+(MenuSize/2);
+
+		//Reposition buttons to menu
+		button1.Pos.x += TL_Position.x;
+		button2.Pos.x += TL_Position.x;
+		button3.Pos.x += TL_Position.x;
+
+		button1.Pos.y = button2.Pos.y = button3.Pos.y = TL_Position.y+40;
+
+		isSetup = true;
+	}
+
+	void RandomizeButtonNames()
+	{
+		string mode_name = getRules().gamemode_name;
+		if (mode_name == "Team Deathmatch") mode_name = "TDM";
+		string mapcycle =  "Rules/"+mode_name+"/mapcycle.cfg";
+
+		ConfigFile cfg;	
+		bool loaded = false;
+		if (CFileMatcher(mapcycle).getFirst() == mapcycle && cfg.loadFile(mapcycle)) loaded = true;
+		else if (cfg.loadFile(mapcycle)) loaded = true;
+		if (!loaded) { warn( mapcycle+ " not found!"); return; }
+
+		string[] map_names;
+		if (cfg.readIntoArray_string(map_names, "mapcycle"))
+		{
+			const u16 arrayleng = map_names.length();
+			const string currentMap = getMap().getMapName();
+			Random _random(getGameTime());
+
+			// randomize button 1 map name
+			int count = 0;
+			bool done = false;
+			while (!done)
+			{				
+				count++;
+				string temp = map_names[_random.NextRanged(arrayleng)];
+				
+				//test to see if the map filename is inside parentheses and cut it out
+				//incase someone wants to add map votes to a gamemode that loads maps via scripts, eg. Challenge/mapcycle.cfg				 
+				string temptest = temp.substr(temp.length() - 1,temp.length() - 1);
+				if (temptest == ")")
+				{
+					string[] name = temp.split(' (');
+					string mapName = name[name.length() - 1];
+					temp = mapName.substr(0,mapName.length() - 1);
+				}
+
+ 				//lots of cases to be sure we get the most randomization and exit safely
+				if (arrayleng == 2)
+				{
+					button1.filename = map_names[0];
+					button1.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(button1.filename));
+					done = true;
+				}
+				else if (temp != button1.filename && temp != button3.filename && temp != currentMap)
+				{
+					button1.filename = temp;
+					button1.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(temp));
+					done = true;
+				}
+				else if (temp != button1.filename && temp != button3.filename)
+				{
+					button1.filename = temp;
+					button1.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(temp));
+					done = true;
+				}
+				else if (temp != button3.filename)
+				{
+					button1.filename = temp;
+					button1.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(temp));
+					done = true;
+				}
+				else if (count == arrayleng) //safely exit the loop, pure random, probably only 1 map in the pool
+				{
+					button1.filename = map_names[_random.NextRanged(arrayleng)];
+					button1.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(button1.filename));
+					done = true;
+				}
+			}
+
+			//randomize button 3 map name
+			count = 0;
+			done = false; 
+			while (!done)
+			{
+				count++;
+				string temp = map_names[_random.NextRanged(arrayleng)];
+
+				string temptest = temp.substr(temp.length() - 1,temp.length() - 1);
+				if (temptest == ")")
+				{
+					string[] name = temp.split(' (');
+					string mapName = name[name.length() - 1];
+					temp = mapName.substr(0,mapName.length() - 1);
+				}
+
+				if (arrayleng == 2)
+				{
+					button3.filename = map_names[1];
+					button3.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(button3.filename));
+					done = true;
+				}
+				else if (temp != button3.filename && temp != button1.filename && temp != currentMap)
+				{
+					button3.filename = temp;
+					button3.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(temp));
+					done = true;
+				}
+				else if (temp != button3.filename && temp != button1.filename)
+				{
+					button3.filename = temp;
+					button3.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(temp));
+					done = true;
+				}
+				else if (temp != button1.filename)
+				{
+					button3.filename = temp;
+					button3.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(temp));
+					done = true;
+				}
+				else if (count == arrayleng)
+				{
+					button3.filename = map_names[_random.NextRanged(arrayleng)];
+					button3.shortname = getFilenameWithoutExtension(getFilenameWithoutPath(button3.filename));
+					done = true;
+				}
+			}
+		}
+	}
+
+	void RefreshButtons()
+	{	
+		Vec2f ButtonSize;
+		MenuSize.x = 30;
+		MenuSize.y = 200;
+
+		button1.RefreshButton( MenuSize.x, ButtonSize);
+		MenuSize.x += ButtonSize.x+30;
+		MenuSize.y = (ButtonSize.y+100) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
+
+		button2.RefreshRandomButton( MenuSize.x, ButtonSize);
+		MenuSize.x += ButtonSize.x+30;
+		MenuSize.y = (ButtonSize.y+100) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
+		
+		button3.RefreshButton( MenuSize.x, ButtonSize);
+		MenuSize.x += ButtonSize.x+30;
+		MenuSize.y = (ButtonSize.y+100) > MenuSize.y ? ButtonSize.y+95 : MenuSize.y;
+	}
+
+	void Update(CControls@ controls, u8 &out SelectedNum)
+	{
+		Vec2f mousepos = controls.getMouseScreenPos();
+		const bool mousePressed = controls.isKeyPressed(KEY_LBUTTON);
+		const bool mouseJustReleased = controls.isKeyJustReleased(KEY_LBUTTON);
+
+		int hoverednum;
+		if (button1.isHovered(mousepos))
+		{
+			if (button1.State == 3) return; 
+			else button1.State = 1; 
+			
+			if (mousePressed) button1.State = 2;
+			else if(mouseJustReleased) 
+			{
+				SelectedNum = 1;
+				button1.State = 3;
+				button2.State = button3.State = 0;
+			}
+		}
+		else if (button2.isHovered(mousepos))
+		{
+			if (button2.State == 3) return; 
+			else button2.State = 1; 
+			
+			if (mousePressed) button2.State = 2;
+			else if(mouseJustReleased) 
+			{
+				SelectedNum = 2;
+				button2.State = 3;
+				button1.State = button3.State = 0;
+			}
+		}
+		else if (button3.isHovered(mousepos))
+		{
+			if (button3.State == 3) return; 
+			else button3.State = 1; 
+			
+			if (mousePressed) button3.State = 2;
+			else if(mouseJustReleased) 
+			{
+				SelectedNum = 3;
+				button3.State = 3;
+				button1.State = button2.State = 0;
+			}
+		}
+		else
+		{
+			SelectedNum = 0;
+			button1.State = button1.State != 3 ? 0 : 3; 
+			button2.State = button2.State != 3 ? 0 : 3;
+			button3.State = button3.State != 3 ? 0 : 3;
+		}		
+	}
+
+	void RenderGUI()
+	{
+		Vec2f ScreenDim = getDriver().getScreenDimensions();
+
+		if (fadeTimer > 0 && fadeTimer < FadeTicks)
+		{
+			SColor col(colors::menu_invisible_color);
+			float fadeamount = 1.0 - (fadeTimer*0.01f);
+			col = col.getInterpolated(colors::menu_fadeout_color, fadeamount);
+
+			GUI::DrawRectangle(Vec2f_zero, ScreenDim, col);
+		}
+		else if (fadeTimer >= FadeTicks) // draw menu
+		{			
+			GUI::SetFont("menu");	
+			GUI::DrawRectangle(Vec2f_zero, ScreenDim, colors::menu_fadeout_color);
+			GUI::DrawFramedPane(TL_Position, BR_Pos);		
+
+			if (VoteTimeLeft < 1)
+			{	
+				string winner = "";
+				switch (MostVoted)
+				{
+					case 1: winner = button1.shortname; break;
+					case 3:	winner = button3.shortname; break;
+					default: winner = "A Random Map"; break;
+				}
+			 	GUI::DrawText("Map Vote Has Ended.. Loading : "+winner, TL_Position+Vec2f(20,8), color_white);
+			}
+			else
+			{
+			 	GUI::DrawText("Map Vote Ends In : "+ VoteTimeLeft +" Secs", TL_Position+Vec2f(20,8), color_white);
+			}
+			
+
+			const Vec2f NameMid1 = button1.Pos+Vec2f((button1.Size.x/2)-2, button1.Size.y + 36);
+			const Vec2f NameMid2 = button2.Pos+Vec2f((button2.Size.x/2)-2, button2.Size.y + 36);
+			const Vec2f NameMid3 = button3.Pos+Vec2f((button3.Size.x/2)-2, button3.Size.y + 36);
+			
+			GUI::SetFont("arial_20");
+			GUI::DrawTextCentered(""+ VotedCount1, NameMid1, MostVoted == 1 ? SColor(colors::green_color) : color_white);
+			GUI::DrawTextCentered(""+ VotedCount2, NameMid2, MostVoted == 2 ? SColor(colors::green_color) : color_white);
+			GUI::DrawTextCentered(""+ VotedCount3, NameMid3, MostVoted == 3 ? SColor(colors::green_color) : color_white);
+			
+			GUI::SetFont("menu");
+			button1.RenderGUI();
+			button2.RenderGUI();
+			button3.RenderGUI();
+		}
+	}
+	void RenderRaw()
+	{
+		if (fadeTimer >= FadeTicks)
+		{
+			button1.RenderRaw();
+			button2.RenderRaw();
+			button3.RenderRaw();
+		}
+	}
+};
+
+class MapVoteButton
+{
+	string filename;
+	string shortname;
+	string displayname;
+	Vertex[] maptex_raw;
+	Vec2f Pos;
+	Vec2f Size;
+	u8 tex_offsetY;
+	int State;
+	bool isRandomButton;
+
+	MapVoteButton(bool _r) 
+	{
+		State = 0;
+		isRandomButton = _r;
+
+		if (!isRandomButton) // initilze vertices array
+		{
+			maptex_raw.push_back(Vertex( 0, 0, 0, 0, 0 ));
+			maptex_raw.push_back(Vertex( 1, 0, 0, 1, 0 ));
+			maptex_raw.push_back(Vertex( 1, 1, 0, 1, 1 ));
+			maptex_raw.push_back(Vertex( 0, 1, 0, 0, 1 ));			
+		}
+	}
+
+	void RefreshRandomButton( u16 MenuWidth, Vec2f &out ButtonSize)
+	{
+		State = 0;
+		displayname = "Random Map";
+		Size = Vec2f(110,100);
+		ButtonSize = Size;
+		Pos.x = MenuWidth;
+	}
+
+	void RefreshButton( u16 MenuWidth, Vec2f &out ButtonSize)
+	{		
+		State = 0;	
+		if (getNet().isServer() && !getNet().isClient()) return; //works for local host and on dedicated
+
+		if(!Texture::exists(shortname))
+		{
+			CreateMapTexture();
+		}
+
+		if(Texture::exists(shortname))
+		{
+			ImageData@ edit = Texture::data(shortname);
+
+			u16 mapW = edit.width();
+			u16 mapH = edit.height();
+
+			Size = Vec2f(mapW, mapH > 100 ? mapH : 100);
+			ButtonSize = Size;
+			Pos.x = MenuWidth;
+			tex_offsetY = mapH <= 100 ? (100-mapH) : 0;
+
+			//crop names longer than the map size
+			Vec2f dim;
+			displayname = shortname;	
+			GUI::SetFont("menu");
+			GUI::GetTextDimensions(displayname, dim);
+			if (dim.x > mapW - 10)
+			{
+				while (dim.x > mapW - 15)
+				{
+					displayname = displayname.substr(0,displayname.length()-1);
+					GUI::GetTextDimensions(displayname, dim);
+				}	
+				displayname += "..";
+			}
+
+			maptex_raw[1].x = maptex_raw[2].x = mapW;
+			maptex_raw[2].y = maptex_raw[3].y = mapH;
+		}
+	}
+
+	void CreateMapTexture()
+	{
+		// not a perfect minimap replication, but the image is so small it's too hard to tell
+		if(!Texture::createFromFile(shortname, filename))
+		{
+			warn("texture creation failed");
+		}
+		else
+		{	
+			const bool show_gold = getRules().get_bool("show_gold");
+			ImageData@ edit = Texture::data(shortname);
+			u16 minimapW = edit.width();
+			u16 minimapH = edit.height();
+
+			CFileImage image( CFileMatcher(filename).getFirst() );
+			if (image.isLoaded())
+			{
+				while(image.nextPixel())
+				{
+					const int offset = image.getPixelOffset();
+					const Vec2f pixelpos = image.getPixelPosition();
+
+					const SColor PixelCol = image.readPixel();
+
+					const SColor PixelCol_u = edit.get(pixelpos.x, pixelpos.y-1);
+					const SColor PixelCol_d = edit.get(pixelpos.x, pixelpos.y+1);
+					const SColor PixelCol_r = edit.get(pixelpos.x+1, pixelpos.y);
+					const SColor PixelCol_l = edit.get(pixelpos.x-1, pixelpos.y);
+
+					SColor editcol = colors::minimap_open;
+					
+					if ( type(PixelCol) == 0  )      			
+					{
+						editcol = colors::minimap_open;
+					}
+					else if ( type(PixelCol) == 1  )       			
+	    			{				
+	    				// Foreground	
+						editcol = colors::minimap_solid;
+						
+						if ((type(PixelCol_u) != 1 ) || 
+						    (type(PixelCol_l) != 1 ) ||
+							(type(PixelCol_d) != 1 ) ||
+						    (type(PixelCol_r) != 1 ) ) 
+						{
+							editcol = colors::minimap_solid_edge;
+						}
+					}
+					else if ( show_gold && type(PixelCol) == 2 )
+					{
+						//Gold
+						editcol = colors::minimap_gold;
+
+						//Edge
+						if (( type(PixelCol_u) != 1 && type(PixelCol_u) != 2 ) || 
+							( type(PixelCol_l) != 1 && type(PixelCol_l) != 2 ) ||
+						 	( type(PixelCol_d) != 1 && type(PixelCol_d) != 2 ) || 
+							( type(PixelCol_r) != 1 && type(PixelCol_r) != 2 ) )
+						{
+							editcol = colors::minimap_gold_edge;
+						}
+					}										
+					else if (type(PixelCol) == 3)
+					{
+						//Background
+						editcol = colors::minimap_back;
+
+						//Edge
+						if(( type(PixelCol_u) == 0 ) || 
+						   ( type(PixelCol_l) == 0 ) ||
+					 	   ( type(PixelCol_d) == 0 ) || 
+						   ( type(PixelCol_r) == 0 )  )
+						{
+							editcol = colors::minimap_back_edge;
+						}
+					}							
+					else 
+					{
+						editcol = PixelCol_u;
+					}
+
+					//tint the map based on Water
+					if ( PixelCol == SColor(map_colors::water_backdirt) || PixelCol == SColor(map_colors::water_air) )
+					{
+						//overides water backwall edge for some reason...
+						editcol = editcol.getInterpolated( colors::minimap_water, 0.5f);
+					}
+
+					edit[offset] = editcol;	
+				}				
+
+				if(!Texture::update(shortname, edit))
+				{
+					warn("texture update failed");
+					return;
+				}
+			}
+		}
+	}
+
+	bool isHovered(Vec2f mousepos)
+	{
+		Vec2f tl = Pos;
+		Vec2f br = Pos + Size;
+		if (mousepos.x > tl.x && mousepos.y > tl.y &&
+		     mousepos.x < br.x && mousepos.y < br.y)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	void RenderGUI()
+	{
+		SColor col(color_white);
+		switch (State)
+		{
+			case 1: {col = SColor(255,220,220,220);} break; //hovered
+			case 2: {col = SColor(255,200,200,200);} break; //pressed
+			case 3: {col = SColor(255,100,255,100);} break; //selected
+			default: {col = color_white;}
+		}
+
+		const Vec2f Padding_outline = Vec2f(8,8);
+		const Vec2f TL_outline = Pos-Padding_outline;
+		const Vec2f BR_outline = Pos+Size+Padding_outline;
+		const Vec2f Padding_window = Vec2f(4,4);		
+		const Vec2f TL_window = Pos-Padding_window;
+		const Vec2f BR_window = Pos+Size+Padding_window;
+		GUI::DrawPane(TL_outline, BR_outline, col);
+		GUI::DrawWindow(TL_window, BR_window);	
+
+		const Vec2f NameMid = Pos+Vec2f((Size.x/2)-2, Size.y+16);
+		GUI::DrawTextCentered(displayname, NameMid, color_white);
+
+		if (isRandomButton)
+		{
+			const Vec2f IconOffset = Pos+Vec2f(24,20);
+			GUI::DrawIcon( "InteractionIcons.png", 14, Vec2f(32,32), IconOffset, 1.0f, 2);
+		}
+	}
+	void RenderRaw()
+	{
+		const u16[] square_IDs = {0,1,2,2,3,0};
+		float[] model;
+
+		Matrix::MakeIdentity(model);
+		Matrix::SetTranslation(model, Pos.x, Pos.y+tex_offsetY, 0);
+		Render::SetModelTransform(model);
+		Render::RawTrianglesIndexed(shortname, maptex_raw, square_IDs);
+	}	
+};
+
+namespace colors
+{
+	enum color
+	{
+		minimap_solid_edge   = 0xff844715,
+		minimap_solid        = 0xffc4873a,
+		minimap_back_edge    = 0xffc4873b, //yep, same as above *(almost, changed to prevent duplicate case)
+		minimap_back         = 0xfff3ac5c,
+		minimap_open         = 0xffedcca6,
+		minimap_gold         = 0xffffbd34,
+		minimap_gold_edge    = 0xffc56c22,
+		minimap_gold_exposed = 0xfff0872c,
+		minimap_water        = 0xff2cafde,
+		minimap_fire         = 0xffd5543f,
+
+		menu_invisible_color = 0x00000000,
+		menu_fadeout_color	   = 0xbe000000,
+
+		red_color	   = 0xffff0000,
+		green_color	   = 0xff00ff00,
+		blue_color	   = 0xff0000ff
+	}
+}
+
+u8 type(SColor PixelCol)
+{
+	u8 type = 4;
+	switch (PixelCol.color)
+	{
+		case map_colors::water_air:
+		case 0xffa5bdc8: //sky col
+		case colors::minimap_open:
+		{
+			 type = 0; break;
+		}
+		case colors::minimap_solid:
+		//case colors::minimap_solid_edge: //duplicated case
+		case map_colors::tile_ground: 
+		case map_colors::tile_stone: 
+		case map_colors::tile_thickstone: 
+		case map_colors::tile_bedrock: 
+		case map_colors::tile_castle: 
+		case map_colors::tile_castle_moss:
+		case map_colors::tile_wood:
+		{
+			 type = 1; break;
+		}
+
+		case colors::minimap_gold_exposed:
+		case colors::minimap_gold:
+		case colors::minimap_gold_edge:
+		case map_colors::tile_gold:
+		{
+			 type = 2; break;
+		} 
+
+		case colors::minimap_back:
+		case colors::minimap_back_edge:
+		case map_colors::tile_ground_back:
+		case map_colors::tile_castle_back: 
+		case map_colors::tile_wood_back:
+		case map_colors::tile_castle_back_moss:
+		case map_colors::water_backdirt:
+		{
+			 type = 3; break;
+		} 
+	}
+	return type;
+}

--- a/Rules/CommonScripts/PostGameMapVotes.as
+++ b/Rules/CommonScripts/PostGameMapVotes.as
@@ -21,6 +21,14 @@ void onInit( CRules@ this )
 	MapVotesMenu mvm();
 	this.set("MapVotesMenu", @mvm);
 
+	if (!GUI::isFontLoaded("AveriaSerif-Bold_22"))
+	{		
+		string AveriaSerif = CFileMatcher("AveriaSerif-Bold.ttf").getFirst();
+		GUI::LoadFont("AveriaSerif-Bold_22", AveriaSerif, 22, true);
+	}
+
+	_random.Reset(XORRandom(999999)); //required otherwise we get the same seed (the same random order)
+
 	int id = Render::addScript(Render::layer_posthud, "PostGameMapVotes.as", "RenderRaw", 0.0f);
 	onRestart(this);
 }
@@ -102,10 +110,10 @@ void onTick( CRules@ this )
 
 			if (blob !is null)
 			{
-				blob.server_Die();				
-				getHUD().SetDefaultCursor();
+				blob.server_Die(); // just a simple way of locking the camera, might be a better way			
 			}
 		}
+		getHUD().SetDefaultCursor();
 	}
 
 	// Vote is now setup, faded to black and is counting down
@@ -137,8 +145,8 @@ void onTick( CRules@ this )
 		this.SendCommand(this.getCommandID(vote_end_id), params);
 	}
 
-	//---------- CLIENT -----------\\
-	if (!getNet().isClient()) return;
+	//--------------------- CLIENT -----------------------\\
+	if (getNet().isServer() && !getNet().isClient()) return; //not server, but also not localhost
 
 	if (mvm.VoteTimeLeft <= 0) return;
 
@@ -173,7 +181,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 		int p2 = mvm.Votes2.find(id);
 		if (p2 != -1) mvm.Votes2.removeAt(p2);
 		int p3 = mvm.Votes3.find(id);
-		if (p3 != -1) mvm.Votes3.removeAt(p3);			
+		if (p3 != -1) mvm.Votes3.removeAt(p3);		
 
 		switch (selected)
 		{
@@ -261,7 +269,6 @@ void RandomizeButtonNames(CRules@ this, MapVotesMenu@ mvm)
 {	
 	string map1name;
 	string map3name;
-	_random.Reset(getGameTime());
 	string mapcycle = sv_mapcycle;
 	if (mapcycle == "")
 	{

--- a/Rules/CommonScripts/PostGameMapVotes.as
+++ b/Rules/CommonScripts/PostGameMapVotes.as
@@ -91,7 +91,7 @@ void onTick( CRules@ this )
 	if (!this.isGameOver()) return;
 	if (!mvm.isSetup)
 	{	
-		mvm.Refresh(); //refresh menu sizes here for persons who join mid vote
+		mvm.Refresh();
 		return;
 	}	
 
@@ -110,7 +110,7 @@ void onTick( CRules@ this )
 
 			if (blob !is null)
 			{
-				blob.server_Die(); // just a simple way of locking the camera, might be a better way			
+				blob.server_Die(); // just a simple way of locking the camera and setting cursor, might be a better way			
 			}
 		}
 		getHUD().SetDefaultCursor();
@@ -119,7 +119,6 @@ void onTick( CRules@ this )
 	// Vote is now setup, faded to black and is counting down
 	if (getGameTime() % getTicksASecond() == 0)
 	mvm.VoteTimeLeft--;
-
 
 	u8 count1 = mvm.Votes1.length();
 	u8 count2 = mvm.Votes2.length();
@@ -192,13 +191,11 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 		}
 
 		CPlayer@ player = getPlayerByNetworkId(id);
-
 		if (getNet().isClient() && player.isMyPlayer()) 
 		{
 			current_Selected = selected;
 			Sound::Play("buttonclick.ogg");
 		}
-
 	}	
 	else if (cmd == this.getCommandID(vote_unselectmap_id))
 	{
@@ -248,7 +245,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 			if(!Texture::exists(mvm.button3.shortname))
 			{
 				CreateMapTexture(mvm.button3.shortname, mvm.button3.filename);
-			}	
+			}
 		}	
 	}
 	else if (getNet().isServer() && cmd == this.getCommandID(vote_end_id))

--- a/Rules/CommonScripts/PostGameMapVotes.as
+++ b/Rules/CommonScripts/PostGameMapVotes.as
@@ -1,0 +1,248 @@
+//-- Written by Monkey_Feats 22/2/2020 --//
+#include "MapVotesCommon.as";
+
+const int VoteSecs = 16;
+const u16 FadeTicks = 60; //2(secs)*30(ticks)
+s16 fadeTimer;
+const string vote_end_id = "mapvote: ended";
+const string vote_selectmap_id = "mapvote: selectmap";
+u8 current_Selected = 0;
+
+void onInit( CRules@ this )
+{
+	onRestart(this);
+
+	string AveriaSerif = CFileMatcher("AveriaSerif-Bold.ttf").getFirst();	
+	GUI::LoadFont("arial_20", AveriaSerif, 20);
+
+	this.addCommandID(vote_end_id);
+	this.addCommandID(vote_selectmap_id);
+
+	MapVotesMenu mvm();
+	this.set("MapVotesMenu", @mvm);
+
+	int id = Render::addScript(Render::layer_posthud, "PostGameMapVotes.as", "RenderFunction", 0.0f);
+}
+
+void onRestart(CRules@ this)
+{	
+	MapVotesMenu@ mvm;
+	if (this.get("MapVotesMenu", @mvm))
+	mvm.isSetup = false;
+	current_Selected = 0;
+}
+
+void onTick( CRules@ this )
+{		
+	MapVotesMenu@ mvm;
+	if (!this.get("MapVotesMenu", @mvm)) return;
+	if (!this.isGameOver()) return;
+	if (!mvm.isSetup)
+	{	
+		fadeTimer = -(4*30); // ticks of endgame time before fading
+		mvm.VoteTimeLeft = VoteSecs;
+		mvm.Refresh();
+
+		return;
+	}
+
+	if (fadeTimer < FadeTicks)
+	{
+		fadeTimer++;
+		return;
+	}
+	else if (fadeTimer == FadeTicks)
+	{
+		CPlayer@ player;
+		for (int i = 0; i < getPlayersCount(); i++)
+		{
+			@player = getPlayer(i);
+			CBlob@ blob = player.getBlob();
+
+			if (blob !is null)
+			{
+				blob.server_Die();				
+				getHUD().SetDefaultCursor();
+			}
+		}
+	}
+
+	// Vote is now setup, faded to black and is counting down
+	if (getGameTime() % 30 == 0)
+	mvm.VoteTimeLeft--;
+
+	if (mvm.VotedCount1 > mvm.VotedCount2 && mvm.VotedCount1 > mvm.VotedCount3)
+	{	//map 1 got the most votes
+		mvm.MostVoted = 1;
+	}
+	else if (mvm.VotedCount3 > mvm.VotedCount1 && mvm.VotedCount3 > mvm.VotedCount2)
+	{	//map 3 got the most votes
+		mvm.MostVoted = 3;
+	}
+	else 
+	{	//random map got the most votes or inconclusive
+		mvm.MostVoted = 2;
+	}
+
+	CBitStream params;
+	if (getNet().isServer() && mvm.VoteTimeLeft == -4) //timeup + 4 secs, load voted map
+	{
+		params.write_u8(mvm.MostVoted);
+		this.SendCommand(this.getCommandID(vote_end_id), params);
+	}
+
+	//---------- CLIENT -----------\\
+	CPlayer@ me = getLocalPlayer();
+	if (!getNet().isClient()) return;
+
+	CControls@ controls = getControls();
+	if (controls is null) return;
+
+	if (mvm.VoteTimeLeft <= 0 || mvm.VoteTimeLeft >= VoteSecs || me.getTeamNum() == this.getSpectatorTeamNum()) return;
+
+	u8 SelectedNum;	//default to zero, so command is sent only once
+	mvm.Update(controls, SelectedNum);
+
+	if (SelectedNum != 0)
+	{
+		u16 id = me.getNetworkID();
+		params.write_u16(id);
+		params.write_u8(SelectedNum);
+		params.write_u8(current_Selected);
+		this.SendCommand(this.getCommandID(vote_selectmap_id), params);
+	}
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
+{
+	MapVotesMenu@ mvm;
+	if (!this.get("MapVotesMenu", @mvm)) return;
+	
+	if (cmd == this.getCommandID(vote_selectmap_id))
+	{
+		u16 id = params.read_u16();
+		u8 selected = params.read_u8(); 
+		u8 lastselected = params.read_u8();
+		CPlayer@ player = getPlayerByNetworkId(id);	
+
+		if (player !is null)
+		{
+			bool myPlayer = player.isMyPlayer();
+			
+			switch (selected)
+			{
+				case 0: break;
+				case 1: mvm.VotedCount1++; break;
+				case 2: mvm.VotedCount2++; break;
+				case 3: mvm.VotedCount3++; break;
+			}
+			switch (lastselected)
+			{
+				case 0: break;
+				case 1: mvm.VotedCount1--; break;
+				case 2: mvm.VotedCount2--; break;
+				case 3: mvm.VotedCount3--; break;
+			}
+
+			if (myPlayer) current_Selected = selected;
+		}
+	}
+	else if (getNet().isServer() && cmd == this.getCommandID(vote_end_id))
+	{		
+		SaveVoteStats(this);
+
+		PrintVoteStats(this);
+
+		u8 MostVoted = params.read_u8(); 
+		switch (MostVoted)
+		{
+			case 1: LoadMap(mvm.button1.filename); break;
+			case 3:	LoadMap(mvm.button3.filename); break;
+			default: LoadNextMap(); break;
+		}
+	}
+}
+
+void onRender(CRules@ this)
+{
+	MapVotesMenu@ mvm;
+	if (!this.get("MapVotesMenu", @mvm)) return;
+	if (!this.isGameOver() || !mvm.isSetup) return;
+
+	mvm.RenderGUI();
+}
+
+void RenderFunction(int id)
+{	
+	MapVotesMenu@ mvm;
+	if (!getRules().get("MapVotesMenu", @mvm)) return;
+	if (!getRules().isGameOver() || !mvm.isSetup) return;
+
+	Render::SetTransformScreenspace();
+	Render::SetAlphaBlend(true);
+	Render::SetBackfaceCull(true);
+	mvm.RenderRaw();
+}
+
+void SaveVoteStats(CRules@ this)
+{
+	MapVotesMenu@ mvm;
+	if (!this.get("MapVotesMenu", @mvm)) return;
+
+	if (getNet().isServer())
+	{
+		string mode = this.gamemode_name;
+		string statsFile = "Stats_"+mode+"_MapVotes""/"+mode+"_mapvote_stats.cfg";
+		ConfigFile stats;
+
+		if (stats.loadFile("../Cache/" + statsFile))
+		{
+			const u32 b1votes = stats.exists(mvm.button1.shortname) ? stats.read_u32(mvm.button1.shortname) : 0;
+			const u32 b2votes = stats.exists("Random_Map") ? stats.read_u32("Random_Map") : 0;
+			const u32 b3votes = stats.exists(mvm.button3.shortname) ? stats.read_u32(mvm.button3.shortname) : 0;
+			
+			stats.add_u32(mvm.button1.shortname, b1votes+mvm.VotedCount1);
+			stats.add_u32("Random_Map", b2votes+mvm.VotedCount2);
+			stats.add_u32(mvm.button3.shortname, b3votes+mvm.VotedCount3);
+
+			stats.saveFile(statsFile);
+		}
+	}
+}
+
+void PrintVoteStats(CRules@ this)
+{
+	if (getNet().isServer())
+	{
+		ConfigFile stats;
+		string mode = this.gamemode_name;
+		string statsFile = "Stats_"+mode+"_MapVotes""/"+mode+"_mapvote_stats.cfg";
+
+		if (mode == "Team Deathmatch") mode = "TDM";
+		string mapcycle =  "Rules/"+mode+"/mapcycle.cfg";
+
+		ConfigFile cfg;	
+		bool loaded = false;
+		if (CFileMatcher(mapcycle).getFirst() == mapcycle && cfg.loadFile(mapcycle)) loaded = true;
+		else if (cfg.loadFile(mapcycle)) loaded = true;
+		if (!loaded) { warn( mapcycle+ " not found!"); return; }
+
+		string[] map_names;
+		if (cfg.readIntoArray_string(map_names, "mapcycle"))
+		{
+			if (stats.loadFile("../Cache/" + statsFile))
+			{
+				for (uint i = 0; i < map_names.length(); i++)
+				{
+					string filename = map_names[i];				
+					string shortname = getFilenameWithoutExtension(getFilenameWithoutPath(filename));
+
+					if (stats.exists(shortname))
+					printf(""+shortname +" = " +stats.read_u32(shortname));
+				}	
+				if (stats.exists("Random_Map"))
+				printf("Random_Map = " +stats.read_u32("Random_Map"));
+			}
+		}
+	}
+}

--- a/Rules/CommonScripts/Spectator.as
+++ b/Rules/CommonScripts/Spectator.as
@@ -40,6 +40,11 @@ void SetTargetPlayer(CPlayer@ p)
 
 void Spectator(CRules@ this)
 {
+	if (this.isGameOver() && this.hasScript("PostGameMapVotes")) 
+	{
+		return; //prevent camera movement while map voting
+	}
+	
 	CCamera@ camera = getCamera();
 	CControls@ controls = getControls();
 	CMap@ map = getMap();

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -23,7 +23,7 @@
 										 Report.as;
 										 ReportRender.as;
 										 TimeToEnd.as;
-										 RestartAfterShortPostGame.as;
+										 PostGameMapVotes.as; #RestartAfterShortPostGame.as;
 										 FanfareOnWin.as;
 										 PlayerCamera.as;
 										 DefaultScoreboard.as;


### PR DESCRIPTION
Status
this PR is (to the best of your knowledge) ready to be incorporated into the game.

Description
Adds a map vote during GameOver time. Maps are randomly chosen from the current gamemodes mapcycle.cfg. Currently only added to CTF and TTH, though any mode can have a map vote by adding 'PostGameMapVotes.as' to the gamemode.cfg, replacing 'RestartAfterShortPostGame.as'.

Additionally I have added one chat command !endgame which will put the game into the gameover state (only for admins), also any nextmap votes that pass will put the game into the gameover state.

Map votes will tally up how may times a map has been voted for and be saved out to the cache each vote.

Steps to Test or Reproduce
Start either CTF or TTH and end the game using !endgame, winning the game, or passing a nextmap vote.