### PR TITLE
[Addition] Spectator support

### DIFF
--- a/Rules/CommonScripts/CoreHooks.as
+++ b/Rules/CommonScripts/CoreHooks.as
@@ -5,6 +5,7 @@
 //Make sure you dont forget JoinCoreHooks! :)
 
 #include "GameplayEvents.as"
+#include "SwitchFromSpec.as"
 
 //not server only so that all the players get this
 void onInit(CRules@ this)
@@ -60,6 +61,9 @@ void onPlayerRequestSpawn(CRules@ this, CPlayer@ player)
 void onPlayerRequestTeamChange(CRules@ this, CPlayer@ player, u8 newteam)
 {
 	if (!getNet().isServer())
+		return;
+
+	if (!CanSwitchFromSpec(this, player, newteam))
 		return;
 
 	if (!this.get_bool("managed teams"))

--- a/Rules/CommonScripts/CoreHooks.as
+++ b/Rules/CommonScripts/CoreHooks.as
@@ -65,7 +65,7 @@ void onPlayerRequestTeamChange(CRules@ this, CPlayer@ player, u8 newteam)
 
 	if (!CanSwitchFromSpec(this, player, newteam))
 	{
-		player.server_setTeamNum(this.getSpectatorTeam());
+		player.server_setTeamNum(this.getSpectatorTeamNum());
 		return;
 	}
 

--- a/Rules/CommonScripts/CoreHooks.as
+++ b/Rules/CommonScripts/CoreHooks.as
@@ -64,7 +64,10 @@ void onPlayerRequestTeamChange(CRules@ this, CPlayer@ player, u8 newteam)
 		return;
 
 	if (!CanSwitchFromSpec(this, player, newteam))
+	{
+		player.server_setTeamNum(this.getSpectatorTeam());
 		return;
+	}
 
 	if (!this.get_bool("managed teams"))
 	{

--- a/Rules/CommonScripts/PatronSupport.as
+++ b/Rules/CommonScripts/PatronSupport.as
@@ -1,18 +1,33 @@
+#define SERVER_ONLY
+
 //implementation of patron-related rules-side extra functionality
 
 //extra patron slots handling
 const int PATRON_EXTRA_SLOTS = 2;
 int onProcessFullJoin(CRules@ this, APIPlayer@ user)
 {
+	this.set_u16("supportTier " + user.username, user.supportTier);
+
 	//allow royal guard and up supporters in
 	if(
 		//user is good supporter
 		user.supportTier >= SUPPORT_TIER_ROYALGUARD
 		//not up to the extra slots yet
-		&& getPlayersCount() < (sv_maxplayers + PATRON_EXTRA_SLOTS)
+		&& getPlayersCount() < (getNet().joined_maxplayers + PATRON_EXTRA_SLOTS)
 	) {
 		return 1;
 	}
 	//ignore otherwise
 	return -1;
+}
+
+// If a patreon joins and is on spec team, lets sort this out
+void onNewPlayerJoin( CRules@ this, CPlayer@ player )
+{
+	if (this.get_u16("supportTier " + player.getUsername()) >= SUPPORT_TIER_ROYALGUARD && // if we are high enough in the tier list
+		this.getSpectatorTeamNum() == player.getTeamNum() && // and we are a spectator
+		getPlayersNum_NotSpectator() + PATRON_EXTRA_SLOTS <= getNet().joined_maxplayers) // and there are still free slots for us
+	{
+		player.server_setTeamNum(255); // server will auto balance them
+	}
 }

--- a/Rules/CommonScripts/PatronSupport.as
+++ b/Rules/CommonScripts/PatronSupport.as
@@ -13,7 +13,7 @@ int onProcessFullJoin(CRules@ this, APIPlayer@ user)
 		//user is good supporter
 		user.supportTier >= SUPPORT_TIER_ROYALGUARD
 		//not up to the extra slots yet
-		&& getPlayersCount() < (getNet().joined_maxplayers + PATRON_EXTRA_SLOTS)
+		&& getPlayersCount() < (sv_maxplayers + PATRON_EXTRA_SLOTS)
 	) {
 		return 1;
 	}
@@ -26,7 +26,7 @@ void onNewPlayerJoin( CRules@ this, CPlayer@ player )
 {
 	if (this.get_u16("supportTier " + player.getUsername()) >= SUPPORT_TIER_ROYALGUARD && // if we are high enough in the tier list
 		this.getSpectatorTeamNum() == player.getTeamNum() && // and we are a spectator
-		getPlayersNum_NotSpectator() + PATRON_EXTRA_SLOTS <= getNet().joined_maxplayers) // and there are still free slots for us
+		getPlayersCount_NotSpectator() + PATRON_EXTRA_SLOTS <= sv_maxplayers) // and there are still free slots for us
 	{
 		player.server_setTeamNum(255); // server will auto balance them
 	}

--- a/Rules/CommonScripts/SwitchFromSpec.as
+++ b/Rules/CommonScripts/SwitchFromSpec.as
@@ -1,0 +1,17 @@
+bool CanSwitchFromSpec(CRules@ this, CPlayer@ player, u8 toTeam)
+{
+    int maxPlayers = getNet().joined_maxplayers;
+    int reservedSlots = getNet().joined_reservedslots;
+    int playerCountNotSpec = getPlayersCount_NotSpectator(); 
+    u8 specTeamNum = this.getSpectatorTeamNum();
+
+    bool canSwitch = playerCountNotSpec < maxPlayers;
+    
+    if (canSwitch || player.getTeamNum() != specTeamNum  || toTeam == specTeamNum || player.isMod() ||
+        getSecurity().checkAccess_Feature(player, "join_reserved") && maxPlayers + reservedSlots < playerCountNotSpec)
+    {
+        return true;
+    }
+
+    return false;
+}

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -75,7 +75,7 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 
 	if (player is getLocalPlayer())
 	{
-		bool canSwitch = !(getPlayersNum_NotSpectator() <= getNet().joined_maxplayers);
+		bool canSwitch = !(getPlayersCount_NotSpectator() <= getNet().joined_maxplayers);
 		
 		if (canSwitch || team == this.getSpectatorTeamNum())
 		{

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -74,19 +74,23 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 
 	if (player is getLocalPlayer())
 	{
-		bool canSwitch = !(getPlayersCount_NotSpectator() <= getNet().joined_maxplayers);
+		bool canSwitch = getPlayersCount_NotSpectator() < getNet().joined_maxplayers;
 		
-		if (canSwitch || team == this.getSpectatorTeamNum())
+		if (canSwitch || player.getTeamNum() != this.getSpectatorTeamNum() || team == this.getSpectatorTeamNum())
 		{
-			player.client_ChangeTeam(team);
-			getHUD().ClearMenus();
+			ChangeTeam(player, team);
 		}
 		else
 		{
-			print("no room"); // TODO: Print sound
+			Sound::Play("NoAmmo.ogg");
 		}
-		
 	}
+}
+
+void ChangeTeam(CPlayer@ player, u8 team)
+{
+	player.client_ChangeTeam(team);
+	getHUD().ClearMenus();
 }
 
 void onCommand(CRules@ this, u8 cmd, CBitStream @params)

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -82,6 +82,7 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 		}
 		else
 		{
+			client_AddToChat("Game is currently full. Please wait for a new slot before switching teams.", ConsoleColour::GAME);
 			Sound::Play("NoAmmo.ogg");
 		}
 	}

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -5,7 +5,6 @@ const int BUTTON_SIZE = 4;
 void onInit(CRules@ this)
 {
 	this.addCommandID("pick teams");
-	this.addCommandID("pick spectator");
 	this.addCommandID("pick none");
 
 	AddIconToken("$BLUE_TEAM$", "GUI/TeamIcons.png", Vec2f(96, 96), 0);
@@ -50,7 +49,7 @@ void ShowTeamMenu(CRules@ this)
 					CBitStream params;
 					params.write_u16(getLocalPlayer().getNetworkID());
 					params.write_u8(this.getSpectatorTeamNum());
-					CGridButton@ button2 = menu.AddButton("$SPECTATOR$", getTranslatedString("Spectator"), this.getCommandID("pick spectator"), Vec2f(BUTTON_SIZE / 2, BUTTON_SIZE), params);
+					CGridButton@ button2 = menu.AddButton("$SPECTATOR$", getTranslatedString("Spectator"), this.getCommandID("pick teams"), Vec2f(BUTTON_SIZE / 2, BUTTON_SIZE), params);
 				}
 				icon = "$RED_TEAM$";
 				name = "Red Team";
