### PR TITLE
Improved blob highlighting while smooth shader is enabled

### DIFF
--- a/Entities/Characters/Builder/BuilderAnim.as
+++ b/Entities/Characters/Builder/BuilderAnim.as
@@ -245,6 +245,14 @@ void onRender(CSprite@ this)
 			if (!hitBlob.hasTag("flesh"))
 			{
 				hitBlob.RenderForHUD(RenderStyle::outline);
+
+				// hacky fix for shitty z-buffer issue
+				// the sprite layers go out of order while hitting with this fix,
+				// but its better than the entire blob glowing brighter than the sun
+				if (v_postprocess)
+				{
+					hitBlob.RenderForHUD(RenderStyle::normal);
+				}
 			}
 		}
 		else// map hit


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The inline comment sums it up
Partially fixes #776 

<details>
  <summary>Screenshots</summary>
  
  ![image](https://user-images.githubusercontent.com/30195802/94228835-442d5480-ff41-11ea-94a5-cfd1aeb6bfce.png) ![image](https://user-images.githubusercontent.com/30195802/94228906-68893100-ff41-11ea-93f7-8316e33a3776.png)
  
</details>

## Steps to Test or Reproduce

1. Open sandbox
2. Enable smooth shader
3. Chop tree
