### PR TITLE
[Change] Added some basic mod compatibility 

### DIFF
--- a/Entities/Characters/Knight/KnightCommon.as
+++ b/Entities/Characters/Knight/KnightCommon.as
@@ -36,6 +36,12 @@ namespace KnightVars
 	const ::f32 slash_move_max_speed = 3.5f;
 
 	const u32 glide_down_time = 50;
+
+	//// OLD MOD COMPATIBILITY ////
+	// These have no purpose in the current code base other then
+	// to allow old mods to still run without needing manual fixing
+	const u8 shieldTimer = 0;
+	const f32 resheath_time = 2.0f;
 }
 
 shared class KnightInfo

--- a/Entities/Characters/Knight/KnightCommon.as
+++ b/Entities/Characters/Knight/KnightCommon.as
@@ -40,7 +40,6 @@ namespace KnightVars
 	//// OLD MOD COMPATIBILITY ////
 	// These have no purpose in the current code base other then
 	// to allow old mods to still run without needing manual fixing
-	const u8 shieldTimer = 0;
 	const f32 resheath_time = 2.0f;
 }
 
@@ -54,6 +53,9 @@ shared class KnightInfo
 	u8 state;
 	Vec2f slash_direction;
 	s32 shield_down;
+
+	//// OLD MOD COMPATIBILITY ////
+	u8 shieldTimer;
 };
 
 shared class KnightState


### PR DESCRIPTION
This is a common error in a lot of mods that edit KnightLogic.as without also replacing KnightCommon.as
Just by adding these 2 var's, it fixes issues with a lot of older mods, without breaking anything vanilla side.

The question is, should we even consider doing stuff like this for mod compatibility.

```
              ---- KnightCommon.as ----
	//// OLD MOD COMPATIBILITY ////
	// These have no purpose in the current code base other then
	// to allow old mods to still run without needing manual fixing
	const u8 shieldTimer = 0;
	const f32 resheath_time = 2.0f;
```
