### PR TITLE
[fixed] Fixed a bug where bow could charge even after all arrows were throw away

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -449,7 +449,20 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		}
 		else if (charge_state == ArcherParams::charging)
 		{
-			charge_time++;
+			if(!hasarrow)
+			{
+				charge_state = ArcherParams::no_arrows;
+				charge_time = 0;
+				
+				if (ismyplayer)   // playing annoying no ammo sound
+				{
+					this.getSprite().PlaySound("Entities/Characters/Sounds/NoAmmo.ogg", 0.5);
+				}
+			}
+			else
+			{
+				charge_time++;
+			}
 
 			if (charge_time >= ArcherParams::legolas_period)
 			{


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
- Fixes a bug where archer could bow charge even after all arrows were throw away.
- Resolves #925

## Steps to Test or Reproduce
1. Start bow charge.
2. Drop all arrows.
3. Bow charge is cancelled.

Some useful information to include:

Before:
![before](https://user-images.githubusercontent.com/31360716/95659530-4ff34c00-0ae7-11eb-874c-7c76c0f9ab18.gif)

After:
![after](https://user-images.githubusercontent.com/31360716/95659536-597cb400-0ae7-11eb-8760-97f9fcd47b02.gif)