@@ -93,10 +92,6 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("pick teams"))
-	{
-		ReadChangeTeam(this, params);
-	}
-	else if (cmd == this.getCommandID("pick spectator"))
 	{
 		ReadChangeTeam(this, params);
 	}

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -76,7 +76,8 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 	{
 		bool canSwitch = getPlayersCount_NotSpectator() < getNet().joined_maxplayers;
 		
-		if (canSwitch || player.getTeamNum() != this.getSpectatorTeamNum() || team == this.getSpectatorTeamNum())
+		if (canSwitch || player.getTeamNum() != this.getSpectatorTeamNum() || 
+			team == this.getSpectatorTeamNum() || player.isMod())
 		{
 			ChangeTeam(player, team);
 		}

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -82,7 +82,8 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 		bool canSwitch = playerCountNotSpec < maxPlayers;
 		
 		if (canSwitch || player.getTeamNum() != specTeamNum  || team == specTeamNum || player.isMod() ||
-			getSecurity().checkAccess_Feature(player, "join_reserved") && maxPlayers + reservedSlots < playerCountNotSpec)
+			getSecurity().checkAccess_Feature(player, "join_reserved") && maxPlayers + reservedSlots < playerCountNotSpec ||
+			getSecurity().checkAccess_Feature(player, "join_full"))
 		{
 			ChangeTeam(player, team);
 		}

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -74,10 +74,15 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 
 	if (player is getLocalPlayer())
 	{
-		bool canSwitch = getPlayersCount_NotSpectator() < getNet().joined_maxplayers;
+		int maxPlayers = getNet().joined_maxplayers;
+		int reservedSlots = getNet().joined_reservedslots;
+		int playerCountNotSpec = getPlayersCount_NotSpectator(); 
+		u8 specTeamNum = this.getSpectatorTeamNum();
+
+		bool canSwitch = playerCountNotSpec < maxPlayers;
 		
-		if (canSwitch || player.getTeamNum() != this.getSpectatorTeamNum() || 
-			team == this.getSpectatorTeamNum() || player.isMod())
+		if (canSwitch || player.getTeamNum() != specTeamNum  || team == specTeamNum || player.isMod() ||
+			getSecurity().checkAccess_Feature(player, "join_reserved") && maxPlayers + reservedSlots < playerCountNotSpec)
 		{
 			ChangeTeam(player, team);
 		}

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -75,9 +75,18 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 
 	if (player is getLocalPlayer())
 	{
-		player.client_ChangeTeam(team);
-		// player.client_RequestSpawn(0);
-		getHUD().ClearMenus();
+		bool canSwitch = !(getPlayersNum_NotSpectator() <= getNet().joined_maxplayers);
+		
+		if (canSwitch || team == this.getSpectatorTeamNum())
+		{
+			player.client_ChangeTeam(team);
+			getHUD().ClearMenus();
+		}
+		else
+		{
+			print("no room"); // TODO: Print sound
+		}
+		
 	}
 }
 

