### PR TITLE
[Fix] Only sync when needed

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -302,8 +302,11 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			}
 		}
 
-		this.set_bool("has_arrow", hasarrow);
-		this.Sync("has_arrow", isServer());
+		if (hasarrow != this.get_bool("has_arrow"))
+		{
+			this.set_bool("has_arrow", hasarrow);
+			this.Sync("has_arrow", isServer());
+		}
 
 		archer.stab_delay = 0;
 	}

--- a/Entities/Characters/Scripts/RunnerDrowning.as
+++ b/Entities/Characters/Scripts/RunnerDrowning.as
@@ -68,8 +68,11 @@ void onTick(CBlob@ this)
 			}
 		}
 
-		this.set_u8("air_count", aircount);
-		this.Sync("air_count", true);
+		if (aircount != this.get_u8("air_count"))
+		{
+			this.set_u8("air_count", aircount);
+			this.Sync("air_count", true);
+		}
 	}
 }
 

--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -66,7 +66,12 @@ void onTick(CBlob@ this)
 
 		if (!this.hasAttached())
 		{
-			this.Tag("flag missing");
+			if (!this.hasTag("flag missing"))
+			{
+				this.Tag("flag missing");
+				this.Sync("flag missing", true);
+			}
+			
 			u16 id = this.get_u16("flag id");
 			CBlob@ b = getBlobByNetworkID(id);
 			if (b !is null)
@@ -104,9 +109,12 @@ void onTick(CBlob@ this)
 		}
 		else
 		{
-			this.Untag("flag missing");
+			if (this.hasTag("flag missing"))
+			{
+				this.Untag("flag missing");
+				this.Sync("flag missing", true);
+			}
 		}
-		this.Sync("flag missing", true);
 	}
 }
 


### PR DESCRIPTION
I found this while messing with sync engine side

CTF flags sync every tick * per flag in map "flag missing"

Archers always sync their bool hasarrows, when we only need to sync it when it swaps. This is also per player.

Each player also syncs air_count every few ticks, which once again is not needed unless aircount is changing. 

This PR means they don't sync until its required. This should save network resources, not like it’s very resource intensive anyway.

