### PR TITLE
[fix] wooden gibs from self-hits (e.g. decay) should not spawn slightly towards more to the left

### DIFF
--- a/Entities/Common/Fabric/Wooden.as
+++ b/Entities/Common/Fabric/Wooden.as
@@ -9,12 +9,17 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 {
 	if (damage > 0.05f) //sound for all damage
 	{
+		f32 angle = (this.getPosition() - worldPoint).getAngle();
 		if (hitterBlob !is this)
 		{
 			this.getSprite().PlayRandomSound("/WoodHit", Maths::Min(1.25f, Maths::Max(0.5f, damage)));
 		}
+		else
+		{
+			angle = 90.0f; // self-hit. spawn gibs upwards
+		}
 
-		makeGibParticle("/GenericGibs", worldPoint, getRandomVelocity((this.getPosition() - worldPoint).getAngle(), 1.0f + damage, 90.0f) + Vec2f(0.0f, -2.0f),
+		makeGibParticle("/GenericGibs", worldPoint, getRandomVelocity(angle, 1.0f + damage, 90.0f) + Vec2f(0.0f, -2.0f),
 		                1, 4 + XORRandom(4), Vec2f(8, 8), 2.0f, 0, "", 0);
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Wooden gibs seem to spawn slightly offset to the left.

## Steps to Test or Reproduce

Spawn a bunch of buckets, notice that more gibs end up going to the left than right.