### PR TITLE
[fixed] Bug in CTF where users could overwrite their teammates' spawn…

### DIFF
--- a/Rules/CTF/Scripts/CTF_PickSpawn.as
+++ b/Rules/CTF/Scripts/CTF_PickSpawn.as
@@ -173,11 +173,13 @@ void ReadPickCmd(CRules@ this, CBitStream @params)
 {
 	CPlayer@ player = getPlayerByNetworkId(params.read_netid());
 	const u16 pick = params.read_netid();
-
-	LAST_PICK = pick; // global!
-
-	if (player is getLocalPlayer())
+    
+	if (player.isMyPlayer())
 	{
+        // Only set the respawn reference, after we've confirmed 
+        //  the involved player is our own. 
+		LAST_PICK = pick; 
+
 		if (player.getTeamNum() == this.getSpectatorTeamNum())
 		{
 			getHUD().ClearMenus(true);


### PR DESCRIPTION
## Status

- **READY**

## Description

Addresses the bug raised in #175, wherein a user's selected spawn preference could be lost/overwritten. After some testing, @Harrison-Miller and I were able to identify that a user's spawn preference/pick is overwritten if another team member selects a different spawn upon death. Additionally, an individual leaving the game or changing teams could clear the preferences of other teammates. 

## Steps to Test or Reproduce

- gamemmode: CTF

Testing was performed by having multiple spawn points set up throughout the map, and having two players taking turns dying and selecting different spawn points. 
