### PR TITLE
[Changes] Trampoline can now rotate 360 like drill

### DIFF
--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -1,4 +1,5 @@
 // TrampolineLogic.as
+#include "StandardControlsCommon.as"
 
 namespace Trampoline
 {
@@ -41,12 +42,20 @@ void onTick(CBlob@ this)
 
 	Vec2f ray = holder.getAimPos() - this.getPosition();
 	ray.Normalize();
-
+	
 	f32 angle = ray.Angle();
-	angle = angle > 135 || angle < 45? (holder.isFacingLeft()? 135 : 45) : 90;
-	angle -= 90;
+	CControls@ controls = getControls();
 
-	this.setAngleDegrees(-angle);
+	if (controls.isKeyPressed(KEY_LCONTROL))
+	{
+		angle = angle > 135 || angle < 45? (holder.isFacingLeft()? 135 : 45) : 90;
+		angle -= 90;
+		this.setAngleDegrees(-angle);
+	}
+	else
+	{
+		this.setAngleDegrees(-angle+90);
+	}
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1, Vec2f point2)

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -42,20 +42,23 @@ void onTick(CBlob@ this)
 
 	Vec2f ray = holder.getAimPos() - this.getPosition();
 	ray.Normalize();
-	
-	f32 angle = ray.Angle();
+
+	f32 angle = 90 - ray.Angle();
 	CControls@ controls = getControls();
 
 	if (controls.isKeyPressed(KEY_LCONTROL))
 	{
-		angle = angle > 135 || angle < 45? (holder.isFacingLeft()? 135 : 45) : 90;
-		angle -= 90;
-		this.setAngleDegrees(-angle);
+		if (Maths::Abs(angle) > 45)
+		{
+			angle = holder.isFacingLeft() ? -45 : 45;
+		}
+		else
+		{
+			angle = 0;
+		}
 	}
-	else
-	{
-		this.setAngleDegrees(-angle+90);
-	}
+
+	this.setAngleDegrees(angle);
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1, Vec2f point2)

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -41,7 +41,6 @@ void onTick(CBlob@ this)
 	if (holder is null) return;
 
 	Vec2f ray = holder.getAimPos() - this.getPosition();
-	ray.Normalize();
 
 	f32 angle = 90 - ray.Angle();
 	CControls@ controls = getControls();
@@ -56,6 +55,11 @@ void onTick(CBlob@ this)
 		{
 			angle = 0;
 		}
+	}
+	else if (ray.LengthSquared() < 4)
+	{
+		//dont update rotation if cursor is close to pivot point
+		return;
 	}
 
 	this.setAngleDegrees(angle);
@@ -141,6 +145,16 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			}
 		}
 	}
+}
+
+void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint@ attachedPoint)
+{
+	this.getShape().SetRotationsAllowed(false);
+}
+
+void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
+{
+	this.getShape().SetRotationsAllowed(true);
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)


### PR DESCRIPTION
Code done by @CatWiz, asked me to make a PR for him

**Key features**
- Trampolines now follow the mouse in 360 degree, like drill does
- Press ctrl to revert back to 45 degree lock like before

Resolves #790 