### PR TITLE
[fixed] staging build: changing resolution would not update hud

### DIFF
--- a/Entities/Common/GUI/ActorHUDStartPos.as
+++ b/Entities/Common/GUI/ActorHUDStartPos.as
@@ -1,12 +1,23 @@
 //for use with DefaultActorHUD.as based HUDs
 
-const f32 HUD_X = getScreenWidth()/3;
-const f32 HUD_Y = getScreenHeight();
+f32 getHUDX()
+{
+	return getScreenWidth() / 3;
+}
+
+f32 getHUDY()
+{
+	return getScreenHeight();
+}
+
+// compatibility - prefer to use getHUDX() and getHUDY() as you are rendering, because resolution may dynamically change (from asu's staging build onwards)
+const f32 HUD_X = getHUDX();
+const f32 HUD_Y = getHUDY();
 
 Vec2f getActorHUDStartPosition(CBlob@ blob, const u8 bar_width_in_slots)
 {
 	f32 width = bar_width_in_slots * 40.0f;
-	return Vec2f(HUD_X + 180 + 50 + 8 - width, HUD_Y - 40);
+	return Vec2f(getHUDX() + 180 + 50 + 8 - width, getHUDY() - 40);
 }
 
 void DrawInventoryOnHUD(CBlob@ this, Vec2f tl)

--- a/Entities/Common/GUI/DefaultActorHUD.as
+++ b/Entities/Common/GUI/DefaultActorHUD.as
@@ -83,7 +83,7 @@ void onRender(CSprite@ this)
 
 	CBlob@ blob = this.getBlob();
 	Vec2f dim = Vec2f(402, 64);
-	Vec2f ul(HUD_X - dim.x / 2.0f, HUD_Y - dim.y + 12);
+	Vec2f ul(getHUDX() - dim.x / 2.0f, getHUDY() - dim.y + 12);
 	Vec2f lr(ul.x + dim.x, ul.y + dim.y);
 	//GUI::DrawPane(ul, lr);
 	renderBackBar(ul, dim.x, 1.0f);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The staging build allows changing the resolution/window size on the fly.  
`HUD_X` and `HUD_Y` were storing the screen size on compile time in a global variable without ever refreshing it. This would cause the HUD to not update its position when resizing the window.

## Steps to Test or Reproduce

Resize windows on staging. This does not affect vanilla.