### PR TITLE
Quarry becomes less efficient each time it drops mats

### DIFF
--- a/Entities/Industry/CTFShops/Quarry/Quarry.as
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.as
@@ -11,7 +11,7 @@ const string rare_ore = "mat_gold";
 const int input = 100;					// input cost in fuel
 const int initial_output = 80;			// output amount in ore
 const int min_output = 30;				// minimal possible output in ore
-const int output_decrease = 3;			// by how much output decreases every time ore is dropped
+const int output_decrease = 2;			// by how much output decreases every time ore is dropped
 const bool enable_rare = false;			// enable/disable
 const int rare_chance = 10;				// one-in
 const int rare_output = 20;				// output for rare ore
@@ -204,8 +204,13 @@ void spawnOre(CBlob@ this)
 	_ore.server_SetQuantity(!rare ? amountToSpawn : rare_output);
 
 	this.set_s16(fuel_prop, blobCount - actual_input); //burn wood
+	const string current_output = "current_quarry_output_" + this.getTeamNum();
+	
 	// reduce output if it's higher than minimal output
-	getRules().set_s32("current_quarry_output_" + this.getTeamNum(), Maths::Max(getRules().get_s32("current_quarry_output_" + this.getTeamNum()) - output_decrease, min_output));
+	if (sv_gamemode == "CTF" || sv_gamemode == "SmallCTF")
+	{
+		getRules().set_s32(current_output, Maths::Max(getRules().get_s32(current_output) - output_decrease, min_output));
+	}
 }
 
 void updateWoodLayer(CSprite@ this)

--- a/Entities/Industry/CTFShops/Quarry/Quarry.as
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.as
@@ -8,14 +8,16 @@ const string ore = "mat_stone";
 const string rare_ore = "mat_gold";
 
 //balance
-const int input = 100;					//input cost in fuel
-const int output = 75;					//output amount in ore
-const bool enable_rare = false;			//enable/disable
-const int rare_chance = 10;				//one-in
-const int rare_output = 20;				//output for rare ore
-const int conversion_frequency = 30;	//how often to convert, in seconds
+const int input = 100;					// input cost in fuel
+const int initial_output = 80;			// output amount in ore
+const int min_output = 30;				// minimal possible output in ore
+const int output_decrease = 3;			// by how much output decreases every time ore is dropped
+const bool enable_rare = false;			// enable/disable
+const int rare_chance = 10;				// one-in
+const int rare_output = 20;				// output for rare ore
+const int conversion_frequency = 30;	// how often to convert, in seconds
 
-const int min_input = Maths::Ceil(input/output);
+const int min_input = Maths::Ceil(input/initial_output);
 
 //fuel levels for animation
 const int max_fuel = 500;
@@ -77,6 +79,11 @@ void onInit(CBlob@ this)
 
 	//commands
 	this.addCommandID("add fuel");
+
+	if (getRules().get_s32("current_quarry_output_" + this.getTeamNum()) == -1)
+	{
+		getRules().set_s32("current_quarry_output_" + this.getTeamNum(), initial_output);
+	}
 }
 
 void onTick(CBlob@ this)
@@ -177,6 +184,8 @@ void spawnOre(CBlob@ this)
 	int actual_input = Maths::Min(input, blobCount);
 
 	int r = XORRandom(rare_chance);
+	int output = getRules().get_s32("current_quarry_output_" + this.getTeamNum());
+
 	//rare chance, but never rare if not a full batch of wood
 	bool rare = (enable_rare && r == 0 && blobCount >= input);
 
@@ -195,6 +204,8 @@ void spawnOre(CBlob@ this)
 	_ore.server_SetQuantity(!rare ? amountToSpawn : rare_output);
 
 	this.set_s16(fuel_prop, blobCount - actual_input); //burn wood
+	// reduce output if it's higher than minimal output
+	getRules().set_s32("current_quarry_output_" + this.getTeamNum(), Maths::Max(getRules().get_s32("current_quarry_output_" + this.getTeamNum()) - output_decrease, min_output));
 }
 
 void updateWoodLayer(CSprite@ this)

--- a/Entities/Industry/CTFShops/Quarry/Quarry.as
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.as
@@ -207,7 +207,7 @@ void spawnOre(CBlob@ this)
 	const string current_output = "current_quarry_output_" + this.getTeamNum();
 	
 	// reduce output if it's higher than minimal output
-	if (sv_gamemode == "CTF" || sv_gamemode == "SmallCTF")
+	if (getRules().hasScript("ResetQuarry.as"))
 	{
 		getRules().set_s32(current_output, Maths::Max(getRules().get_s32(current_output) - output_decrease, min_output));
 	}

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -685,6 +685,11 @@ void Reset(CRules@ this)
 	this.set("core", @core);
 	this.set("start_gametime", getGameTime() + core.warmUpTime);
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as
+
+	for (int team = 0; team < this.getTeamsCount(); team++)
+	{
+		this.set_s32("current_quarry_output_" + team, -1); // reset quarry output rate, actual values for output are set in Quarry.as
+	}
 }
 
 void onRestart(CRules@ this)

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -685,11 +685,6 @@ void Reset(CRules@ this)
 	this.set("core", @core);
 	this.set("start_gametime", getGameTime() + core.warmUpTime);
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as
-
-	for (int team = 0; team < this.getTeamsCount(); team++)
-	{
-		this.set_s32("current_quarry_output_" + team, -1); // reset quarry output rate, actual values for output are set in Quarry.as
-	}
 }
 
 void onRestart(CRules@ this)

--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -52,6 +52,7 @@ scripts                                           = KAG.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
 													RegrowPlants.as;
+													ResetQuarry.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0

--- a/Rules/CommonScripts/ResetQuarry.as
+++ b/Rules/CommonScripts/ResetQuarry.as
@@ -1,0 +1,12 @@
+// resets quarry output rate, actual values for output are set in Quarry.as
+// this script has to be added to gamemode.cfg for quarry output to decrease 
+
+#define SERVER_ONLY
+
+void onRestart(CRules@ this)
+{
+	for (int team = 0; team < this.getTeamsCount(); team++)
+	{
+		this.set_s32("current_quarry_output_" + team, -1);
+	}
+}

--- a/Rules/SmallCTF/gamemode.cfg
+++ b/Rules/SmallCTF/gamemode.cfg
@@ -52,6 +52,7 @@ scripts                                           = KAG.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
 													RegrowPlants.as;
+													ResetQuarry.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

1. Starting output slightly increased (75 => 80)
2. Output decreases by 2 each time stone is dropped, until it reaches 30. Because stone drops are rounded to 5, it should drop same amount of stone 2-3 times before going down by 5
3. Same amount of wood is consumed for all outputs
4. Breaking the quarry doesn't reset it's output
5. Output resets on map change/restart