### PR TITLE
[fixed] Fixed doors not showing destruction visuals after bomb damage

### DIFF
--- a/Entities/Structures/Door/SwingDoor.as
+++ b/Entities/Structures/Door/SwingDoor.as
@@ -185,10 +185,9 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 		if (destruction_anim !is null)
 		{
-			if (this.getHealth() < this.getInitialHealth())
+			if ((this.getHealth() - damage) < this.getInitialHealth())
 			{
 				f32 ratio = (this.getHealth() - damage * getRules().attackdamage_modifier) / this.getInitialHealth();
-
 
 				if (ratio <= 0.0f)
 				{


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

- Fixes a bug where doors wouldn't show destruction visuals after being open and closed after a previous bomb impact.
- Resolves #881

## Steps to Test or Reproduce
1. Build a door.
2. Throw a bomb to the door.
