### PR TITLE
Archer: some fixes for no-arrows cycling

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -963,7 +963,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		}
 		if (archer.charge_state == ArcherParams::no_arrows)
 		{
-			archer.charge_state = ArcherParams::readying;
+			archer.charge_state = ArcherParams::not_aiming;
 		}
 
 	}

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -492,7 +492,8 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			{
 				charge_time--;
 
-				if (charge_time <= 0)
+				// when no arrows, ignore charge timer
+				if (charge_time <= 0 || !hasarrow)
 				{
 					charge_state = ArcherParams::not_aiming;
 					charge_time = 0;

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -961,6 +961,11 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				break;
 			}
 		}
+		if (archer.charge_state == ArcherParams::no_arrows)
+		{
+			archer.charge_state = ArcherParams::readying;
+		}
+
 	}
 	else
 	{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes two issues: 
1. Cycling from no-arrow type to has-arrow type quickly (!) now actually cycles. Fixes #576.
2. While charging, cycling from no-arrow type to has-arrow type will cycle and start charging.

## Steps to Test or Reproduce

- as archer get normal arrows and one special arrow type
- shoot a normal arrow
- drop the normal arrows in inventory, so you don't have any more normal ones
- try shooting a normal arrow and notice the empty-bow draw animation
- then either:
  - (1) start charging the empty bow, cycle to the special arrow. Notice it starts charging without having to cancel first.
  - (2) in quick succession start charging the empty bow, stop charging, cycle, start charging again. Notice the special arrow is now charging. (this is the timing issue)


