### PR TITLE
Tweaking archer aiming and arrow bbox

### DIFF
--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -237,10 +237,7 @@ void onTick(CSprite@ this)
 	bool knocked = isKnocked(blob);
 	Vec2f pos = blob.getPosition() + Vec2f(0, -2);
 	Vec2f aimpos = blob.getAimPos();
-	if (this.isFacingLeft())
-		pos.x += 2;
-	else
-		pos.x -= 2;
+	pos.x += this.isFacingLeft() ? 2 : -2;
 
 	// get the angle of aiming with mouse
 	Vec2f vec = aimpos - pos;

--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -10,7 +10,7 @@
 #include "Accolades.as"
 
 
-const f32 config_offset = -4.0f;
+const f32 config_offset = -6.0f;
 const string shiny_layer = "shiny bit";
 
 void onInit(CSprite@ this)
@@ -235,8 +235,13 @@ void onTick(CSprite@ this)
 	bool crouch = false;
 
 	bool knocked = isKnocked(blob);
-	Vec2f pos = blob.getPosition();
+	Vec2f pos = blob.getPosition() + Vec2f(0, -2);
 	Vec2f aimpos = blob.getAimPos();
+	if (this.isFacingLeft())
+		pos.x += 2;
+	else
+		pos.x -= 2;
+
 	// get the angle of aiming with mouse
 	Vec2f vec = aimpos - pos;
 	f32 angle = vec.Angle();

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -797,16 +797,8 @@ void ClientFire(CBlob@ this, const s8 charge_time, const bool hasarrow, const u8
 			arrowspeed = ArcherParams::shoot_max_vel;
 		}
 
-		Vec2f offset;
-		if (this.isFacingLeft()) 
-		{
-			offset.x = 2;
-		} 
-		else
-		{
-			offset.x = -2;
-		}
-		ShootArrow(this, this.getPosition() + Vec2f(0.0f, -2.0f) + offset, this.getAimPos(), arrowspeed, arrow_type, legolas);
+		Vec2f offset(this.isFacingLeft() ? 2 : -2, -2);
+		ShootArrow(this, this.getPosition() + offset, this.getAimPos(), arrowspeed, arrow_type, legolas);
 	}
 }
 

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -797,7 +797,16 @@ void ClientFire(CBlob@ this, const s8 charge_time, const bool hasarrow, const u8
 			arrowspeed = ArcherParams::shoot_max_vel;
 		}
 
-		ShootArrow(this, this.getPosition() + Vec2f(0.0f, -2.0f), this.getAimPos() + Vec2f(0.0f, -2.0f), arrowspeed, arrow_type, legolas);
+		Vec2f offset;
+		if (this.isFacingLeft()) 
+		{
+			offset.x = 2;
+		} 
+		else
+		{
+			offset.x = -2;
+		}
+		ShootArrow(this, this.getPosition() + Vec2f(0.0f, -2.0f) + offset, this.getAimPos(), arrowspeed, arrow_type, legolas);
 	}
 }
 

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -541,7 +541,7 @@ void ArrowHitMap(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, u8 c
 
 	Vec2f norm = velocity;
 	norm.Normalize();
-	norm *= (1.0f * radius);
+	norm *= (1.5f * radius);
 	Vec2f lock = worldPoint - norm;
 	this.set_Vec2f("lock", lock);
 

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -541,7 +541,7 @@ void ArrowHitMap(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, u8 c
 
 	Vec2f norm = velocity;
 	norm.Normalize();
-	norm *= (1.5f * radius);
+	norm *= (1.0f * radius);
 	Vec2f lock = worldPoint - norm;
 	this.set_Vec2f("lock", lock);
 

--- a/Entities/Items/Projectiles/Arrow.cfg
+++ b/Entities/Items/Projectiles/Arrow.cfg
@@ -11,7 +11,7 @@ $sprite_texture                = Arrow.png
 s32_sprite_frame_width         = 16
 s32_sprite_frame_height        = 8
 f32 sprite_offset_x            = 0
-f32 sprite_offset_y            = 0
+f32 sprite_offset_y            = 0.5
 
 $sprite_gibs_start                     = *start*
 $sprite_gibs_end                       = *end*
@@ -43,7 +43,10 @@ bool shape_collides            = yes
 bool shape_ladder              = no
 bool shape_platform            = no
  #block_collider
-@f32 verticesXY                =
+@f32 verticesXY                = 8; 1;
+                                 14; 1;
+                                 14; 4;
+                                 8; 4;
 u8 block_support               = 0
 bool block_background          = no
 bool block_lightpasses         = no

--- a/Entities/Items/Projectiles/Arrow.cfg
+++ b/Entities/Items/Projectiles/Arrow.cfg
@@ -44,8 +44,8 @@ bool shape_ladder              = no
 bool shape_platform            = no
  #block_collider
 @f32 verticesXY                = 8; 1;
-                                 14; 1;
-                                 14; 4;
+                                 13; 1;
+                                 13; 4;
                                  8; 4;
 u8 block_support               = 0
 bool block_background          = no


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.


## Description

Improves archer aiming and arrow bbox. Will make it easier to shoot through gaps, and will be less confusing for (new) players.

- moved archer bow 2px up to align with arrow spawn. This was originally chosen to make it easy to shoot over level blocks, now the bow should be on the same level.
- align *arrow spawn* better when aiming up/down. The bow animation is out-of-center horizontally. This is most notabily when aiming up and down
- arrow bbox now rectangle to fit better in between blocks

## Steps to Test or Reproduce

Mostly try shooting in between small gaps. The arrow on the bow animation should be a better indicator if you can shoot through. Water arrows should still stun behind 2 layer walls.

