### PR TITLE
Team Colored Kill Icons

### DIFF
--- a/Rules/CommonScripts/KillMessages.as
+++ b/Rules/CommonScripts/KillMessages.as
@@ -194,7 +194,14 @@ class KillFeed
 			{
 				Vec2f dim(getScreenWidth() - max_username_size.x - max_clantag_size.x - (single_space_size.x*2) - 32, 0);
 				ul.Set(dim.x, ((message_step + yOffset + assists) * 16) - 8);
-				GUI::DrawIconByName(hitterIcon, ul);
+				if (message.attackerteam < 0 || message.attackerteam > 6)
+				{
+					GUI::DrawIconByName(hitterIcon, ul, 1, 1, 7, color_white);
+				}
+				else
+				{
+					GUI::DrawIconByName(hitterIcon, ul, 1, 1, message.attackerteam, color_white);
+				}
 			}
 
 			//draw victim name


### PR DESCRIPTION
Kill message Icons are colored depending on attacker

## Status

 **READY**

## Description
Ever since kill messages were added there has been kill icons. Some of these icons are sprited to be able to change team, but this was never added and those icons always look like they are from blue team no matter what team the attacker is. This PR changes that, so the attacker's team will likewise go onto the kill icon as well. 

Thanks to @Betelgeuse0

## Steps to Test or Reproduce
Simply kill another player from a different team.
