### PR TITLE
BuilderAutoPickup.as bugfix

### DIFF
--- a/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -17,7 +17,7 @@ void Take(CBlob@ this, CBlob@ blob)
 		blobName == "mat_stone" ||
 		blobName == "mat_wood"
 	) {
-		if ((this.getDamageOwnerPlayer() is blob.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
+		if ((blob.getDamageOwnerPlayer() !is this.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
 		{
 			if (this.server_PutInInventory(blob))
 			{
@@ -86,7 +86,7 @@ void IgnoreCollisionLonger(CBlob@ this, CBlob@ blob)
 	        blobName == "mat_wood" || blobName == "grain")
 	{
 		blob.set_u32("autopick time", getGameTime() +  getTicksASecond() * 7);
-		blob.SetDamageOwnerPlayer(blob.getPlayer());
+		blob.SetDamageOwnerPlayer(this.getPlayer());
 	}
 }
 


### PR DESCRIPTION
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

BuilderAutoPickup.as used an incorrect expression for SetDamageOwnerPlayer on line 88: blob.getPlayer() instead this.getPlayer(); "this" is the builder, and "blob" is the mat_wood/mat_stone or whatever; that means blob.getPlayer() is always null.

Changing this allows builders to immediately autopickup mats that other people drop when they switch off builder (after building time ends, if they resupply for you at tent every time they respawn, etc.) by simply walking over the mats.

The one downside of this is that because the bug that makes people drop their 300 wood + 100 stone sometimes on nextmap still exists in vanilla (it's fixed on captains), this change might make picking up your own mats in that scenario impossible; that bug should just be fixed in vanilla as well.