### PR TITLE
[Fix] Null fix that occours on join

### DIFF
--- a/Entities/Characters/MovementScripts/RunnerMovement.as
+++ b/Entities/Characters/MovementScripts/RunnerMovement.as
@@ -796,7 +796,7 @@ bool checkForSolidMapBlob(CMap@ map, Vec2f pos, CBlob@ blob = null)
 		@_tempShape = _tempBlob.getShape();
 		if (_tempShape.isStatic())
 		{
-			if (_tempBlob.getName() == "wooden_platform" || _tempBlob.getName() == "bridge")
+			if (blob !is null && (_tempBlob.getName() == "wooden_platform" || _tempBlob.getName() == "bridge"))
 			{
 				f32 angle = _tempBlob.getAngleDegrees();
 				Vec2f runnerPos = blob.getPosition();


### PR DESCRIPTION

User logs:
```
[22:38:28] Loaded texture: C:/Program Files (x86)/Steam/steamapps/common/King Arthur's Gold/Base/Entities/Characters/Knight/KnightGibs.png
[22:38:30] Script: Exception occurred while executing 'Entities/Characters/MovementScripts/RunnerMovement.as'; Line 802 Column 5; in function: bool checkForSolidMapBlob(CMap@ map, Vec2f pos, CBlob@ blob = null)
Null pointer access
[22:38:30] 
[22:38:30] 
[22:38:30] PRINTING SCRIPT EXECUTION TRACE
[22:38:30] Tip: You can fetch callstack and scriptstack info from string[]@ getCallStack() and string[]@ getScriptStack().
[22:38:30] 
[22:38:30] Callstack for current script: runnermovement
[22:38:30] #1: bool checkForSolidMapBlob(CMap@ map, Vec2f pos, CBlob@ blob = null)
[22:38:30] #2: bool canVault(CBlob@ blob, CMap@ map, float movingside)
[22:38:30] #3: void onTick(CMovement@ this)
[22:38:30] 
[22:38:30] Script stack (nested script execution, i.e. when causing hook calls from hooks):
[22:38:30] #1: runnermovement
[22:38:30] 
[22:38:32] Script: Exception occurred while executing 'Entities/Common/Movement/FaceAimPosition.as'; Line 12 Column 2; in function: void onTick(CMovement@ this)
Null pointer access
[22:38:32] 
[22:38:32] 
[22:38:32] PRINTING SCRIPT EXECUTION TRACE
[22:38:32] Tip: You can fetch callstack and scriptstack info from string[]@ getCallStack() and string[]@ getScriptStack().
[22:38:32] 
[22:38:32] Callstack for current script: faceaimposition
[22:38:32] #1: void onTick(CMovement@ this)
[22:38:32] 
[22:38:32] Script stack (nested script execution, i.e. when causing hook calls from hooks):
[22:38:32] #1: faceaimposition
[22:38:32] 
[22:38:32] Script: Exception occurred while executing 'Entities/Common/FireScripts/HOTHOTHOT.as'; Line 14 Column 2; in function: void onTick(CMovement@ this)
Null pointer access
[22:38:32] 
[22:38:32] 
[22:38:32] PRINTING SCRIPT EXECUTION TRACE
[22:38:32] Tip: You can fetch callstack and scriptstack info from string[]@ getCallStack() and string[]@ getScriptStack().
[22:38:32] 
[22:38:32] Callstack for current script: hothothot
[22:38:32] #1: void onTick(CMovement@ this)
[22:38:32] 
[22:38:32] Script stack (nested script execution, i.e. when causing hook calls from hooks):
[22:38:32] #1: hothothot
[22:38:32] 
```
