### PR TITLE
[modified] make storage, tunnels and quarries non-flammable

### DIFF
--- a/Entities/Industry/CTFShops/Quarry/Quarry.cfg
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.cfg
@@ -64,7 +64,6 @@ $name                                             = quarry
 													Quarry.as;
 													WoodStructureHit.as;
 													Stone.as;
-													IsFlammable.as;
 													BuildingEffects.as;
 													GenericDestruction.as;
 													GoldBuilding.as;

--- a/Entities/Industry/CTFShops/Storage/Storage.cfg
+++ b/Entities/Industry/CTFShops/Storage/Storage.cfg
@@ -70,7 +70,6 @@ $name                                             = storage
 													Storage.as;
 													WoodStructureHit.as;
 													Stone.as;
-													IsFlammable.as;
 													BuildingEffects.as;
 													GenericDestruction.as;
 													RandomExitVelocity.as;

--- a/Entities/Industry/Tunnel/Tunnel.cfg
+++ b/Entities/Industry/Tunnel/Tunnel.cfg
@@ -78,7 +78,6 @@ $name                                      = tunnel
 											 Tunnel.as;
 											 WoodStructureHit.as;
 											 Stone.as;
-											 IsFlammable.as;
 											 BuildingEffects.as;
 											 GoldBuilding.as;
 f32_health                                 = 8.0


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Removed isFlammable from storage, tunnels and quarries. See #829.

