### PR TITLE
[Fix] Added cap on knightlogic set quantity to stop underflows

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1245,7 +1245,11 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 						{
 							int quantity = Maths::Ceil(float(damage) * 20.0f);
 							int max_quantity = b.getHealth() / 0.024f; // initial log health / max mats
-							quantity = Maths::Min(quantity, max_quantity);
+							
+							quantity = Maths::Max(
+								Maths::Min(quantity, max_quantity),
+								0
+							);
 
 							wood.Tag('custom quantity');
 							wood.Init();


### PR DESCRIPTION
This prevents the bug where a lot of wood spawns out of nowhere.

An engine side fix is also on its way to include a warning on what file is causing this to happen.

Log from test server with engine side patch
```
(ignore the broken name below)
[15:07:43] ﾰ-!_￙-!_ￚ-!_ called server_SetQuantity with value -5, please make sure its within 0 and 65535.
Value has been set to 0.
[15:07:43] 
[15:07:43] 
[15:07:43] PRINTING SCRIPT EXECUTION TRACE
[15:07:43] Tip: You can fetch callstack and scriptstack info from string[]@ getCallStack() and string[]@ getScriptStack().
[15:07:43] 
[15:07:43] Callstack for current script: knightlogic
[15:07:43] #1: void DoAttack(CBlob@ this, float damage, float aimangle, float arcdegrees, uint8 type, int deltaInt, KnightInfo@ info)
[15:07:43] #2: bool SlashState::TickState(CBlob@ this, KnightInfo@ knight, RunnerMoveVars@ moveVars)
[15:07:43] #3: void RunStateMachine(CBlob@ this, KnightInfo@ knight, RunnerMoveVars@ moveVars)
[15:07:43] #4: void onTick(CBlob@ this)
[15:07:43] 
[15:07:43] Script stack (nested script execution, i.e. when causing hook calls from hooks):
[15:07:43] #1: knightlogic
[15:07:43] 
```