### PR TITLE
[Fix] Water sounds now play client side

### DIFF
--- a/Entities/Characters/Scripts/RunnerDrowning.as
+++ b/Entities/Characters/Scripts/RunnerDrowning.as
@@ -20,14 +20,14 @@ void onTick(CBlob@ this)
 	if (this.getShape().isStatic())
 		return;
 
-	if (getNet().isServer())
+	Vec2f pos = this.getPosition();
+	const bool inwater = this.isInWater() && this.getMap().isInWater(pos + Vec2f(0.0f, -this.getRadius() * 0.66f));
+
+	u8 aircount = this.get_u8("air_count");
+	this.getCurrentScript().tickFrequency = FREQ;
+
+	if (isServer())
 	{
-		Vec2f pos = this.getPosition();
-		const bool inwater = this.isInWater() && this.getMap().isInWater(pos + Vec2f(0.0f, -this.getRadius() * 0.66f));
-
-		u8 aircount = this.get_u8("air_count");
-
-		this.getCurrentScript().tickFrequency = FREQ;
 
 		if (inwater)
 		{
@@ -40,7 +40,6 @@ void onTick(CBlob@ this)
 			if (aircount < FREQ)
 			{
 				this.server_Hit(this, pos, Vec2f(0, 0), 0.5f, Hitters::drown, true);
-				Sound::Play("Gurgle", pos, 2.0f);
 				aircount += 30;
 			}
 		}
@@ -48,7 +47,6 @@ void onTick(CBlob@ this)
 		{
 			if (aircount < default_aircount/2)
 			{
-				Sound::Play("Sounds/gasp.ogg", pos, 3.0f);
 				aircount = default_aircount/2;
 			}
 			else if (aircount < default_aircount)
@@ -72,6 +70,25 @@ void onTick(CBlob@ this)
 		{
 			this.set_u8("air_count", aircount);
 			this.Sync("air_count", true);
+		}
+	}
+
+	if (isClient()) // sound control
+	{
+		aircount -= 6; // -6 since the lowest value we every get from the server is 6 (which means no sound plays)
+		if (inwater)
+		{
+			if (aircount < FREQ)
+			{
+				Sound::Play("Gurgle", pos, 2.0f);
+			}
+		}
+		else
+		{
+			if(aircount < default_aircount/2)
+			{
+				Sound::Play("Sounds/gasp.ogg", pos, 3.0f);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Water sounds would only play localhost, this is because the sounds were hidden in some isServer() block.

This fixes that, we check if we are a client, and run the sounds depending on the value the server syncs and if we are in water or not.
