### PR TITLE
Typo in MapVotesCommon.as that fails to compile on newer AS

### DIFF
--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -773,8 +773,8 @@ u8 type(SColor PixelCol, bool show_gold)
 		}
 
 		case map_colors::water_backdirt:
-		case map_colors::interpolated_water_backwall:
-		case map_colors::interpolated_water_backwall_edge:
+		case colors::interpolated_water_backwall:
+		case colors::interpolated_water_backwall_edge:
 		{
 			 return ColTileType::Backwall_Water;
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

No idea why it even works right now but this solves the issue. `interpolated_water_backwall{,_edge}` is not declared in the `map_colors` namespace but in the `colors` enum