### PR TITLE
[Fixes/WIP] Fixes errors contained in current test build

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -364,6 +364,11 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
+	if (this !is getLocalPlayerBlob())
+	{
+		return;
+	}
+
 	if (this.hasTag("reload blocks"))
 	{
 		this.Untag("reload blocks");

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -57,6 +57,7 @@ void onInit(CBlob@ this)
 	this.set("knightInfo", @knight);
 
 	this.set_f32("gib health", -1.5f);
+	this.set_bool("hasMenu", false);
 	addShieldVars(this, SHIELD_BLOCK_ANGLE, 2.0f, 5.0f);
 	knight_actorlimit_setup(this);
 	this.getShape().SetRotationsAllowed(false);
@@ -136,11 +137,18 @@ void onTick(CBlob@ this)
 	const int direction = this.getAimDirection(vec);
 	const f32 side = (this.isFacingLeft() ? 1.0f : -1.0f);
 
+	if (isClient() && this.get_bool("hasMenu") != hud.hasMenus())
+	{
+		this.set_bool("hasMenu", hud.hasMenus());
+		this.Sync("hasMenu", false);
+	}
+
+
 	bool shieldState = isShieldState(knight.state);
 	bool specialShieldState = isSpecialShieldState(knight.state);
 	bool swordState = isSwordState(knight.state);
-	bool pressed_a1 = this.isKeyPressed(key_action1) && !hud.hasMenus() && (this.getTickSinceCreated() > 2);
-	bool pressed_a2 = this.isKeyPressed(key_action2) && !hud.hasMenus() && (this.getTickSinceCreated() > 2);
+	bool pressed_a1 = this.isKeyPressed(key_action1) && !this.get_bool("hasMenu") && (this.getTickSinceCreated() > 2);
+	bool pressed_a2 = this.isKeyPressed(key_action2) && !this.get_bool("hasMenu") && (this.getTickSinceCreated() > 2);
 	bool walking = (this.isKeyPressed(key_left) || this.isKeyPressed(key_right));
 
 	const bool myplayer = this.isMyPlayer();

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -57,7 +57,6 @@ void onInit(CBlob@ this)
 	this.set("knightInfo", @knight);
 
 	this.set_f32("gib health", -1.5f);
-	this.set_bool("hasMenu", false);
 	addShieldVars(this, SHIELD_BLOCK_ANGLE, 2.0f, 5.0f);
 	knight_actorlimit_setup(this);
 	this.getShape().SetRotationsAllowed(false);
@@ -136,19 +135,11 @@ void onTick(CBlob@ this)
 
 	const int direction = this.getAimDirection(vec);
 	const f32 side = (this.isFacingLeft() ? 1.0f : -1.0f);
-
-	if (isClient() && this.get_bool("hasMenu") != hud.hasMenus())
-	{
-		this.set_bool("hasMenu", hud.hasMenus());
-		this.Sync("hasMenu", false);
-	}
-
-
 	bool shieldState = isShieldState(knight.state);
 	bool specialShieldState = isSpecialShieldState(knight.state);
 	bool swordState = isSwordState(knight.state);
-	bool pressed_a1 = this.isKeyPressed(key_action1) && !this.get_bool("hasMenu") && (this.getTickSinceCreated() > 2);
-	bool pressed_a2 = this.isKeyPressed(key_action2) && !this.get_bool("hasMenu") && (this.getTickSinceCreated() > 2);
+	bool pressed_a1 = this.isKeyPressed(key_action1);
+	bool pressed_a2 = this.isKeyPressed(key_action2);
 	bool walking = (this.isKeyPressed(key_left) || this.isKeyPressed(key_right));
 
 	const bool myplayer = this.isMyPlayer();

--- a/Entities/Meta/CTFMusic.as
+++ b/Entities/Meta/CTFMusic.as
@@ -31,7 +31,7 @@ void onInit(CBlob@ this)
 	mixer.ResetMixer();
 	this.set_bool("initialized game", false);
 
-	this.getCurrentScript().tickFrequency = 10
+	this.getCurrentScript().tickFrequency = 10;
 }
 
 void onTick(CBlob@ this)
