### PR TITLE
Siege no longer shoots if gunner leaves while charging

### DIFF
--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -13,8 +13,6 @@ const u8 charge_contrib = 35;
 const u8 cooldown_time = 45;
 const u8 startStone = 100;
 
-bool hadAttached = false;
-
 void onInit(CBlob@ this)
 {
 	Vehicle_Setup(this,
@@ -55,6 +53,8 @@ void onInit(CBlob@ this)
 
 	this.set_string("autograb blob", "mat_stone");
 
+	this.set_bool("had_attached", false);
+
 	// auto-load on creation
 	if (getNet().isServer())
 	{
@@ -75,6 +75,7 @@ void onTick(CBlob@ this)
 {
 	const int time = this.getTickSinceCreated();
 	const bool hasAttached = this.hasAttached();
+	const bool hadAttached = this.get_bool("had_attached");
 
 	VehicleInfo@ v;
 	if (!this.get("VehicleInfo", @v))
@@ -136,7 +137,7 @@ void onTick(CBlob@ this)
 	else if (time % 30 == 0)
 		Vehicle_StandardControls(this, v); //just make sure it's updated
 
-	hadAttached = hasAttached;
+	this.set_bool("had_attached", hasAttached);
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -13,6 +13,8 @@ const u8 charge_contrib = 35;
 const u8 cooldown_time = 45;
 const u8 startStone = 100;
 
+bool hadAttached = false;
+
 void onInit(CBlob@ this)
 {
 	Vehicle_Setup(this,
@@ -72,6 +74,7 @@ void onInit(CBlob@ this)
 void onTick(CBlob@ this)
 {
 	const int time = this.getTickSinceCreated();
+	const bool hasAttached = this.hasAttached();
 
 	VehicleInfo@ v;
 	if (!this.get("VehicleInfo", @v))
@@ -80,7 +83,8 @@ void onTick(CBlob@ this)
 	const u16 delay = float(v.fire_delay);
 	const f32 time_til_fire = Maths::Max(0, Maths::Min(v.fire_time - getGameTime(), delay));
 
-	if (this.hasAttached() || time < 30 || time_til_fire > 0) //driver, seat or gunner, or just created
+	// hadAttached is here so it sets the arm angle the tick after the last player detaches
+	if (hasAttached || hadAttached || time < 30 || time_til_fire > 0) //driver, seat or gunner, or just created
 	{
 		// load new item if present in inventory
 		Vehicle_StandardControls(this, v);
@@ -131,6 +135,8 @@ void onTick(CBlob@ this)
 	}
 	else if (time % 30 == 0)
 		Vehicle_StandardControls(this, v); //just make sure it's updated
+
+	hadAttached = hasAttached;
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -972,14 +972,10 @@ void Vehicle_onDetach(CBlob@ this, VehicleInfo@ v, CBlob@ detached, AttachmentPo
 
 	if (detached.hasTag("player") && attachedPoint.socket)
 	{
-
-		// Fires on detach. Blame Fuzzle.
-		if (attachedPoint.name == "GUNNER" && v.charge > 0)
+		// reset charge if gunner leaves while charging
+		if (attachedPoint.name == "GUNNER")
 		{
-			CBitStream params;
-			params.write_u16(detached.getNetworkID());
-			params.write_u8(v.charge);
-			this.SendCommand(this.getCommandID("fire"), params);
+			v.charge = 0;
 		}
 
 		detached.setPosition(detached.getPosition() + Vec2f(0.0f, -4.0f));


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Now the charge is reset when the gunner leaves mid charge. The catapult arm correctly retracts as well.

## Steps to Test or Reproduce

1. Sit in gunner seat of siege
2. Hold left click to charge
3. Press up to leave mid charge