### PR TITLE
Resupply message tweaks; resupply on ballista without switching; builder and archer have seperate resupply timers.

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -15,28 +15,28 @@ string base_name() { return "tent"; }
 bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
 {
 	CInventory@ inv = blob.getInventory();
-	
+
 	//avoid over-stacking arrows
 	if (name == "mat_arrows")
 	{
 		inv.server_RemoveItems(name, quantity);
 	}
-	
+
 	CBlob@ mat = server_CreateBlobNoInit(name);
-	
+
 	if (mat !is null)
 	{
 		mat.Tag('custom quantity');
 		mat.Init();
-		
+
 		mat.server_SetQuantity(quantity);
-		
+
 		if (not blob.server_PutInInventory(mat))
 		{
 			mat.setPosition(blob.getPosition());
 		}
 	}
-	
+
 	return true;
 }
 
@@ -44,10 +44,10 @@ bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
 void onSetPlayer(CRules@ this, CBlob@ blob, CPlayer@ player)
 {
 	if (!getNet().isServer()) return;
-	
+
 	if (blob is null) return;
 	if (player is null) return;
-	
+
 	doGiveSpawnMats(this, player, blob);
 }
 
@@ -115,17 +115,17 @@ void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b)
 			
 			int wood_amount = 100;
 			int stone_amount = 30;
-			
+
 			if (this.isWarmup()) {
 				wood_amount = 300;
 				stone_amount = 100;
 			}
-			
+
 			bool did_give_wood = SetMaterials(b, "mat_wood", wood_amount);
 			bool did_give_stone = SetMaterials(b, "mat_stone", stone_amount);
 			
 			if (did_give_wood || did_give_stone)
-			{
+{
 				SetCTFTimerBuilder(this, p, gametime + (this.isWarmup() ? materials_wait_warmup : materials_wait)*getTicksASecond());
 			}
 		}
@@ -163,12 +163,12 @@ void onTick(CRules@ this)
 {
 	if (!getNet().isServer())
 		return;
-	
+
 	s32 gametime = getGameTime();
-	
+
 	if ((gametime % 15) != 5)
 		return;
-	
+
 	CBlob@[] spots;
 	getBlobsByName(base_name(),   @spots);
 	getBlobsByName("ballista",	@spots);
@@ -180,23 +180,23 @@ void onTick(CRules@ this)
 		
 		CBlob@ spot = spots[step];
 		if (spot is null) continue;
-		
+
 		CBlob@[] overlapping;
 		if (!spot.getOverlapping(overlapping)) continue;
 		
 		string name = spot.getName();
 		bool isShop = (name.find("shop") != -1);
 		for (uint o_step = 0; o_step < overlapping.length; ++o_step) {
-			
+
 			CBlob@ overlapped = overlapping[o_step];
 			if (overlapped is null) continue;
-			
+
 			if (!overlapped.hasTag("player")) continue;
 			CPlayer@ p = overlapped.getPlayer();
 			if (p is null) continue;
-			
+
 			if (isShop && name.find(overlapped.getName()) == -1) continue; // NOTE(hobey): builder doesn't get wood+stone at archershop, archer doesn't get arrows at buildershop
-			
+
 			doGiveSpawnMats(this, p, overlapped);
 		}
 	}
