### PR TITLE
Firing arrows is visually better

### DIFF
--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -472,6 +472,7 @@ void DrawBow(CSprite@ this, CBlob@ blob, ArcherInfo@ archer, f32 armangle, const
 	}
 
 	frontarm.SetRelativeZ(1.5f);
+	arrow.SetRelativeZ(1.4f);
 	setArmValues(this.getSpriteLayer("backarm"), true, armangle, -0.1f, "default", Vec2f(-4.0f * sign, 0.0f), armOffset);
 
 	// fire arrow particles


### PR DESCRIPTION
## Status

**READY**

## Description
When shooting arrows, the arrows appear behind the player's head- which looks odd if you notice. Probably unintentional so it is fixed in this request.
_Before:_
![before](https://user-images.githubusercontent.com/68350259/107452208-128ae380-6b06-11eb-9686-3e0d6987f4de.png)
_After:_
![after](https://user-images.githubusercontent.com/68350259/107452231-1b7bb500-6b06-11eb-8468-8ef8a7210364.png)
## Steps to Test or Reproduce
Simply shoot some arrows and look in awe of how much better the animation looks!

