### PR TITLE
[modified] prevent placement of seeds on non-growing tiles. Seeds fall down when losing supporting tile

### DIFF
--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -125,15 +125,16 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 	{
 		bool isLadder = false;
 		bool isSpikes = false;
+		bool isSeed = false;
 		if (blob !is null)
 		{
 			const string bname = blob.getName();
 			isLadder = bname == "ladder";
 			isSpikes = bname == "spikes";
+			isSeed = bname == "seed";
 		}
 
 		Vec2f middle = p;
-
 		if (!isLadder && (buildSolid || isSpikes) && map.getSectorAtPosition(middle, "no build") !is null)
 		{
 			return false;
@@ -181,6 +182,14 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 					}
 				}
 			}
+		}
+
+
+		if (isSeed)
+		{
+			// from canGrow.as
+			return (map.isTileGroundStuff(map.getTile(p + Vec2f(0, 8)).type));
+
 		}
 	}
 

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -188,7 +188,7 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 		if (isSeed)
 		{
 			// from canGrow.as
-			return (map.isTileGroundStuff(map.getTile(p + Vec2f(0, 8)).type));
+			return (map.isTileGround(map.getTile(p + Vec2f(0, 8)).type));
 
 		}
 	}

--- a/Entities/Natural/Seed/Seed.as
+++ b/Entities/Natural/Seed/Seed.as
@@ -136,4 +136,25 @@ void onTick(CBlob@ this)
 			}*/
 		}
 	}
+
+	if (isServer())
+	{
+		CMap@ map = getMap();
+		const f32 tilesize = map.tilesize;
+
+		Vec2f tpos = this.getPosition() + Vec2f(0, tilesize);
+		if (!map.isTileGround(map.getTile(tpos).type))
+		{
+			// drop down when not supported
+			CShape@ shape = this.getShape();
+			shape.server_SetActive(true);
+
+			shape.SetStatic(false);
+		}
+	}
+}
+
+bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
+{
+	return blob.getShape().isStatic() && blob.isCollidable();
 }

--- a/Entities/Natural/Seed/Seed.cfg
+++ b/Entities/Natural/Seed/Seed.cfg
@@ -41,12 +41,12 @@ $shape_factory                         = box2d_shape
 
 @$shape_scripts                        =
 f32 shape_mass                         = 0.2
-f32 shape_radius                       = 4.0
+f32 shape_radius                       = 3.5
 f32 shape_friction                     = 1.1
 f32 shape_elasticity                   = 0.0
 f32 shape_buoyancy                     = 0.8
 f32 shape_drag                         = 0.3
-bool shape_collides                       = no
+bool shape_collides                    = yes
 bool shape_ladder                      = no
 bool shape_platform                    = no
  #block_collider


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Placement of seeds now only allowed on tiles where seeds can actually grow.
Seeds should have improved physics, which means they will fall down when their support is lost.
This should also fix issue #606.

## Steps to Test or Reproduce

Try and fail planting seeds on stone, wood, platforms, shop etc.
Plant a seed on ground tile (only place you can put them now), then dig out that tile and the seed will drop down (with a slight delay).
