### PR TITLE
Fixed being able to place blocks in no build sectors

### DIFF
--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -18,10 +18,16 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 	CBitStream missing;
 
 	CInventory@ inv = this.getInventory();
-	if (bc.tile > 0 && hasRequirements(inv, bc.reqs, missing))
+	CMap@ map = getMap();
+
+	bool sameTile;
+	Vec2f tileCenter = cursorPos + Vec2f(map.tilesize, map.tilesize) / 2.0f;
+	bool buildable = isBuildableAtPos(this, tileCenter, bc.tile, null, sameTile);
+
+	if (bc.tile > 0 && hasRequirements(inv, bc.reqs, missing) && buildable)
 	{
 		server_TakeRequirements(inv, bc.reqs);
-		getMap().server_SetTile(cursorPos, bc.tile);
+		map.server_SetTile(cursorPos, bc.tile);
 
 		SendGameplayEvent(createBuiltBlockEvent(this.getPlayer(), bc.tile));
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

How people are able to bypass the client buildable check is a mystery to me, but I know this fix will fix this. I just added the same client-side buildable check to server-side.

Resolves #588 

## Steps to Test or Reproduce

1. Replace PlacementCommon.as line 140 with `return isClient();` so you can place blocks in no build sectors on the client but not on the server.
2. Attempt to place a block inside a no build sector (e.g. tent or flag).