### PR TITLE
Boats collision fix

### DIFF
--- a/Entities/Vehicles/Common/FakeBoatCollision.as
+++ b/Entities/Vehicles/Common/FakeBoatCollision.as
@@ -85,5 +85,5 @@ void onTick(CBlob@ this)
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
-	return !blob.hasTag("fake boat collision") || (blob.hasTag("fake boat collision") && blob.getTeamNum() != this.getTeamNum()) ;
+	return !blob.hasTag("fake boat collision") || blob.getTeamNum() != this.getTeamNum();
 }


### PR DESCRIPTION
READY: this PR is (to the best of your knowledge) ready to be incorporated into the game.

Description
Fixes collison with enemy boats, I guess no one really care about this one anyway.

Steps to Test or Reproduce
one person on server (or localhost):

1.Ram enemy dinghy with longboat without code change, to see that you are unable to brake it*
2.Ram enemy dinghy with longboat with code change, to see that you are able to brake it*

(why dinghy? because one player in longboat can't generate enough speed to "hurt" other boats. )

Some useful information to include:
This change will affect following vehicles in kag: dinghy, longboat, warboat.