### PR TITLE
Fixed knight slash not being reset when sitting on a siege

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1523,6 +1523,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @ap)
 		knight.state = KnightStates::normal; //cancel any attacks or shielding
 		knight.swordTimer = 0;
 		knight.doubleslash = false;
+		this.set_s32("currentKnightState", 0);
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Without this, you are able to immediately slash when exiting a siege.

## Steps to Test or Reproduce

1. Charge a slash
2. Release the slash
3. Immediately sit in a siege
4. Get out of the siege