### PR TITLE
Remove random gold drop from chests

### DIFF
--- a/Entities/Common/Loot/LootCommon.as
+++ b/Entities/Common/Loot/LootCommon.as
@@ -15,7 +15,6 @@ enum                Index
 	MAT_BOMBARROWS,
 	MAT_WOOD,
 	MAT_STONE,
-	MAT_GOLD,
 	DRILL,
 	MAT_BOMBS,
 	MAT_WATERBOMBS,
@@ -33,7 +32,6 @@ const string[]      NAME =
 	"mat_bombarrows",
 	"mat_wood",
 	"mat_stone",
-	"mat_gold",
 	"drill",
 	"mat_bombs",
 	"mat_waterbombs",
@@ -51,7 +49,6 @@ const u8[]          WEIGHT =
 	20,                     // mat_bombarrows
 	40,                     // mat_wood
 	25,                     // mat_stone
-	10,                     // mat_gold
 	25,                     // drill
 	55,                     // mat_bombs
 	25,                     // mat_waterbombs
@@ -75,7 +72,6 @@ const u8[]          INDEX_BUILDER =
 {
 	MAT_WOOD,
 	MAT_STONE,
-	MAT_GOLD,
 	DRILL
 };
 
@@ -97,7 +93,6 @@ const u8[]          INDEX_CTF =
 	MAT_BOMBARROWS,
 	MAT_WOOD,
 	MAT_STONE,
-	MAT_GOLD,
 	DRILL,
 	MAT_BOMBS,
 	MAT_WATERBOMBS,


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Removes mat_gold dropping from chests, which is unbalanced because it can lead to one team having more gold than the other due to RNG on maps with sparse gold.
