### PR TITLE
Remove TDM coin cap

### DIFF
--- a/Rules/TDM/Scripts/TDM_Trading.as
+++ b/Rules/TDM/Scripts/TDM_Trading.as
@@ -135,8 +135,8 @@ void Reset(CRules@ this)
 		if (player is null) continue;
 
 		s32 coins = player.getCoins();
-		coins = Maths::Max(coins, min_coins);
-		coins = Maths::Min(coins, max_coins);
+		if (min_coins >= 0) coins = Maths::Max(coins, min_coins);
+		if (max_coins >= 0) coins = Maths::Min(coins, max_coins);
 		player.server_setCoins(coins);
 	}
 

--- a/Rules/TDM/tdm_vars.cfg
+++ b/Rules/TDM/tdm_vars.cfg
@@ -79,7 +79,7 @@
 	# min > max, you'll have max coins
 	# on spawn.
 
-	maxCoinsOnRestart 	= 200
+	maxCoinsOnRestart 	= -1
 
 
 # tdm trading


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`maxCoinsOnRestart` can be specified as negative to disable the max coin cap, and it is now the default option in vanilla TDM.