### PR TITLE
fixed image in boatshop where it displayed a longboat image instead of a warboat

### DIFF
--- a/Entities/Industry/CTFShops/BoatShop/BoatShop.as
+++ b/Entities/Industry/CTFShops/BoatShop/BoatShop.as
@@ -39,7 +39,7 @@ void onInit(CBlob@ this)
 		s.crate_icon = 1;
 	}
 	{
-		string warboat_icon = getTeamIcon("warboat", "VehicleIcons.png", team_num, Vec2f(32, 32), 4);
+		string warboat_icon = getTeamIcon("warboat", "VehicleIcons.png", team_num, Vec2f(32, 32), 2);
 		ShopItem@ s = addShopItem(this, "War Boat", warboat_icon, "warboat", warboat_icon + "\n\n\n" + Descriptions::warboat, false, true);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::warboat);
 		s.crate_icon = 2;


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
The boatshop currently doesn't display the right image when selecting the warboat, this change the longboat image to the warboat image

## Steps to Test or Reproduce
build a boatshop, notice that the warboat image is actually a warboat image 