### PR TITLE
Double the frequency of resupply checks

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -219,7 +219,7 @@ void onTick(CRules@ this)
 
 	s32 gametime = getGameTime();
 
-	if ((gametime % 31) != 5)
+	if ((gametime % 15) != 5)
 		return;
 
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This doubles the frequency of checks at shops and tent for whether resupplies should be given to a player. It should make resupplies feel a lot more snappy, and remove some cases where your character walks over a shop but does not receive a resupply.

## Steps to Test or Reproduce

Walk over a shop and notice that you get given your resupply mats faster than usual.

Affected:

- Tent
- Builder shop
- Knight shop (if it actually gave any mats)
- Archer shop
