### PR TITLE
Fixed fire arrows setting siege on fire inconsistently

### DIFF
--- a/Entities/Common/FireScripts/IsFlammable.as
+++ b/Entities/Common/FireScripts/IsFlammable.as
@@ -23,7 +23,7 @@ void onInit(CBlob@ this)
 
 f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
 {
-	if ((isIgniteHitter(customData) && damage > 0.0f) ||					 	   // Fire arrows
+	if (isIgniteHitter(customData) ||					 	   // Fire arrows
 	        (this.isOverlapping(hitterBlob) &&
 	         hitterBlob.isInFlames() && !this.isInFlames()))	   // Flaming enemy
 	{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes fire arrows setting siege on fire only some of the time. I am unsure if my fix will cause any unintended side effects.

Resolves #875 

## Steps to Test or Reproduce

Shoot an enemy siege with a fire arrow