### PR TITLE
[Change] Client side gui no longer use cmd

### DIFF
--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -57,7 +57,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 			this.get_u8("shop icon"),                                // icon token
 			this.get_Vec2f("shop offset"),                           // button offset
 			this,                                                    // shop blob
-			CreateMenu,                                              // func callback
+			createMenu,                                              // func callback
 			getTranslatedString(this.get_string("shop description")) // description
 		);
 
@@ -66,7 +66,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 }
 
 
-void CreateMenu(CBlob@ this, CBlob@ caller)
+void createMenu(CBlob@ this, CBlob@ caller)
 {
 	if (this.hasTag("shop disabled"))
 		return;

--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -11,7 +11,6 @@
 
 void onInit(CBlob@ this)
 {
-	this.addCommandID("shop menu");
 	this.addCommandID("shop buy");
 	this.addCommandID("shop made item");
 
@@ -54,19 +53,25 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	if (shop_items.length > 0 && this.get_bool("shop available") && !this.hasTag("shop disabled"))
 	{
-		CBitStream params;
-		params.write_u16(caller.getNetworkID());
-
 		CButton@ button = caller.CreateGenericButton(
-		this.get_u8("shop icon"),                   // icon token
-		this.get_Vec2f("shop offset"),              // button offset
-		this,                                       // button attachment
-		this.getCommandID("shop menu"),             // command id
-		getTranslatedString(this.get_string("shop description")),        // description
-		params);                                    // bit stream
+			this.get_u8("shop icon"),                                // icon token
+			this.get_Vec2f("shop offset"),                           // button offset
+			this,                                                    // shop blob
+			CreateMenu,                                              // func callback
+			getTranslatedString(this.get_string("shop description")) // description
+		);
 
 		button.enableRadius = this.get_u8("shop button radius");
 	}
+}
+
+
+void CreateMenu(CBlob@ this, CBlob@ caller)
+{
+	if (this.hasTag("shop disabled"))
+		return;
+
+	BuildShopMenu(this, caller, this.get_string("shop description"), Vec2f(0, 0), this.get_Vec2f("shop menu size"));
 }
 
 bool isInRadius(CBlob@ this, CBlob @caller)
@@ -83,16 +88,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	bool isServer = getNet().isServer();
 
-	if (cmd == this.getCommandID("shop menu"))
-	{
-		if (this.hasTag("shop disabled"))
-			return;
-
-		// build menu for them
-		CBlob@ caller = getBlobByNetworkID(params.read_u16());
-		BuildShopMenu(this, caller, this.get_string("shop description"), Vec2f(0, 0), this.get_Vec2f("shop menu size"));
-	}
-	else if (cmd == this.getCommandID("shop buy"))
+	if (cmd == this.getCommandID("shop buy"))
 	{
 		if (this.hasTag("shop disabled"))
 			return;

--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -58,18 +58,22 @@ void BuildRespawnMenuFor(CBlob@ this, CBlob @caller)
 	}
 }
 
+void buildSpawnMenu(CBlob@ this, CBlob@ caller)
+{
+	BuildRespawnMenuFor(this, caller);
+}
+
 void onRespawnCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 
 	switch (cmd)
 	{
-		case SpawnCmd::buildMenu:
+		// Legacy, we now use func callback
+		case SpawnCmd::buildMenu: 
 		{
 			{
-				// build menu for them
 				CBlob@ caller = getBlobByNetworkID(params.read_u16());
 				BuildRespawnMenuFor(this, caller);
-				this.set_bool("quick switch class", false);
 			}
 		}
 		break;

--- a/Entities/Industry/Hall/Hall.as
+++ b/Entities/Industry/Hall/Hall.as
@@ -382,7 +382,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
 
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(12, 7), this, SpawnCmd::buildMenu, getTranslatedString("Change class"), params);
+		caller.CreateGenericButton("$change_class$", Vec2f(12, 7), this, buildSpawnMenu, getTranslatedString("Change class"));
 
 		if (caller.getName() == "builder")
 		{

--- a/Entities/Special/Tent/TentLogic.as
+++ b/Entities/Special/Tent/TentLogic.as
@@ -52,9 +52,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	// create menu for class change
 	if (canChangeClass(this, caller) && caller.getTeamNum() == this.getTeamNum())
 	{
-		CBitStream params;
-		params.write_u16(caller.getNetworkID());
-		caller.CreateGenericButton("$change_class$", Vec2f(0, 0), this, SpawnCmd::buildMenu, getTranslatedString("Swap Class"), params);
+		caller.CreateGenericButton("$change_class$", Vec2f(0, 0), this, buildSpawnMenu, getTranslatedString("Swap Class"));
 	}
 }
 

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -242,9 +242,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		if (!isAnotherRespawnClose(this) && !isFlipped(this))
 		{
-			CBitStream params;
-			params.write_u16(caller.getNetworkID());
-			CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, -4), this, SpawnCmd::buildMenu, getTranslatedString("Change class"), params);
+			caller.CreateGenericButton("$change_class$", Vec2f(0, -4), this, buildSpawnMenu, getTranslatedString("Change class"));
 		}
 
 		if (!Vehicle_AddFlipButton(this, caller) && caller.getTeamNum() == this.getTeamNum())
@@ -256,7 +254,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == SpawnCmd::buildMenu || cmd == SpawnCmd::changeClass)
+	if (cmd == SpawnCmd::changeClass)
 	{
 		onRespawnCommand(this, cmd, params);
 	}

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -210,9 +210,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	if (caller.getTeamNum() == this.getTeamNum())
 	{
-		CBitStream params;
-		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(13, 4), this, SpawnCmd::buildMenu, getTranslatedString("Change class"), params);
+		caller.CreateGenericButton("$change_class$", Vec2f(13, 4), this, buildSpawnMenu, getTranslatedString("Change class"));
 	}
 }
 


### PR DESCRIPTION
Title, cmd would result in a delay depending on your ping. I updated the engine to include new binds for CreateGenericButton to have an option for a function callback, so if we do have any client only code we want to call, we can use that.

I tested using clumsy, your ping no longer makes a difference on how fast the gui's appear.

Requires engine pr to be merged to work
```
New funcdef: void CallbackButtonFunc(CBlob@, CBlob@)

New script binds:
CButton@ CreateGenericButton( int _frameNum, Vec2f _offset, CBlob@ attached, CallbackButtonFunc@ cb, const string &in )
CButton@ CreateGenericButton( const string &in iconName, Vec2f _offset, CBlob@ attached, CallbackButtonFunc@ cb, const string &in )
```

Fixes #612 