### PR TITLE
Refill bucket using water bomb

### DIFF
--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -1,7 +1,7 @@
 
 #include "Hitters.as";
 #include "SplashWater.as";
-
+#include "ArcherCommon.as";
 //config
 
 const int splash_width = 9;
@@ -79,8 +79,9 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		}
 	}
 
-	if ((customData == Hitters::water || customData == Hitters::water_stun) && 
-	    hitterBlob.getName() == "waterbomb") 
+	const string name = hitterBlob.getName();
+	if ((customData == Hitters::water || customData == Hitters::water_stun) &&
+	    (name == "waterbomb" || (name == "arrow" && hitterBlob.get_u8("arrow type") == ArrowType::water)))
 	{
 		u8 filled = this.get_u8("filled");
 		if (filled < splashes)

--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -20,6 +20,7 @@ void onInit(CBlob@ this)
 
 	this.getSprite().ReloadSprites(0, 0);
 	this.addCommandID("splash");
+	this.addCommandID("fill");
 
 	this.set_u8("filled", this.hasTag("_start_filled") ? splashes : 0);
 
@@ -79,26 +80,31 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		}
 	}
 
-	const string name = hitterBlob.getName();
-	if ((customData == Hitters::water || customData == Hitters::water_stun) &&
-	    (name == "waterbomb" || (name == "arrow" && hitterBlob.get_u8("arrow type") == ArrowType::water)) && 
-	    !hitterBlob.hasTag("has filled"))
-	{
-		u8 filled = this.get_u8("filled");
-		u8 filling_left = hitterBlob.get_u8("filling left");
-		if (filling_left == 0) filling_left = splashes; // up to one full bucket
-		
-		if (filled < splashes)
-		{
-			u8 d = Maths::Min(filling_left, splashes - filled);
-			this.set_u8("filled", filled + d);
-			filling_left -= d;
-			hitterBlob.set_u8("filling left" , filling_left);
-			if (filling_left <= 0)
-				hitterBlob.Tag("has filled");
 
-			this.set_u8("water_delay", 5); // only slight delay
-			this.getSprite().SetAnimation("full");
+	if (getNet().isServer()) {
+		const string name = hitterBlob.getName();
+
+		if ((customData == Hitters::water || customData == Hitters::water_stun) &&
+		    (name == "waterbomb" || (name == "arrow" && hitterBlob.get_u8("arrow type") == ArrowType::water)) && 
+		    !hitterBlob.hasTag("tmp has filled"))
+		{
+			u8 filled = this.get_u8("filled");
+			u8 tmp_filling_left = hitterBlob.get_u8("tmp filling left");
+			if (tmp_filling_left == 0) tmp_filling_left = splashes; // up to one full bucket
+			
+			if (filled < splashes)
+			{
+				u8 d = Maths::Min(tmp_filling_left, splashes - filled);
+				tmp_filling_left -= d;
+				hitterBlob.set_u8("tmp filling left" , tmp_filling_left);
+
+				if (tmp_filling_left <= 0)
+					hitterBlob.Tag("tmp has filled");
+				
+				CBitStream params;
+				params.write_u8(filled + d);
+				this.SendCommand(this.getCommandID("fill"), params);
+			}
 		}
 	}
 
@@ -110,6 +116,14 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("splash"))
 	{
 		DoSplash(this);
+	}
+	else if (cmd == this.getCommandID("fill"))
+	{
+		const u8 filled = params.read_u8();
+		this.set_u8("water_delay", 5); // only slight delay
+		this.set_u8("filled", filled);
+				
+		this.getSprite().SetAnimation("full");
 	}
 }
 

--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -78,6 +78,19 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			TakeWaterCount(this);
 		}
 	}
+
+	if ((customData == Hitters::water || customData == Hitters::water_stun) && 
+	    hitterBlob.getName() == "waterbomb") 
+	{
+		u8 filled = this.get_u8("filled");
+		if (filled < splashes)
+		{
+			this.set_u8("filled", splashes);
+			this.set_u8("water_delay", 5); // only slight delay
+			this.getSprite().SetAnimation("full");
+		}
+	}
+
 	return damage;
 }
 

--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -81,12 +81,22 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 	const string name = hitterBlob.getName();
 	if ((customData == Hitters::water || customData == Hitters::water_stun) &&
-	    (name == "waterbomb" || (name == "arrow" && hitterBlob.get_u8("arrow type") == ArrowType::water)))
+	    (name == "waterbomb" || (name == "arrow" && hitterBlob.get_u8("arrow type") == ArrowType::water)) && 
+	    !hitterBlob.hasTag("has filled"))
 	{
 		u8 filled = this.get_u8("filled");
+		u8 filling_left = hitterBlob.get_u8("filling left");
+		if (filling_left == 0) filling_left = splashes; // up to one full bucket
+		
 		if (filled < splashes)
 		{
-			this.set_u8("filled", splashes);
+			u8 d = Maths::Min(filling_left, splashes - filled);
+			this.set_u8("filled", filled + d);
+			filling_left -= d;
+			hitterBlob.set_u8("filling left" , filling_left);
+			if (filling_left <= 0)
+				hitterBlob.Tag("has filled");
+
 			this.set_u8("water_delay", 5); // only slight delay
 			this.getSprite().SetAnimation("full");
 		}


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

Allow refilling of buckets using water bombs. Related to #788. This implementation is very simple. As such, it allows an "unlimited" buckets to be filled with a single water bomb. No water quantity calculations etc are done, but I do not feel they are required. Currently the buckets are also filled fully (3 splashes). 

Thoughts?

## Steps to Test or Reproduce

- spawn empty bucket(s)
- buy water bomb, let it explode on the buckets
- buckets are now full of water