### PR TITLE
BuilderAutoPickup.as bugfix

### DIFF
--- a/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -4,99 +4,99 @@
 
 void onInit(CBlob@ this)
 {
-    this.getCurrentScript().tickFrequency = 12;
-    this.getCurrentScript().removeIfTag = "dead";
+	this.getCurrentScript().tickFrequency = 12;
+	this.getCurrentScript().removeIfTag = "dead";
 }
 
 void Take(CBlob@ this, CBlob@ blob)
 {
-    const string blobName = blob.getName();
-    
-    if (
-        blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
-        blobName == "mat_stone" ||
-        blobName == "mat_wood"
-        ) {
-        if ((blob.getDamageOwnerPlayer() !is this.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
-        {
-            if (this.server_PutInInventory(blob))
-            {
-                return;
-            }
-        }
-    }
-    
-    CBlob@ carryblob = this.getCarriedBlob();
-    if (carryblob !is null && carryblob.getName() == "crate")
-    {
-        if (crateTake(carryblob, blob))
-        {
-            return;
-        }
-    }
+	const string blobName = blob.getName();
+
+	if (
+		blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
+		blobName == "mat_stone" ||
+		blobName == "mat_wood"
+	) {
+		if ((blob.getDamageOwnerPlayer() !is this.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
+		{
+			if (this.server_PutInInventory(blob))
+			{
+				return;
+			}
+		}
+	}
+
+	CBlob@ carryblob = this.getCarriedBlob();
+	if (carryblob !is null && carryblob.getName() == "crate")
+	{
+		if (crateTake(carryblob, blob))
+		{
+			return;
+		}
+	}
 }
 
 bool pickupCriteria(CBlob@ this, CBlob@ blob, uint16 quantity)
 {
-    return blob.getQuantity() >= quantity || this.hasBlob(blob.getName(), 1);
+	return blob.getQuantity() >= quantity || this.hasBlob(blob.getName(), 1);
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
-    if (blob is null || blob.getShape().vellen > 1.0f)
-    {
-        return;
-    }
-    
-    Take(this, blob);
+	if (blob is null || blob.getShape().vellen > 1.0f)
+	{
+		return;
+	}
+
+	Take(this, blob);
 }
 
 void onTick(CBlob@ this)
 {
-    CBlob@[] overlapping;
-    
-    if (this.getOverlapping(@overlapping))
-    {
-        for (uint i = 0; i < overlapping.length; i++)
-        {
-            CBlob@ blob = overlapping[i];
-            {
-                if (blob.getShape().vellen > 1.0f)
-                {
-                    continue;
-                }
-                
-                Take(this, blob);
-            }
-        }
-    }
+	CBlob@[] overlapping;
+
+	if (this.getOverlapping(@overlapping))
+	{
+		for (uint i = 0; i < overlapping.length; i++)
+		{
+			CBlob@ blob = overlapping[i];
+			{
+				if (blob.getShape().vellen > 1.0f)
+				{
+					continue;
+				}
+
+				Take(this, blob);
+			}
+		}
+	}
 }
 
 // make ignore collision time a lot longer for auto-pickup stuff
 void IgnoreCollisionLonger(CBlob@ this, CBlob@ blob)
 {
-    if (this.hasTag("dead"))
-    {
-        return;
-    }
-    
-    const string blobName = blob.getName();
-    
-    if (blobName == "mat_gold" || blobName == "mat_stone" ||
-        blobName == "mat_wood" || blobName == "grain")
-    {
-        blob.set_u32("autopick time", getGameTime() +  getTicksASecond() * 7);
-        blob.SetDamageOwnerPlayer(this.getPlayer());
-    }
+	if (this.hasTag("dead"))
+	{
+		return;
+	}
+
+	const string blobName = blob.getName();
+
+	if (blobName == "mat_gold" || blobName == "mat_stone" ||
+	        blobName == "mat_wood" || blobName == "grain")
+	{
+		blob.set_u32("autopick time", getGameTime() +  getTicksASecond() * 7);
+		blob.SetDamageOwnerPlayer(this.getPlayer());
+	}
 }
 
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
 {
-    IgnoreCollisionLonger(this, detached);
+	IgnoreCollisionLonger(this, detached);
 }
 
 void onRemoveFromInventory(CBlob@ this, CBlob@ blob)
 {
-    IgnoreCollisionLonger(this, blob);
+	IgnoreCollisionLonger(this, blob);
 }

--- a/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -4,99 +4,99 @@
 
 void onInit(CBlob@ this)
 {
-	this.getCurrentScript().tickFrequency = 12;
-	this.getCurrentScript().removeIfTag = "dead";
+    this.getCurrentScript().tickFrequency = 12;
+    this.getCurrentScript().removeIfTag = "dead";
 }
 
 void Take(CBlob@ this, CBlob@ blob)
 {
-	const string blobName = blob.getName();
-
-	if (
-		blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
-		blobName == "mat_stone" ||
-		blobName == "mat_wood"
-	) {
-		if ((this.getDamageOwnerPlayer() is blob.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
-		{
-			if (this.server_PutInInventory(blob))
-			{
-				return;
-			}
-		}
-	}
-
-	CBlob@ carryblob = this.getCarriedBlob();
-	if (carryblob !is null && carryblob.getName() == "crate")
-	{
-		if (crateTake(carryblob, blob))
-		{
-			return;
-		}
-	}
+    const string blobName = blob.getName();
+    
+    if (
+        blobName == "mat_gold" && pickupCriteria(this, blob, 50) ||
+        blobName == "mat_stone" ||
+        blobName == "mat_wood"
+        ) {
+        if ((blob.getDamageOwnerPlayer() !is this.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
+        {
+            if (this.server_PutInInventory(blob))
+            {
+                return;
+            }
+        }
+    }
+    
+    CBlob@ carryblob = this.getCarriedBlob();
+    if (carryblob !is null && carryblob.getName() == "crate")
+    {
+        if (crateTake(carryblob, blob))
+        {
+            return;
+        }
+    }
 }
 
 bool pickupCriteria(CBlob@ this, CBlob@ blob, uint16 quantity)
 {
-	return blob.getQuantity() >= quantity || this.hasBlob(blob.getName(), 1);
+    return blob.getQuantity() >= quantity || this.hasBlob(blob.getName(), 1);
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
-	if (blob is null || blob.getShape().vellen > 1.0f)
-	{
-		return;
-	}
-
-	Take(this, blob);
+    if (blob is null || blob.getShape().vellen > 1.0f)
+    {
+        return;
+    }
+    
+    Take(this, blob);
 }
 
 void onTick(CBlob@ this)
 {
-	CBlob@[] overlapping;
-
-	if (this.getOverlapping(@overlapping))
-	{
-		for (uint i = 0; i < overlapping.length; i++)
-		{
-			CBlob@ blob = overlapping[i];
-			{
-				if (blob.getShape().vellen > 1.0f)
-				{
-					continue;
-				}
-
-				Take(this, blob);
-			}
-		}
-	}
+    CBlob@[] overlapping;
+    
+    if (this.getOverlapping(@overlapping))
+    {
+        for (uint i = 0; i < overlapping.length; i++)
+        {
+            CBlob@ blob = overlapping[i];
+            {
+                if (blob.getShape().vellen > 1.0f)
+                {
+                    continue;
+                }
+                
+                Take(this, blob);
+            }
+        }
+    }
 }
 
 // make ignore collision time a lot longer for auto-pickup stuff
 void IgnoreCollisionLonger(CBlob@ this, CBlob@ blob)
 {
-	if (this.hasTag("dead"))
-	{
-		return;
-	}
-
-	const string blobName = blob.getName();
-
-	if (blobName == "mat_gold" || blobName == "mat_stone" ||
-	        blobName == "mat_wood" || blobName == "grain")
-	{
-		blob.set_u32("autopick time", getGameTime() +  getTicksASecond() * 7);
-		blob.SetDamageOwnerPlayer(blob.getPlayer());
-	}
+    if (this.hasTag("dead"))
+    {
+        return;
+    }
+    
+    const string blobName = blob.getName();
+    
+    if (blobName == "mat_gold" || blobName == "mat_stone" ||
+        blobName == "mat_wood" || blobName == "grain")
+    {
+        blob.set_u32("autopick time", getGameTime() +  getTicksASecond() * 7);
+        blob.SetDamageOwnerPlayer(this.getPlayer());
+    }
 }
 
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
 {
-	IgnoreCollisionLonger(this, detached);
+    IgnoreCollisionLonger(this, detached);
 }
 
 void onRemoveFromInventory(CBlob@ this, CBlob@ blob)
 {
-	IgnoreCollisionLonger(this, blob);
+    IgnoreCollisionLonger(this, blob);
 }


### PR DESCRIPTION
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

BuilderAutoPickup.as used an incorrect expression for SetDamageOwnerPlayer on line 88: blob.getPlayer() instead this.getPlayer(); "this" is the builder, and "blob" is the mat_wood/mat_stone or whatever; that means blob.getPlayer() is always null.

Changing this allows builders to immediately autopickup mats that other people drop when they switch off builder (after building time ends, if they resupply for you at tent every time they respawn, etc.) by simply walking over the mats.

The one downside of this is that because the bug that makes people drop their 300 wood + 100 stone sometimes on nextmap still exists in vanilla (it's fixed on captains), this change might make picking up your own mats in that scenario impossible; that bug should just be fixed in vanilla as well.