### PR TITLE
Food Ownership Changes

### DIFF
--- a/Entities/Items/Food/EatCommon.as
+++ b/Entities/Items/Food/EatCommon.as
@@ -37,8 +37,8 @@ void Heal(CBlob@ this, CBlob@ food)
 
 void setHealer(CBlob@ this, CBlob@ healer)
 {
-    CPlayer@ player = attached.getPlayer();
-	
+    CPlayer@ player = healer.getPlayer();
+
     if (isServer() && player !is null && (this.getTeamNum() != healer.getTeamNum() || !this.exists("healer")))
     {
         this.server_setTeamNum(healer.getTeamNum());

--- a/Entities/Items/Food/EatCommon.as
+++ b/Entities/Items/Food/EatCommon.as
@@ -34,3 +34,15 @@ void Heal(CBlob@ this, CBlob@ food)
 		food.Tag("healed");
 	}
 }
+
+void setHealer(CBlob@ this, CBlob@ healer)
+{
+    CPlayer@ player = attached.getPlayer();
+	
+    if (isServer() && player !is null && (this.getTeamNum() != healer.getTeamNum() || !this.exists("healer")))
+    {
+        this.server_setTeamNum(healer.getTeamNum());
+        this.set_u16("healer", player.getNetworkID());
+        this.Sync("healer", true);
+    }
+}

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -84,7 +84,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 
 	if (isServer())
 	{
-	Heal(attached, this);
+		Heal(attached, this);
 	}
 
 	setHealer(this, attached);

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -80,14 +80,14 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
-    if (this is null || attached is null) {return;}
+	if (this is null || attached is null) {return;}
 
-    if (isServer())
-    {
-        Heal(attached, this);
-    }
-    
-    setHealer(this, attached);
+	if (isServer())
+	{
+	Heal(attached, this);
+	}
+
+	setHealer(this, attached);
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -106,34 +106,12 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
         Heal(attached, this);
     }
     
-    CPlayer@ player = attached.getPlayer();
-
-    if (player !is null && (this.getTeamNum() != attached.getTeamNum() || !this.exists("healer")))
-    {
-        if (isServer())
-        {
-            this.server_setTeamNum(attached.getTeamNum());
-        }
-
-        this.set_u16("healer", player.getNetworkID());
-        this.Sync("healer", true);
-    }
+    setHealer(this, attached)
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
 {
-    CPlayer@ player = inventoryBlob.getPlayer();
-
-    if (player !is null && (this.getTeamNum() != inventoryBlob.getTeamNum() || !this.exists("healer")))
-    {
-        if (isServer())
-        {
-            this.server_setTeamNum(inventoryBlob.getTeamNum());
-        }
-
-        this.set_u16("healer", player.getNetworkID());
-        this.Sync("healer", true);
-    }
+    setHealer(this, inventoryBlob)
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -92,7 +92,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
 {
-    setHealer(this, inventoryBlob);
+	setHealer(this, inventoryBlob);
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)

--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -10,25 +10,6 @@ void onInit(CBlob@ this)
 	this.addCommandID(heal_id);
 }
 
-void onTick(CBlob@ this)
-{
-	if(!this.exists("healer"))
-	{
-		this.set_string("owner", "No owner");
-	}
-	else
-	{
-		u16 healerID = this.get_u16("healer");
-		CPlayer@ healer = getPlayerByNetworkId(healerID);
-		if(healer !is null)
-		{
-			this.set_string("owner", healer.getUsername());
-		}
-	}
-
-	this.Sync("owner", true);
-}
-
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
 	if (cmd == this.getCommandID(heal_id))
@@ -106,12 +87,12 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
         Heal(attached, this);
     }
     
-    setHealer(this, attached)
+    setHealer(this, attached);
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
 {
-    setHealer(this, inventoryBlob)
+    setHealer(this, inventoryBlob);
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -30,11 +30,30 @@ void onRender(CSprite@ this)
 	Vec2f mouseWorld = getControls().getMouseWorldPos();
 	const f32 renderRadius = (blob.getRadius()) * 0.95f;
 	bool mouseOnBlob = (mouseWorld - center).getLength() < renderRadius;
-	string foodOwner = "Owner: " + blob.get_string("owner");
+
+	string healerName;
+
+	if(!blob.exists("healer"))
+	{
+		healerName = "No owner";
+	}
+	else
+	{
+		u16 healerID = blob.get_u16("healer");
+		CPlayer@ healer = getPlayerByNetworkId(healerID);
+		if(healer !is null)
+		{
+			healerName = healer.getUsername(); 
+		}
+	}
+
+	blob.Sync("healer", true);
+
+	string foodOwnership = "Owner: " + blob.get_string("owner");
 
 	if (mouseOnBlob && getLocalPlayerBlob() !is null && blob.getTeamNum() == getLocalPlayerBlob().getTeamNum() && !blob.isInInventory())
 	{
 		GUI::SetFont("menu");
-		GUI::DrawTextCentered(foodOwner, blob.getScreenPos() + Vec2f(0, -30), color_white);
+		GUI::DrawTextCentered(foodOwnership, blob.getScreenPos() + Vec2f(0, -30), color_white);
 	}
 }

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -46,8 +46,6 @@ void onRender(CSprite@ this)
 		}
 	}
 
