### PR TITLE
Catapult rocks are shieldable

### DIFF
--- a/Entities/Common/Attacks/KnockBack.as
+++ b/Entities/Common/Attacks/KnockBack.as
@@ -41,6 +41,9 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		case Hitters::arrow:
 			scale = 0.0f; break;
 
+		case Hitters::cata_stones:
+			scale = 0.25f; break;
+
 		default: break;
 	}
 

--- a/Entities/Common/Attacks/ShieldHit.as
+++ b/Entities/Common/Attacks/ShieldHit.as
@@ -14,6 +14,7 @@ bool canBlockThisType(u8 type) // this function needs to use a tag on the hitter
 	       type == Hitters::arrow ||
 	       type == Hitters::bite ||
 	       type == Hitters::stab ||
+	       type == Hitters::cata_stones ||
 	       isExplosionHitter(type);
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Title. It's the only widely used projectile/item with decent destructive ability that you cant really defend against without spamming blocks a lot