### PR TITLE
Fixed kaggen sometimes generating blocks inside flag

### DIFF
--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -51,6 +51,15 @@ void onTick(CBlob@ this)
 
 				map.server_AddSector(pos + Vec2f(-12, -32), pos + Vec2f(12, 16), "no build", "", this.getNetworkID());
 
+				//clear the no build zone so we dont get unbreakable blocks
+				for (int x = -12; x < 12; x += 8)
+				{
+					for (int y = -32; y < 8; y += 8)
+					{
+						map.server_SetTile(pos + Vec2f(x, y), CMap::tile_empty);
+					}
+				}
+
 				map.server_SetTile(pos + Vec2f(-8, 12), CMap::tile_bedrock);
 				map.server_SetTile(pos + Vec2f(0, 12), CMap::tile_bedrock);
 				map.server_SetTile(pos + Vec2f(8, 12), CMap::tile_bedrock);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This clears the flag of blocks when the flag's build sector is added.

## Steps to Test or Reproduce

My method:
1. Using code, set the corner tiles of the flag's build sector to any block before the code in this PR
2. Load any CTF map to see that these blocks were removed

Alternative method:
1. Make a CTF map with blocks inside the flag
2. Load the map