### PR TITLE
Replaced hardcoded spike kills with a special tag

### DIFF
--- a/Entities/Common/Building/BlobPlacement.as
+++ b/Entities/Common/Building/BlobPlacement.as
@@ -17,9 +17,7 @@ void PlaceBlob(CBlob@ this, CBlob @blob, Vec2f cursorPos)
 		shape.server_SetActive(true);
 
 		blob.Tag("temp blob placed");
-		// hack for spike kills
-		// TODO: add proper functionality for any block with a specific tag to blob.SetDamageOwnerPlayer(this.getPlayer());
-		if (blob.getName() == "spikes")
+		if (blob.hasTag("has damage owner"))
 		{
 			blob.SetDamageOwnerPlayer(this.getPlayer());
 		}

--- a/Entities/Common/Scripts/HasDamageOwner.as
+++ b/Entities/Common/Scripts/HasDamageOwner.as
@@ -1,0 +1,4 @@
+void onInit(CBlob@ this)
+{
+	this.Tag("has damage owner");
+}

--- a/Entities/Structures/Spikes/Spikes.cfg
+++ b/Entities/Structures/Spikes/Spikes.cfg
@@ -73,6 +73,8 @@ $name                                  = spikes
 										 Stone.as;									 
 										 Spikes.as;
 										 GenericHit.as;
+										 HasDamageOwner.as;
+
 f32 health                             = 1.0
 # looks & behaviour inside inventory
 $inventory_name                        = Spikes


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Marks the spikes block with a special tag to allow the blob placement script to assign the player placing the block as it's owner. It was previously hardcoded for the spikes only.

This small script can be used to add the same functionality to custom blocks.