### PR TITLE
Fixed issues with bomb selection

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1557,13 +1557,14 @@ void onAddToInventory(CBlob@ this, CBlob@ blob)
 void SetFirstAvailableBomb(CBlob@ this)
 {
 	u8 type = 255;
+	u8 nowType = 255;
 	if (this.exists("bomb type"))
-		type = this.get_u8("bomb type");
+		nowType = this.get_u8("bomb type");
 
 	CInventory@ inv = this.getInventory();
 
-	bool typeReal = (uint(type) < bombTypeNames.length);
-	if (typeReal && inv.getItem(bombTypeNames[type]) !is null)
+	bool typeReal = (uint(nowType) < bombTypeNames.length);
+	if (typeReal && inv.getItem(bombTypeNames[nowType]) !is null)
 		return;
 
 	for (int i = 0; i < inv.getItemsCount(); i++)

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1611,3 +1611,22 @@ bool canHit(CBlob@ this, CBlob@ b)
 	return b.getTeamNum() != this.getTeamNum();
 
 }
+
+void onRemoveFromInventory(CBlob@ this, CBlob@ blob)
+{
+	CheckSelectedBombRemovedFromInventory(this, blob);
+}
+
+void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
+{
+	CheckSelectedBombRemovedFromInventory(this, detached);
+}
+
+void CheckSelectedBombRemovedFromInventory(CBlob@ this, CBlob@ blob)
+{
+	string name = blob.getName();
+	if (bombTypeNames.find(name) > -1 && this.getBlobCount(name) == 0)
+	{
+		SetFirstAvailableBomb(this);
+	}
+}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

* Fixes the issue where you need to press space twice to light a bomb in some situations
* Resolves #879

## Steps to Test or Reproduce

1. Have a regular bomb and a water bomb in your inventory (or any two different bomb types)
2. Select the water bomb
3. Throw the water bomb item on the ground (don't light the bomb)
4. **Old behaviour:**  The water bomb remains selected. Attempting to light a bomb switches to the regular bomb but doesn't light it. You need to press space a second time to light the regular bomb.
**New behaviour:** The regular bomb is immediately switched to. Pressing space once lights the regular bomb.