### PR TITLE
Revert pickup behaviour to pre-halloween.

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -627,6 +627,8 @@ bool canBlobBePickedUp(CBlob@ this, CBlob@ blob)
 			}
 		}
 
+	} else {
+		canRayCast = true;
 	}
 
 	return (((pos2 - pos).getLength() <= maxDist)


### PR DESCRIPTION
Status:
- **READY**  -- I have tested this branch local only
Partially resolves [Issue #972: Revert all recent pickup changes](https://github.com/transhumandesign/kag-base/issues/972)

---

[This commit from the halloween update](https://github.com/transhumandesign/kag-base/commit/eee806be1ebac365c10f9c6d4ea6240df6cf980f) added the feature that you can pickup items through platforms. It also added a bug where:
-  Trying to pickup an item right after throwing it would often fail.
-  Trying to pickup chickens, crates became harder, you would need to overlap the chicken/crate in order to pick it up.

The bug is caused by `if(map.getHitInfosFromRay(pos, -ray.getAngle(), ray.Length(), this, hitInfos))` (line 560) failing (and returning false and not filling the hitInfos array with anything). The function seems to always fail for chickens/crates. The function also seems to fail when the ray hits a blob that has been detached from something moment ago (or when the blob has been detached from you but never stopped overlapping you).

I tried to add a workaround (`canRayCast = true;` if getHitInfosFromRay returns false) which preserves the "you can pickup items through platforms" but fixes the pickup failures described above.
[Demo of new behaviour with the workaround](https://user-images.githubusercontent.com/26771587/102951627-9abd1700-44cd-11eb-8b45-479b69951e15.mp4)

---

I prefer this behaviour a lot over the behaviour introduced by the halloween update. It is super hard to pickup chickens, you often times just can't pickup kegs on the ground for half a second etc.
A nice thing about it is that picking up items next to corpses/mat_arrows/logs is easier because you can just press c over and over until you have the item that you really want (since dropping a corpse or whatever effectively put a cooldown on picking up that same corpse again, caused by getHitInfosFromRay failing and canBlobBePickedUp defaulting to "can't pickup" in that case).
But still, I'd much much much rather revert to the pre-halloween struggle with corpses than struggle with the new halloween issues (and that change wasn't intentional to my knowledge).

---

There is an remaining issue with pickup raycasts: When you drop an item and are overlapping a blob, for example a shop/platform/corpse, and are continuing to overlap with the dropped item, you can't pickup the item for ~1 second after you dropped it.
[Demo of the issue](https://user-images.githubusercontent.com/26771587/102951645-a1e42500-44cd-11eb-86af-431945b139b1.mp4)
I haven't figured out the source/workaround of this issue.
