### PR TITLE
Move yellow flag indicators 1 pixel up

### DIFF
--- a/Entities/Special/CTF/CTF_Flag.as
+++ b/Entities/Special/CTF/CTF_Flag.as
@@ -171,11 +171,11 @@ void onRender(CSprite@ this)
 			{
 				if (!shouldFastReturn(blob))
 				{
-					GUI::DrawIconByName("$return_indicator$", Vec2f(pos2d.x-8.0f, pos2d.y-40.0f));
+					GUI::DrawIconByName("$return_indicator$", Vec2f(pos2d.x-8.0f, pos2d.y-41.0f));
 				}
 				else
 				{
-					GUI::DrawIconByName("$fast_return_indicator$", Vec2f(pos2d.x-18.0f, pos2d.y-40.0f));
+					GUI::DrawIconByName("$fast_return_indicator$", Vec2f(pos2d.x-18.0f, pos2d.y-41.0f));
 				}
 			}
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Should have been in previous PR #859. Now yellow `<` en `<<<` indicators are vertically aligned properly.