--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -1,5 +1,7 @@
 // show menu that only allows to join spectator
 
+#include "SwitchFromSpec.as"
+
 const int BUTTON_SIZE = 4;
 
 void onInit(CRules@ this)
@@ -74,16 +76,7 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 
 	if (player is getLocalPlayer())
 	{
-		int maxPlayers = getNet().joined_maxplayers;
-		int reservedSlots = getNet().joined_reservedslots;
-		int playerCountNotSpec = getPlayersCount_NotSpectator(); 
-		u8 specTeamNum = this.getSpectatorTeamNum();
-
-		bool canSwitch = playerCountNotSpec < maxPlayers;
-		
-		if (canSwitch || player.getTeamNum() != specTeamNum  || team == specTeamNum || player.isMod() ||
-			getSecurity().checkAccess_Feature(player, "join_reserved") && maxPlayers + reservedSlots < playerCountNotSpec ||
-			getSecurity().checkAccess_Feature(player, "join_full"))
+		if (CanSwitchFromSpec(this, player, team))
 		{
 			ChangeTeam(player, team);
 		}


### PR DESCRIPTION
ENGINE PR IS NEEDED FOR THIS TO WORK


Add's spectator slots, the server api/browser already supports this, so there isnt much work that needs to go in there.

Autoconfig settings:
``sv_spectatorslots``, default value is 4

Binds:
``getPlayersCount_NotSpectator()``, ``getNet().joined_maxplayers``, ``getNet().joined_spectatorslots``, ``getNet().joined_reservedslots``

What does this do:
```
- Players who join will get forced to team 200 (spectator team) if game is full
- Patreons who join will be put into a team AS LONG AS there are enough patreon slots (2 by default)
- People with reserved slots will be put into a team if there's a spare slot, otherwise they will become a spectator
- People with joinfull access will be put into a team no matter what
```