### PR TITLE
[modified] allow grappling right after firing

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -72,7 +72,8 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 	if (right_click)
 	{
 		// cancel charging
-		if (charge_state != ArcherParams::not_aiming)
+		if (charge_state != ArcherParams::not_aiming &&
+		    charge_state != ArcherParams::fired) // allow grapple right after firing
 		{
 			charge_state = ArcherParams::not_aiming;
 			archer.charge_time = 0;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

It is already possible to grapple immediately after a legolas shot. But trying to grapple immediately after a normal shot does not work. This commit fixes that inconsistency.

## Steps to Test or Reproduce

- Start charging an arrow as archer.
- Shoot the arrow and immediately after try grappling.
- Notice that is works!