### PR TITLE
Fixed accolades overlapping username

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -83,7 +83,7 @@ float drawScoreboard(CPlayer@ localplayer, CPlayer@[] players, Vec2f topleft, CT
 
 	topleft.y += stepheight * 2;
 
-	const int accolades_start = 740;
+	const int accolades_start = 770;
 	const int age_start = accolades_start + 80;
 
 	draw_age = false;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

It's about time this was fixed!

![image](https://user-images.githubusercontent.com/30195802/94792267-0f773c80-041c-11eb-91b3-39e1ed635060.png)


## Steps to Test or Reproduce

1. Be good at tournaments
2. Open scoreboard