@@ -207,27 +207,27 @@ void onRender(CRules@ this)
 {
 	if (g_videorecording || this.isGameOver())
 		return;
-	
+
 	CPlayer@ p = getLocalPlayer();
 	if (p is null || !p.isMyPlayer()) { return; }
-	
+
 	CBlob@ b = p.getBlob();
 	if (b is null) return;
 	
 	string name = b.getName();
-	
+
 	string propname = getCTFTimerPropertyNameBuilder(p);
 	if (this.exists(propname)) {
 		s32 next_items = this.get_s32(propname);
-		
+
 		GUI::SetFont("menu");
-		
+
 		u32 secs = ((next_items - 1 - getGameTime()) / getTicksASecond()) + 1;
 		string units = ((secs != 1) ? " seconds" : " second");
-		
+
 		string need_to_switch_string = "";
 		if (name != "builder") need_to_switch_string = getTranslatedString("and switch to builder ");
-		
+
 		SColor color = SColor(200, 135, 185, 45);
 		int wood_amount = 100;
 		int stone_amount = 30;
@@ -240,34 +240,34 @@ void onRender(CRules@ this)
 			.replace("{SWITCH}", need_to_switch_string)
 			.replace("{WOOD}", "" + wood_amount)
 			.replace("{STONE}", "" + stone_amount);
-		
-		
+
+
 		if (next_items > getGameTime())
 		{
 			// color = SColor(255, 255, 55, 55);
 			color = SColor(120, 255, 55, 55);
-			
+
 			text = getTranslatedString("Next resupply of {WOOD} wood and {STONE} stone in {SEC}{TIMESUFFIX}.")
-				.replace("{SEC}", "" + secs)
-				.replace("{TIMESUFFIX}", getTranslatedString(units))
-				.replace("{WOOD}", "" + wood_amount)
-				.replace("{STONE}", "" + stone_amount);
+			                           .replace("{SEC}", "" + secs)
+			                           .replace("{TIMESUFFIX}", getTranslatedString(units))
+			                           .replace("{WOOD}", "" + wood_amount)
+			                           .replace("{STONE}", "" + stone_amount);
 		}
-		
+
 		GUI::DrawTextCentered(text, Vec2f(getScreenWidth() / 2, getScreenHeight() / 3 - 70.0f), color);
 	}
-	
-	
+
+
 	// TODO(hobey): maybe only draw the cooldown/helptext for archer if low on arrows?
 	propname = getCTFTimerPropertyNameArcher(p);
 	if (name == "archer" && this.exists(propname)) {
 		s32 next_items = this.get_s32(propname);
-		
+
 		GUI::SetFont("menu");
-		
+
 		u32 secs = ((next_items - 1 - getGameTime()) / getTicksASecond()) + 1;
 		string units = ((secs != 1) ? " seconds" : " second");
-		
+
 		SColor color = SColor(200, 135, 185, 45);
 		int wood_amount = 100;
 		int stone_amount = 30;
@@ -277,18 +277,17 @@ void onRender(CRules@ this)
 			stone_amount = 100;
 		}
 		string text = getTranslatedString("Go to an archer shop or a respawn point to get a resupply of 30 arrows.");
-		
+
 		if (next_items > getGameTime())
 		{
-			// color = SColor(255, 255, 55, 55);
 			color = SColor(120, 255, 55, 55);
-			
+
 			text = getTranslatedString("Next resupply of 30 arrows in {SEC}{TIMESUFFIX}.")
-				.replace("{SEC}", "" + secs)
-				.replace("{TIMESUFFIX}", getTranslatedString(units));
+			                           .replace("{SEC}", "" + secs)
+			                           .replace("{TIMESUFFIX}", getTranslatedString(units));
 		}
-		
-		GUI::DrawTextCentered(text, Vec2f(getScreenWidth() / 2, getScreenHeight() / 3 - 16.0f), color);
+
+		GUI::DrawTextCentered(text, Vec2f(getScreenWidth() / 2, getScreenHeight() / 3 - 100.0f), color);
 	}
-	
+
 }

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -7,96 +7,48 @@ const u32 materials_wait = 20; //seconds between free mats
 const u32 materials_wait_warmup = 40; //seconds between free mats
 
 //property
