### PR TITLE
Crate changes: pressing space with mines inside, boobytrap when trying to get in with enemy mines

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -766,9 +766,7 @@ bool DumpOutItems(CBlob@ this, float pop_out_speed = 5.0f, Vec2f init_velocity =
 
 		while (inv !is null && (inv.getItemsCount() > target_items_left))
 		{
-			CBlob@ item;
-
-			@item = inv.getItem(item_num);
+			CBlob@ item = inv.getItem(item_num);
 
 			if (!item.hasTag("player") && item.getName() != "mine")
 			{

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -429,7 +429,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBlob@ carrier = this.getAttachments().getAttachmentPointByName("PICKUP").getOccupied();
 		if (carrier !is null)
 		{
-			DumpOutItems(this, 5.0f, carrier.getVelocity(), false, false);
+			DumpOutItems(this, 5.0f, carrier.getVelocity(), false);
 		}
 	}
 }
@@ -745,7 +745,7 @@ CBlob@ getPlayerInside(CBlob@ this)
 	return null;
 }
 
-bool DumpOutItems(CBlob@ this, float pop_out_speed = 5.0f, Vec2f init_velocity = Vec2f_zero, bool dump_player = true, bool dump_mine = true)
+bool DumpOutItems(CBlob@ this, float pop_out_speed = 5.0f, Vec2f init_velocity = Vec2f_zero, bool dump_special = true)
 {
 	bool dumped_anything = false;
 	if (getNet().isClient())
@@ -760,7 +760,6 @@ bool DumpOutItems(CBlob@ this, float pop_out_speed = 5.0f, Vec2f init_velocity =
 	{
 		Vec2f velocity = (init_velocity == Vec2f_zero) ? this.getOldVelocity() : init_velocity;
 		CInventory@ inv = this.getInventory();
-		//u8 target_items_left = dump_player ? 0 : 1;
 		u8 target_items_left = 0;
 		u8 item_num = 0;
 
@@ -782,11 +781,7 @@ bool DumpOutItems(CBlob@ this, float pop_out_speed = 5.0f, Vec2f init_velocity =
 					item.setVelocity(velocity + getRandomVelocity(90, magnitude, 45));
 				}
 			}
-			else if (dump_player && item.hasTag("player"))
-			{
-				this.server_PutOutInventory(item);
-			}
-			else if (dump_mine && item.getName() == "mine")
+			else if (dump_special && (item.hasTag("player") || item.getName() == "mine"))
 			{
 				this.server_PutOutInventory(item);
 			}

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -514,7 +514,7 @@ void onCreateInventoryMenu(CBlob@ this, CBlob@ forBlob, CGridMenu @gridmenu)
 		if (item.getName() == "mine" && item.getTeamNum() != forBlob.getTeamNum())
 		{
 			CBitStream params;
-			params.write_u16(caller.getNetworkID());
+			params.write_u16(forBlob.getNetworkID());
 			params.write_u16(item.getNetworkID());
 			this.SendCommand(this.getCommandID("boobytrap"), params);
 			break;

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -346,10 +346,32 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		}
 		CBlob @caller = getBlobByNetworkID( params.read_u16() );
 
-		if (caller !is null && this.getInventory() !is null) {
-			// We might have to make room
+		if (caller !is null && this.getInventory() !is null) 
+		{
 			CInventory@ inv = this.getInventory();
 			u8 itemcount = inv.getItemsCount();
+
+			// Boobytrap if crate has enemy mine
+			CBlob@ mine = null;
+			for (int i = 0; i < inv.getItemsCount(); i++)
+			{
+				CBlob@ item = inv.getItem(i);
+				if (item.getName() == "mine" && item.getTeamNum() != caller.getTeamNum())
+				{
+					@mine = item;
+					break;
+				}
+			}
+			if (mine !is null)
+			{
+				CBitStream params;
+				params.write_u16(caller.getNetworkID());
+				params.write_u16(mine.getNetworkID());
+				this.SendCommand(this.getCommandID("boobytrap"), params);
+				return;
+			}
+
+			// We might have to make room
 			while (!inv.canPutItem(caller) && itemcount > 0)
 			{
 				// pop out last items until we can put in player or there's nothing left

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -358,17 +358,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				CBlob@ item = inv.getItem(i);
 				if (item.getName() == "mine" && item.getTeamNum() != caller.getTeamNum())
 				{
-					@mine = item;
-					break;
+					CBitStream params;
+					params.write_u16(caller.getNetworkID());
+					params.write_u16(item.getNetworkID());
+					this.SendCommand(this.getCommandID("boobytrap"), params);
+					return;
 				}
-			}
-			if (mine !is null)
-			{
-				CBitStream params;
-				params.write_u16(caller.getNetworkID());
-				params.write_u16(mine.getNetworkID());
-				this.SendCommand(this.getCommandID("boobytrap"), params);
-				return;
 			}
 
 			// We might have to make room
@@ -516,18 +511,14 @@ void onCreateInventoryMenu(CBlob@ this, CBlob@ forBlob, CGridMenu @gridmenu)
 			// Get out of there, can't grab players
 			forBlob.ClearGridMenus();
 		}
-		if (item.getName() == "mine" && item.getTeamNum() != forBlob.getTeamNum())
+		if (item.getName() == "mine" && item.getTeamNum() != caller.getTeamNum())
 		{
-			@mine = item;
+			CBitStream params;
+			params.write_u16(caller.getNetworkID());
+			params.write_u16(item.getNetworkID());
+			this.SendCommand(this.getCommandID("boobytrap"), params);
 			break;
 		}
-	}
-	if (mine !is null)
-	{
-		CBitStream params;
-		params.write_u16(forBlob.getNetworkID());
-		params.write_u16(mine.getNetworkID());
-		this.SendCommand(this.getCommandID("boobytrap"), params);
 	}
 }
 

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -511,7 +511,7 @@ void onCreateInventoryMenu(CBlob@ this, CBlob@ forBlob, CGridMenu @gridmenu)
 			// Get out of there, can't grab players
 			forBlob.ClearGridMenus();
 		}
-		if (item.getName() == "mine" && item.getTeamNum() != caller.getTeamNum())
+		if (item.getName() == "mine" && item.getTeamNum() != forBlob.getTeamNum())
 		{
 			CBitStream params;
 			params.write_u16(caller.getNetworkID());


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Code is probably bad, please review uwu

- Crates are now boobytrapped if they have an enemy mine and you try to get in; the mine instakills you. Previously only opening inventory was boobytrapped (the mine goes up and instantly activates on inventory open, you can avoid it).

- Pressing space with crate in hand no longer dumps mines (previously it was only players) 