-	blob.Sync("healer", true);
-
 	string foodOwnership = "Owner: " + healerName;
 
 	if (mouseOnBlob && getLocalPlayerBlob() !is null && blob.getTeamNum() == getLocalPlayerBlob().getTeamNum() && !blob.isInInventory())

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -15,7 +15,6 @@ void onInit(CBlob@ this)
 
 	this.getSprite().SetFrameIndex(index);
 	this.SetInventoryIcon(this.getSprite().getConsts().filename, index, Vec2f(16, 16));
-	// this.server_setTeamNum(0); // blue fishy like in sprite sheet
 
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -25,7 +25,7 @@ void onRender(CSprite@ this)
 		return;
 
 	CBlob@ blob = this.getBlob();
-	Vec2f center = blob.getPosition();
+	Vec2f center = blob.getInterpolatedPosition();
 	Vec2f mouseWorld = getControls().getMouseWorldPos();
 	const f32 renderRadius = (blob.getRadius()) * 0.95f;
 	bool mouseOnBlob = (mouseWorld - center).getLength() < renderRadius;

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -49,7 +49,7 @@ void onRender(CSprite@ this)
 
 	blob.Sync("healer", true);
 
-	string foodOwnership = "Owner: " + blob.get_string("owner");
+	string foodOwnership = "Owner: " + healerName;
 
 	if (mouseOnBlob && getLocalPlayerBlob() !is null && blob.getTeamNum() == getLocalPlayerBlob().getTeamNum() && !blob.isInInventory())
 	{

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -15,7 +15,26 @@ void onInit(CBlob@ this)
 
 	this.getSprite().SetFrameIndex(index);
 	this.SetInventoryIcon(this.getSprite().getConsts().filename, index, Vec2f(16, 16));
-	this.server_setTeamNum(0); // blue fishy like in sprite sheet
+	// this.server_setTeamNum(0); // blue fishy like in sprite sheet
 
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
+}
+
+void onRender(CSprite@ this)
+{
+	if (g_videorecording)
+		return;
+
+	CBlob@ blob = this.getBlob();
+	Vec2f center = blob.getPosition();
+	Vec2f mouseWorld = getControls().getMouseWorldPos();
+	const f32 renderRadius = (blob.getRadius()) * 0.95f;
+	bool mouseOnBlob = (mouseWorld - center).getLength() < renderRadius;
+	string foodOwner = "Owner: " + blob.get_string("owner");
+
+	if (mouseOnBlob && getLocalPlayerBlob() !is null && blob.getTeamNum() == getLocalPlayerBlob().getTeamNum() && !blob.isInInventory())
+	{
+		GUI::SetFont("menu");
+		GUI::DrawTextCentered(foodOwner, blob.getScreenPos() + Vec2f(0, -30), color_white);
+	}
 }

--- a/Entities/Items/Food/Food.cfg
+++ b/Entities/Items/Food/Food.cfg
@@ -1,7 +1,7 @@
 # Food.cfg
 
 $sprite_factory                                   = generic_sprite
-@$sprite_scripts                                  =
+@$sprite_scripts                                  = Food.as;
 $sprite_texture                                   = Food.png
 s32_sprite_frame_width                            = 16
 s32_sprite_frame_height                           = 16


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Food ownership now works similiarly to mines - the "owner" of a food item is the person who bought it or first picked it up. You also become owner of food items taken from enemies. When somebody in your team picks up your food items, you are still the owner. The point of this PR is that the coins for healing people are given to the person who buys the food, rather than the person that throws food at damaged teammates.

Moreover, you can also see owner of a food item when you hover your mouse over a food item. This works the same as my recent mine PR https://github.com/transhumandesign/kag-base/pull/894