-const string SPAWN_ITEMS_TIMER = "CTF SpawnItems:";
+const string SPAWN_ITEMS_TIMER_BUILDER = "CTF SpawnItems Builder:";
+const string SPAWN_ITEMS_TIMER_ARCHER  = "CTF SpawnItems Archer:";
 
 string base_name() { return "tent"; }
 
 bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
 {
 	CInventory@ inv = blob.getInventory();
-
+	
 	//avoid over-stacking arrows
 	if (name == "mat_arrows")
 	{
 		inv.server_RemoveItems(name, quantity);
 	}
-
+	
 	CBlob@ mat = server_CreateBlobNoInit(name);
-
+	
 	if (mat !is null)
 	{
 		mat.Tag('custom quantity');
 		mat.Init();
-
+		
 		mat.server_SetQuantity(quantity);
-
+		
 		if (not blob.server_PutInInventory(mat))
 		{
 			mat.setPosition(blob.getPosition());
 		}
 	}
-
+	
 	return true;
-}
-
-bool GiveSpawnResources(CRules@ this, CBlob@ blob, CPlayer@ player, CTFPlayerInfo@ info)
-{
-	bool ret = false;
-
-	if (blob.getName() == "builder")
-	{
-		if (this.isWarmup())
-		{
-			ret = SetMaterials(blob, "mat_wood", 300) || ret;
-			ret = SetMaterials(blob, "mat_stone", 100) || ret;
-
-		}
-		else
-		{
-			ret = SetMaterials(blob, "mat_wood", 100) || ret;
-			ret = SetMaterials(blob, "mat_stone", 30) || ret;
-		}
-
-		if (ret)
-		{
-			info.items_collected |= ItemFlag::Builder;
-		}
-	}
-	else if (blob.getName() == "archer")
-	{
-		ret = SetMaterials(blob, "mat_arrows", 30) || ret;
-
-		if (ret)
-		{
-			info.items_collected |= ItemFlag::Archer;
-		}
-	}
-	else if (blob.getName() == "knight")
-	{
-		if (ret)
-		{
-			info.items_collected |= ItemFlag::Knight;
-		}
-	}
-
-	return ret;
 }
 
 //when the player is set, give materials if possible
 void onSetPlayer(CRules@ this, CBlob@ blob, CPlayer@ player)
 {
-	if (!getNet().isServer())
-		return;
-
-	if (blob !is null && player !is null)
-	{
-		RulesCore@ core;
-		this.get("core", @core);
-		if (core !is null)
-		{
-			doGiveSpawnMats(this, player, blob, core);
-		}
-	}
+	if (!getNet().isServer()) return;
+	
+	if (blob is null) return;
+	if (player is null) return;
+	
+	doGiveSpawnMats(this, player, blob);
 }
 
 //when player dies, unset archer flag so he can get arrows if he really sucks :)
@@ -105,90 +57,83 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 {
 	if (victim !is null)
 	{
-		RulesCore@ core;
-		this.get("core", @core);
-		if (core !is null)
-		{
-			CTFPlayerInfo@ info = cast < CTFPlayerInfo@ > (core.getInfoFromPlayer(victim));
-			if (info !is null)
-			{
-				info.items_collected &= ~ItemFlag::Archer;
-			}
-		}
+		SetCTFTimerArcher(this, victim, 0);
 	}
 }
 
-bool canGetSpawnmats(CRules@ this, CPlayer@ p, RulesCore@ core)
+string getCTFTimerPropertyNameBuilder(CPlayer@ p)
 {
-	s32 next_items = getCTFTimer(this, p);
-	s32 gametime = getGameTime();
-
-	CTFPlayerInfo@ info = cast < CTFPlayerInfo@ > (core.getInfoFromPlayer(p));
-
-	if (gametime > next_items)		// timer expired
-	{
-		info.items_collected = 0; //reset available class items
-		return true;
-	}
-	else //trying to get new class items, give a guy a break
-	{
-		u32 items = info.items_collected;
-		u32 flag = 0;
-
-		CBlob@ b = p.getBlob();
-		string name = b.getName();
-		if (name == "builder")
-			flag = ItemFlag::Builder;
-		else if (name == "knight")
-			flag = ItemFlag::Knight;
-		else if (name == "archer")
-			flag = ItemFlag::Archer;
-
-		if (info.items_collected & flag == 0)
-		{
-			return true;
-		}
-	}
-
-	return false;
-
+	return SPAWN_ITEMS_TIMER_BUILDER + p.getUsername();
 }
 
-string getCTFTimerPropertyName(CPlayer@ p)
+s32 getCTFTimerBuilder(CRules@ this, CPlayer@ p)
 {
-	return SPAWN_ITEMS_TIMER + p.getUsername();
-}
-
-s32 getCTFTimer(CRules@ this, CPlayer@ p)
-{
-	string property = getCTFTimerPropertyName(p);
+	string property = getCTFTimerPropertyNameBuilder(p);
 	if (this.exists(property))
 		return this.get_s32(property);
 	else
 		return 0;
 }
 
-void SetCTFTimer(CRules@ this, CPlayer@ p, s32 time)
+void SetCTFTimerBuilder(CRules@ this, CPlayer@ p, s32 time)
 {
-	string property = getCTFTimerPropertyName(p);
+	string property = getCTFTimerPropertyNameBuilder(p);
+	this.set_s32(property, time);
+	this.SyncToPlayer(property, p);
+}
+
+string getCTFTimerPropertyNameArcher(CPlayer@ p)
+{
+	return SPAWN_ITEMS_TIMER_ARCHER + p.getUsername();
+}
+
+s32 getCTFTimerArcher(CRules@ this, CPlayer@ p)
+{
+	string property = getCTFTimerPropertyNameArcher(p);
+	if (this.exists(property))
+		return this.get_s32(property);
+	else
+		return 0;
+}
+
+void SetCTFTimerArcher(CRules@ this, CPlayer@ p, s32 time)
+{
+	string property = getCTFTimerPropertyNameArcher(p);
 	this.set_s32(property, time);
 	this.SyncToPlayer(property, p);
 }
 
 //takes into account and sets the limiting timer
 //prevents dying over and over, and allows getting more mats throughout the game