@@ -215,7 +215,7 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 								if (b.getConfig() == "keg" && !b.hasTag("exploding")) // only exploding kegs
 									continue;
 
-								if (classList.find(b.getConfig()) && b.hasTag("dead")) // skip corpses
+								if (classList.find(b.getConfig()) >= 0 && b.hasTag("dead")) // skip corpses
 									continue;
 
 								chosen = world_battle;

--- a/Entities/Structures/Ladder/Ladder.as
+++ b/Entities/Structures/Ladder/Ladder.as
@@ -32,6 +32,14 @@ void onInit(CBlob@ this)
 			this.set('harvest', harvest);
 		}
 	}
+
+	if (this.hasTag("cheated")) // spawned in using chat commands
+	{
+		shape.SetStatic(true); // stop from falling
+		shape.SetGravityScale(0.0f);
+		this.set_u16("timePlaced",0);
+		this.Tag("fallen");
+	}
 }
 
 void onSetStatic(CBlob@ this, const bool isStatic)

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -264,9 +264,18 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 			// otherwise, try to spawn an actor with this name !actor
 			string name = text_in.substr(1, text_in.size());
 
-			if (server_CreateBlob(name, team, pos) is null)
+			CBlob@ newBlob = server_CreateBlobNoInit(name);
+
+			if (newBlob is null)
 			{
 				client_AddToChat("blob " + text_in + " not found", SColor(255, 255, 0, 0));
+			}
+			else
+			{
+				newBlob.setPosition(pos);
+				newBlob.server_setTeamNum(team);
+				newBlob.Tag("cheated"); // tag item with this so we know it was made with chat commands
+				newBlob.Init();
 			}
 		}
 	}

--- a/Rules/CommonScripts/CinematicCommon.as
+++ b/Rules/CommonScripts/CinematicCommon.as
@@ -287,9 +287,15 @@ void SetTimeToCinematic()
 
 bool isCinematicEnabled()
 {
-	ConfigFile cfg;
-	getRules().get("cinematic_cfg", cfg);
-	return cfg.read_bool("cinematic_enabled");
+	ConfigFile@ cfg;
+	getRules().get("cinematic_cfg", @cfg);
+	if (cfg.exists("cinematic_enabled"))
+	{
+		return cfg.read_bool("cinematic_enabled");
+	}
+
+	LoadCinematicConfig(getRules());
+	return false; 
 }
 
 bool isCinematic()


### PR DESCRIPTION
## Tree sync error (REQUIRES Engine side fix)

This bug happens on multiplayer only, where the hitbox would not grow what so ever for new trees that had to grow.

The current changes are as follows;
- Before we grow, we grab all hitboxes we in our sector
- Grab each one and check that we own it
- Do what we were doing before

Using get and set with sync did not fix this issue, so i decided to fix some engine side bugs and do it like this.

## Cinematic camera null fix

In rare cases where the config has not updated with the game, we force it to return false & try save the working config. The null error it self happens when you try to call an none existing "cinematic_enabled" key.


## Music syntax error fix

Nothing to say really, just fixing 2 errors that happened


## Knight no jab at shops removed

I'll look into adding this back in the future, but because hasMenus() does not sync, and syncing it from client to server results in some errors, along with possible no animations, desync and more, its not worth doing for now.


## Fixes block UI bug

When you use shift + num, you end up changing everybody's button. It just make sure we cant run ontick unless we own that blob. 

## Ladder falling upon being spawned in (misc/minor issue)

I added 'cheated' in chatcommands.as, so any blob we do spawn will be tagged with that (excluding ones that get spawned in manually in chatcommands), this means that in future use, we can have blobs do certain things in sandbox.

In this case, when the ladder has the tag "cheated", it'll be set to static on spawn.