### PR TITLE
Fixed several attachment bugs

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -1107,3 +1107,18 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 		}
 	}
 }
+
+void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
+{
+	ArcherInfo@ archer;
+	if (!this.get("archerInfo", @archer))
+	{
+		return;
+	}
+
+	if (canSend(this))
+	{
+		archer.grappling = false;
+		SyncGrapple(this);
+	}
+}

--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -225,7 +225,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			return;
 
 		CBlob@ caller = getBlobByNetworkID(caller_id);
-		if (caller !is null)
+		if (caller !is null && !caller.isAttached())
 		{
 			AttachmentPoint@ bed = this.getAttachments().getAttachmentPointByName("BED");
 			if (bed !is null && bedAvailable(this))

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -139,21 +139,10 @@ void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 		//if (isKnockable(caller) && caller.get_u8("knocked") > 0)
 		//	return;
 
-		if (caller.isAttached())   // attached - like sitting in cata? move whole cata
-		{
-			const int count = caller.getAttachmentPointCount();
-			for (int i = 0; i < count; i++)
-			{
-				AttachmentPoint @ap = caller.getAttachmentPoint(i);
-				CBlob@ occBlob = ap.getOccupied();
-				if (occBlob !is null)
-				{
-					occBlob.setPosition(tunnel.getPosition());
-					occBlob.setVelocity(Vec2f_zero);
-					//occBlob.getShape().PutOnGround();
-				}
-			}
-		}
+		//dont travel if caller is attached to something (e.g. siege)
+		if (caller.isAttached())
+			return;
+
 		// move caller
 		caller.setPosition(tunnel.getPosition());
 		caller.setVelocity(Vec2f_zero);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

* Fixed being able to sleep in quarters while attached.
  * This fixes being able to drive a siege while sleeping in a quarters by sitting on the siege right before sleeping.
* Fixed travelling through tunnels while attached.
  * This fixes siege teleporting with you if you hop on it right before teleporting.
* Fixed archer grapple staying extended while attached.
  * This fixes being able to grapple right after sitting on a siege, and the grapple stays extended as you drive the siege.

Resolves #599 

## Steps to Test or Reproduce

* Press down to sit in a siege right before attempting to sleep in a quarters.
* Press down to sit in a siege right before attempting to travel through the tunnel.
* Press down to sit in a siege right before attempting to grapple.
