### PR TITLE
Fixed incorrect GUI:: namespace for AddIconToken

### DIFF
--- a/Entities/Common/Scripts/TeamIconToken.as
+++ b/Entities/Common/Scripts/TeamIconToken.as
@@ -11,7 +11,7 @@ string getTeamIcon(string icon, string file_name, int team_num, Vec2f frame_size
 		return team_icon_name;
 	}
 
-	GUI::AddIconToken(team_icon_name, file_name, frame_size, frame_num, team_num);
+	AddIconToken(team_icon_name, file_name, frame_size, frame_num, team_num);
 	return team_icon_name;
 
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This would cause issues on staging because of the different AS version. It looks like the vanilla version of KAG has an AS version that incorrectly allows to use a namespace prefix for a function that is not located within a namespace.

This will be worked around in staging for the time being by declaring said functions inside of the `GUI::` namespace as part of the `g_allowdeprecated` retrocompatibility set for now.