### PR TITLE
[Fix] No resource sound spam fix (Test build)

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -216,7 +216,7 @@ void onCommand(CInventory@ this, u8 cmd, CBitStream@ params)
 		{
 			BuildBlock@ block = @blocks[PAGE][i];
 
-			if (!canBuild(blob, @blocks[PAGE], i))
+			if (!canBuild(blob, @blocks[PAGE], i) && blob.isMyPlayer())
 			{
 				Sound::Play("/NoAmmo");
 				return;


### PR DESCRIPTION
Title, fixes an issue with verra's block ui where if you had no resources, and tried to make a mat, all players would get that no resource sound effect.