### PR TITLE
[Fix] Correctly removes file extension if mapcycle doesnt include .png

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -702,7 +702,7 @@ void onTick(CRules@ this)
 {
 	if(isServer() && this.getCurrentState() == GAME)
 	{
-		this.set_u32("match_time", this.get_u32("match_time")+1);
+		this.add_u32("match_time", 1);
 		this.Sync("match_time", true);
 	}
 }
@@ -729,9 +729,9 @@ void getMapName(CRules@ this)
 	{
 		string[] name = map.getMapName().split('/');	 //Official server maps seem to show up as
 		string mapName = name[name.length() - 1];		 //``Maps/CTF/MapNameHere.png`` while using this instead of just the .png
-		mapName = mapName.substr(0,mapName.length() - 4);//Sub by 4 so .cfg OR .png are removed when loading the map
+		mapName = getFilenameWithoutExtension(mapName);  // Remove extension from the filename if it exists
 
-		this.set_string("map_name",mapName);
+		this.set_string("map_name", mapName);
 		this.Sync("map_name",true);
 	}
 }


### PR DESCRIPTION
bunnie_the is no more, long live bunnie_the-End!

# What caused this?
We assumed CMap@ getMapName() would always finish with a file extension, however this is not the case. It can have no extension if a map in mapcycle.cfg doesnt include a .png at the end.
