### PR TITLE
Bucket pickup priority increased when not empty

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -458,6 +458,12 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
 		return factor_boring;
 	}
 
+	if (name == "bucket" && b.get_u8("filled") > 0)
+	{
+		return factor_resource_useful;
+	}
+
+
 	// super low priority, dead stuff - sick of picking up corpses
 	if (b.hasTag("dead"))
 	{


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

Increased pickup priority for buckets containing water (non-empty). 
Until now they always seem to be tricky to pick up, which can be frustrating when something is on fire and time is of the essence. This PR, together with #845 will make this easier.
The actual priority factor can be tuned.

## Steps to Test or Reproduce

- Spawn both empty and filled buckets, on top of each other
- Try picking them up
- Notice filled buckets are much easier to pick up
