### PR TITLE
[fix] CTF - Added visual indicator for when a player attempts to change teams while respawning.

### DIFF
--- a/Rules/CTF/Scripts/CTF_Interface.as
+++ b/Rules/CTF/Scripts/CTF_Interface.as
@@ -182,7 +182,9 @@ void onRender(CRules@ this)
 			string spawn_message = getTranslatedString("Respawning in: {SEC}").replace("{SEC}", ((spawn > 250) ? getTranslatedString("approximatively never") : ("" + spawn)));
 
 			GUI::SetFont("hud");
-			GUI::DrawText(spawn_message , Vec2f(getScreenWidth() / 2 - 70, getScreenHeight() / 3 + Maths::Sin(getGameTime() / 3.0f) * 5.0f), SColor(255, 255, 255, 55));
+			// Apply offset if change team menu is also opened.
+			u8 offset = (getGridMenuByName("Change team") !is null) ? 20.0f : 0.0f;
+			GUI::DrawText(spawn_message , Vec2f(getScreenWidth() / 2 - 70, getScreenHeight() / 3 + Maths::Sin(getGameTime() / 3.0f) * 5.0f - offset), SColor(255, 255, 255, 55));
 		}
 	}
 }

--- a/Rules/CTF/Scripts/CTF_PickSpawn.as
+++ b/Rules/CTF/Scripts/CTF_PickSpawn.as
@@ -118,25 +118,7 @@ void onTick(CRules@ this)
 			}
 		}
 	}*/
-
-	CPlayer@ p = getLocalPlayer();
-
-	if (p is null || !p.isMyPlayer()) { return; }
-
-    string propname = "ctf spawn time " + p.getUsername();
-    if(this.exists(propname))
-    {
-        u8 spawn = this.get_u8(propname);
-        if(spawn < 2)
-        {
-            getHUD().ClearMenus(true);
-            return;
-
-        }
-
-    }
-
-}
+} 
 
 //hook after the change has been decided
 void onPlayerChangedTeam(CRules@ this, CPlayer@ player, u8 oldteam, u8 newteam)

--- a/Rules/CTF/Scripts/CTF_TeamMenu.as
+++ b/Rules/CTF/Scripts/CTF_TeamMenu.as
@@ -1,0 +1,45 @@
+#include "TeamMenu.as"
+
+void onTick(CRules@ this)
+{
+	CPlayer@ p = getLocalPlayer();
+
+	if (p is null || !p.isMyPlayer()) { return; }
+
+    string propname = "ctf spawn time " + p.getUsername();
+    if(this.exists(propname))
+    {
+        u8 spawn = this.get_u8(propname);
+
+		CGridMenu@ changeTeamMenu = getGridMenuByName("Change team");
+
+		// The player has the change team menu open, and is respawning.
+		if (changeTeamMenu !is null and spawn < 255)
+		{
+			// Update the menu with the player's remaining spawn time.
+			BuildTeamMenu(this, spawn);
+
+			// The player's preference is locked in, and all team options
+			// are disabled
+			if (spawn < 2)
+			{
+				// Update ref to menu, now that it's been newly recreated
+				CGridMenu@ changeTeamMenu = getGridMenuByName("Change team");
+				uint buttonCount = changeTeamMenu.getButtonsCount();
+				for (uint i = 0; i < buttonCount; i++)
+				{
+					changeTeamMenu.getButtonOfIndex(i).SetEnabled(false);
+				}	
+			}
+
+			return;
+		}
+
+		// Original default behavior - close all menus during last 2s of spawn.
+		if (spawn < 2)
+		{
+			getHUD().ClearMenus();
+		}
+    }
+
+}

--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -10,6 +10,7 @@ gamemode_info                                     = Capture the Flag
 scripts                                           = KAG.as;
 													PatronSupport.as;
 													CTF.as;
+													CTF_TeamMenu.as;
 													CTF_Interface.as;
 													CTF_Trading.as;
 													UseFakeTechs.as;

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -15,6 +15,18 @@ void onInit(CRules@ this)
 
 void ShowTeamMenu(CRules@ this)
 {
+	BuildTeamMenu(this, 0);
+}
+
+/// 
+///	Builds the menu for selecting a team change.
+/// 
+/// <param> this	The gamemode's rules reference.
+/// <param> remainingSpawnTime	Used in CTF to display info for a respawning player.
+///		Default epxected value is 0.
+///
+void BuildTeamMenu(CRules@ this, u8 remainingSpawnTime)
+{
 	if (getLocalPlayer() is null)
 	{
 		return;
@@ -22,7 +34,11 @@ void ShowTeamMenu(CRules@ this)
 
 	getHUD().ClearMenus(true);
 
-	CGridMenu@ menu = CreateGridMenu(getDriver().getScreenCenterPos(), null, Vec2f((this.getTeamsCount() + 0.5f) * BUTTON_SIZE, BUTTON_SIZE), "Change team");
+	// If a valid remainingSpawnTime was given, allow for more vertical space
+	// for the additional countdown text button.
+	u8 yOffset = (remainingSpawnTime > 0) ? 1 : 0;
+
+	CGridMenu@ menu = CreateGridMenu(getDriver().getScreenCenterPos(), null, Vec2f((this.getTeamsCount() + 0.5f) * BUTTON_SIZE, (BUTTON_SIZE + yOffset) ), "Change team");
 
 	if (menu !is null)
 	{
@@ -63,6 +79,15 @@ void ShowTeamMenu(CRules@ this)
 
 			CGridButton@ button =  menu.AddButton(icon, getTranslatedString(name), this.getCommandID("pick teams"), Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
 		}
+
+		// Render additional text denoting how many seconds the player 
+		// has to change teams, before their option is locked in.
+		if (remainingSpawnTime > 0)
+		{
+			string lockInText = (remainingSpawnTime > 2) ? "Locking selection, in: " + (remainingSpawnTime - 2) : "Locked in!";
+			CGridButton@ countdownButton = menu.AddTextButton(lockInText, Vec2f( (BUTTON_SIZE * 2) + 2, BUTTON_SIZE/4));	
+		}
+
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Attempting to create better UX to address the issue raised by #586 . It appears that a conscious decision was made to prevent a player from changing teams 2 seconds prior to respawning. However, the present implementation abruptly closes the change-team menu. My attempted solution is to provide a text button to the change-team menu, that indicates the remaining time a player has to make a selection. And once the cutoff has been reached, instead of closing, the menu's options are disabled.  

[You can view a demonstration here](https://drive.google.com/file/d/1RlUyhb-5nteUZyMteezjK5UecJlS8wHl/view?usp=sharing)


## Steps to Test or Reproduce

- Choose CTF
- Start round
- Suicide
- Select change team
- Witness my sick menu