-void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b, RulesCore@ core)
+void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b)
 {
-	if (canGetSpawnmats(this, p, core))
-	{
-		s32 gametime = getGameTime();
-
-		CTFPlayerInfo@ info = cast < CTFPlayerInfo@ > (core.getInfoFromPlayer(p));
-
-		bool gotmats = GiveSpawnResources(this, b, p, info);
-		if (gotmats)
-		{
-			SetCTFTimer(this, p, gametime + (this.isWarmup() ? materials_wait_warmup : materials_wait)*getTicksASecond());
+	s32 gametime = getGameTime();
+	string name = b.getName();
+	
+	if (name == "builder") {
+		if (gametime > getCTFTimerBuilder(this, p)) {
+			
+			int wood_amount = 100;
+			int stone_amount = 30;
+			
+			if (this.isWarmup()) {
+				wood_amount = 300;
+				stone_amount = 100;
+			}
+			
+			bool did_give_wood = SetMaterials(b, "mat_wood", wood_amount);
+			bool did_give_stone = SetMaterials(b, "mat_stone", stone_amount);
+			
+			if (did_give_wood || did_give_stone)
+			{
+				SetCTFTimerBuilder(this, p, gametime + (this.isWarmup() ? materials_wait_warmup : materials_wait)*getTicksASecond());
+			}
+		}
+	} else if (name == "archer") {
+		if (gametime > getCTFTimerArcher(this, p)) {
+			if (SetMaterials(b, "mat_arrows", 30)) {
+				SetCTFTimerArcher(this, p, gametime + (this.isWarmup() ? materials_wait_warmup : materials_wait)*getTicksASecond());
+			}
 		}
 	}
 }
@@ -198,8 +143,10 @@ void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b, RulesCore@ core)
 void Reset(CRules@ this)
 {
 	//restart everyone's timers
-	for (uint i = 0; i < getPlayersCount(); ++i)
-		SetCTFTimer(this, getPlayer(i), 0);
+	for (uint i = 0; i < getPlayersCount(); ++i) {
+		SetCTFTimerBuilder(this, getPlayer(i), 0);
+		SetCTFTimerArcher(this, getPlayer(i), 0);
+	}
 }
 
 void onRestart(CRules@ this)
@@ -216,48 +163,41 @@ void onTick(CRules@ this)
 {
 	if (!getNet().isServer())
 		return;
-
+	
 	s32 gametime = getGameTime();
-
+	
 	if ((gametime % 15) != 5)
 		return;
-
-
-	RulesCore@ core;
-	this.get("core", @core);
-	if (core !is null)
-	{
-
-		CBlob@[] spots;
-		getBlobsByName(base_name(), @spots);
-		getBlobsByName("buildershop", @spots);
-		getBlobsByName("knightshop", @spots);
-		getBlobsByName("archershop", @spots);
-		for (uint step = 0; step < spots.length; ++step)
-		{
-			CBlob@ spot = spots[step];
-			CBlob@[] overlapping;
-			if (spot !is null && spot.getOverlapping(overlapping))
-			{
-				string name = spot.getName();
-				bool isShop = (name.find("shop") != -1);
-				for (uint o_step = 0; o_step < overlapping.length; ++o_step)
-				{
-					CBlob@ overlapped = overlapping[o_step];
-					if (overlapped !is null && overlapped.hasTag("player"))
-					{
-						if (!isShop || name.find(overlapped.getName()) != -1)
-						{
-							CPlayer@ p = overlapped.getPlayer();
-							if (p !is null)
-							{
-								doGiveSpawnMats(this, p, overlapped, core);
-							}
-						}
-					}
-				}
-			}
-
+	
+	CBlob@[] spots;
+	getBlobsByName(base_name(),   @spots);
+	getBlobsByName("ballista",	@spots);
+	getBlobsByName("warboat",	 @spots);
+	getBlobsByName("buildershop", @spots);
+	getBlobsByName("archershop",  @spots);
+	// getBlobsByName("knightshop",  @spots);
+	for (uint step = 0; step < spots.length; ++step) {
+		
+		CBlob@ spot = spots[step];
+		if (spot is null) continue;
+		
+		CBlob@[] overlapping;
+		if (!spot.getOverlapping(overlapping)) continue;
+		
+		string name = spot.getName();
+		bool isShop = (name.find("shop") != -1);
+		for (uint o_step = 0; o_step < overlapping.length; ++o_step) {
+			
+			CBlob@ overlapped = overlapping[o_step];
+			if (overlapped is null) continue;
+			
+			if (!overlapped.hasTag("player")) continue;
+			CPlayer@ p = overlapped.getPlayer();
+			if (p is null) continue;
+			
+			if (isShop && name.find(overlapped.getName()) == -1) continue; // NOTE(hobey): builder doesn't get wood+stone at archershop, archer doesn't get arrows at buildershop
+			
+			doGiveSpawnMats(this, p, overlapped);
 		}
 	}
 }
@@ -267,32 +207,88 @@ void onRender(CRules@ this)
 {
 	if (g_videorecording || this.isGameOver())
 		return;
-
+	
 	CPlayer@ p = getLocalPlayer();
 	if (p is null || !p.isMyPlayer()) { return; }
-
-	string propname = getCTFTimerPropertyName(p);
+	
 	CBlob@ b = p.getBlob();
-	if (b !is null && this.exists(propname))
-	{
+	if (b is null) return;
+	
+	string name = b.getName();
+	
+	string propname = getCTFTimerPropertyNameBuilder(p);
+	if (this.exists(propname)) {
 		s32 next_items = this.get_s32(propname);
+		
+		GUI::SetFont("menu");
+		
+		u32 secs = ((next_items - 1 - getGameTime()) / getTicksASecond()) + 1;
+		string units = ((secs != 1) ? " seconds" : " second");
+		
+		string need_to_switch_string = "";
+		if (name != "builder") need_to_switch_string = getTranslatedString("and switch to builder ");
+		
+		SColor color = SColor(200, 135, 185, 45);
+		int wood_amount = 100;
+		int stone_amount = 30;
+		if (this.isWarmup())
+		{
+			wood_amount = 300;
+			stone_amount = 100;
+		}
+		string text = getTranslatedString("Go to a builder shop or a respawn point {SWITCH}to get a resupply of {WOOD} wood and {STONE} stone.")
+			.replace("{SWITCH}", need_to_switch_string)
+			.replace("{WOOD}", "" + wood_amount)
+			.replace("{STONE}", "" + stone_amount);
+		
+		
 		if (next_items > getGameTime())
 		{
-			string action = (b.getName() == "builder" ? "Go Build" : "Go Fight");
-			if (this.isWarmup())
-			{
-				action = "Prepare for Battle";
-			}
-
-			u32 secs = ((next_items - 1 - getGameTime()) / getTicksASecond()) + 1;
-			string units = ((secs != 1) ? " seconds" : " second");
-			GUI::SetFont("menu");
-			GUI::DrawTextCentered(getTranslatedString("Next resupply in {SEC}{TIMESUFFIX}, {ACTION}!")
-							.replace("{SEC}", "" + secs)
-							.replace("{TIMESUFFIX}", getTranslatedString(units))
-							.replace("{ACTION}", getTranslatedString(action)),
-			              Vec2f(getScreenWidth() / 2, getScreenHeight() / 3 - 70.0f + Maths::Sin(getGameTime() / 3.0f) * 5.0f),
-			              SColor(255, 255, 55, 55));
+			// color = SColor(255, 255, 55, 55);
+			color = SColor(120, 255, 55, 55);
+			
+			text = getTranslatedString("Next resupply of {WOOD} wood and {STONE} stone in {SEC}{TIMESUFFIX}.")
+				.replace("{SEC}", "" + secs)
+				.replace("{TIMESUFFIX}", getTranslatedString(units))
+				.replace("{WOOD}", "" + wood_amount)
+				.replace("{STONE}", "" + stone_amount);
 		}
+		
+		GUI::DrawTextCentered(text, Vec2f(getScreenWidth() / 2, getScreenHeight() / 3 - 70.0f), color);
 	}
+	
+	
+	// TODO(hobey): maybe only draw the cooldown/helptext for archer if low on arrows?
+	propname = getCTFTimerPropertyNameArcher(p);
+	if (name == "archer" && this.exists(propname)) {
+		s32 next_items = this.get_s32(propname);
+		
+		GUI::SetFont("menu");
+		
+		u32 secs = ((next_items - 1 - getGameTime()) / getTicksASecond()) + 1;
+		string units = ((secs != 1) ? " seconds" : " second");
+		
+		SColor color = SColor(200, 135, 185, 45);
+		int wood_amount = 100;
+		int stone_amount = 30;
+		if (this.isWarmup())
+		{
+			wood_amount = 300;
+			stone_amount = 100;
+		}
+		string text = getTranslatedString("Go to an archer shop or a respawn point to get a resupply of 30 arrows.");
+		
+		if (next_items > getGameTime())
+		{
+			// color = SColor(255, 255, 55, 55);
+			color = SColor(120, 255, 55, 55);
+			
+			text = getTranslatedString("Next resupply of 30 arrows in {SEC}{TIMESUFFIX}.")
+				.replace("{SEC}", "" + secs)
+				.replace("{TIMESUFFIX}", getTranslatedString(units));
+		}
+		
+		GUI::DrawTextCentered(text, Vec2f(getScreenWidth() / 2, getScreenHeight() / 3 - 16.0f), color);
+	}
+	
 }

--- a/Rules/CTF/Scripts/CTF_Structs.as
+++ b/Rules/CTF/Scripts/CTF_Structs.as
@@ -3,7 +3,7 @@
 #include "Rules/CommonScripts/BaseTeamInfo.as";
 #include "Rules/CommonScripts/PlayerInfo.as";
 
-namespace ItemFlag
+namespace ItemFlag // NOTE(hobey): unused enum; leaving it here to reduce the probability of mods breaking
 {
 
 	const u32 Builder = 0x01;
@@ -72,7 +72,7 @@ shared class CTFPlayerInfo : PlayerInfo
 
 	u32 spawn_point;
 
-	u32 items_collected;
+	u32 items_collected; // NOTE(hobey): unused variable; leaving it here to reduce the probability of mods breaking
 
 	CTFPlayerInfo() { Setup("", 0, ""); }
 	CTFPlayerInfo(string _name, u8 _team, string _default_config) { Setup(_name, _team, _default_config); }


### PR DESCRIPTION
- **READY**


[Demo Video 1](https://user-images.githubusercontent.com/26771587/102963130-abc75180-44e8-11eb-876b-3d3c24bd766c.mp4)
[Demo Video 2](https://user-images.githubusercontent.com/26771587/102963134-aec24200-44e8-11eb-947a-0f682dbe3f92.mp4)

---

Archer's resupply (for 30 arrows) and builder's resupply (for 300/100 wood + 100/30 stone) are now on seperate timers, meaning that if you resupply as builder, then 10 seconds later switch to archer, the builder resupply will not be delayed because you got 30 arrows. _Archers can now dropmats each respawn in a less annoying way to get wood+stone for their team and dropmats at their tower/midbase more effectively and without having to worry about the arrow-resupply stalling their wood+stone resupply if you messed up your retreat/resupply/death timings as archer._

You can now just walk to of a ballista/warboat when your resupply timer runs out and will get a resupply (just like with the spawn tent/shops). _Just for quality of life_

---

Changed the resupply message to help people that haven't figured out resupplies yet; see Demo Video 1 above.
Tweaked color of resupply message, disabled the text wobbling effect. _There's a lot of players that have played the game a lot but still don't know about resupplying or don't understand it fully. Resupplying and "dropping mats" is an awesome, fundamental game mechanic. It should be like the first thing you learn when you start playing CTF. At the moment, it is harder than it should be to notice the mechanic and figure it out. I hope the new resupply message + help text helps players learn it._

---

If all players in a 6v6-12v12 CTF match drop mats, 100 wood + 30 stone is actually too much. And in a 1v1-4v4, there's not really enough. I'll (hopefully find time and energy to) PR a resupply nerf (something similar to what we have on Captains, less mats the more players there are in a team; or some kind of diminishing return system maybe) at some point (feel free to do it, CatWiz/Bunnie, if you feel like it).

---

collapsed doGiveSpawnMats, canGetSpawnmats and GiveSpawnResources into one function; 
cleaned up onTick in CTF_GiveSpawnItems a bit for readability.
stopped using playerinfo.items_collected since there's now 2 resupply timers anyway (left the variable in the struct to minimize mods breaking)