### PR TITLE
Bumped Nevrotik custom head start timestamp to 2020-03-01

### DIFF
--- a/Rules/CommonScripts/accolade_data.cfg
+++ b/Rules/CommonScripts/accolade_data.cfg
@@ -609,7 +609,7 @@ Monkey_Feats =
 	# community - created MapMakerMode mod, an essential tool for making maps
 
 Nevrotik =
-	customhead 1581033600 3;
+	customhead 1583020800 3;
 	gold 1;
 	participation 5;
 	# gold - EU 1v1 knight tournament for people with no gold medals no. 1


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Bump Nevrotik head timestamp to 01/03/2020 to match approximate possible release date
