### PR TITLE
Fix scoreboard username copying while dragging mouse

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -17,6 +17,8 @@ float scrollSpeed = 4.0f;
 float maxMenuWidth = 700;
 float screenMidX = getScreenWidth()/2;
 
+bool mouseWasPressed2 = false;
+
 string[] age_description = {
 	"New Player - Welcome them to the game!",
 	//first month
@@ -143,7 +145,7 @@ float drawScoreboard(CPlayer@ localplayer, CPlayer@[] players, Vec2f topleft, CT
 				setSpectatePlayer(p.getUsername());
 			}
 
-			if (controls.mousePressed2)
+			if (controls.mousePressed2 && !mouseWasPressed2)
 			{
 				// reason for this is because this is called multiple per click (since its onRender, and clicking is updated per tick)
 				// we don't want to spam anybody using a clipboard history program
@@ -501,6 +503,7 @@ float drawScoreboard(CPlayer@ localplayer, CPlayer@[] players, Vec2f topleft, CT
 		DrawFancyCopiedText(rules.get_string("client_copy_name"), rules.get_Vec2f("client_copy_pos"), durationLeft);
 	}
 
+	mouseWasPressed2 = controls.mousePressed2;
 
 	return topleft.y;
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Usernames are now copied on click.
Resolves #871 

## Steps to Test or Reproduce

1. Open scoreboard
2. Drag over players on scoreboard while right clicking
