### PR TITLE
Team icons

### DIFF
--- a/Entities/Characters/Archer/ArcherHUD.as
+++ b/Entities/Characters/Archer/ArcherHUD.as
@@ -56,5 +56,5 @@ void onRender(CSprite@ this)
 	DrawCoinsOnHUD(blob, coins, tl, slotsSize - 2);
 
 	// class weapon icon
-	GUI::DrawIcon(iconsFilename, arrow_frame, Vec2f(16, 32), tl + Vec2f(8 + (slotsSize - 1) * 40, -16), 1.0f);
+	GUI::DrawIcon(iconsFilename, arrow_frame, Vec2f(16, 32), tl + Vec2f(8 + (slotsSize - 1) * 40, -16), 1.0f, player.getTeamNum());
 }

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -1071,6 +1071,11 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 // arrow pick menu
 void onCreateInventoryMenu(CBlob@ this, CBlob@ forBlob, CGridMenu @gridmenu)
 {
+	AddIconToken("$Arrow$", "Entities/Characters/Archer/ArcherIcons.png", Vec2f(16, 32), 0, this.getTeamNum());
+	AddIconToken("$WaterArrow$", "Entities/Characters/Archer/ArcherIcons.png", Vec2f(16, 32), 1, this.getTeamNum());
+	AddIconToken("$FireArrow$", "Entities/Characters/Archer/ArcherIcons.png", Vec2f(16, 32), 2, this.getTeamNum());
+	AddIconToken("$BombArrow$", "Entities/Characters/Archer/ArcherIcons.png", Vec2f(16, 32), 3, this.getTeamNum());
+	
 	if (arrowTypeNames.length == 0)
 	{
 		return;

--- a/Entities/Characters/Knight/KnightHUD.as
+++ b/Entities/Characters/Knight/KnightHUD.as
@@ -65,5 +65,5 @@ void onRender(CSprite@ this)
 
 	// draw class icon
 
-	GUI::DrawIcon(iconsFilename, frame, Vec2f(16, 32), tl + Vec2f(8 + (slotsSize - 1) * 40, -16), 1.0f);
+	GUI::DrawIcon(iconsFilename, frame, Vec2f(16, 32), tl + Vec2f(8 + (slotsSize - 1) * 40, -16), 1.0f, player.getTeamNum());
 }

--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -34,9 +34,6 @@ bool canChangeClass(CBlob@ this, CBlob@ blob)
 // default classes
 void InitClasses(CBlob@ this)
 {
-	AddIconToken("$builder_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 8);
-	AddIconToken("$knight_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 12);
-	AddIconToken("$archer_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 16);
 	AddIconToken("$change_class$", "/GUI/InteractionIcons.png", Vec2f(32, 32), 12, 2);
 	addPlayerClass(this, "Builder", "$builder_class_icon$", "builder", "Build ALL the towers.");
 	addPlayerClass(this, "Knight", "$knight_class_icon$", "knight", "Hack and Slash.");
@@ -60,6 +57,9 @@ void BuildRespawnMenuFor(CBlob@ this, CBlob @caller)
 
 void buildSpawnMenu(CBlob@ this, CBlob@ caller)
 {
+	AddIconToken("$builder_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 8, caller.getTeamNum());
+	AddIconToken("$knight_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 12, caller.getTeamNum());
+	AddIconToken("$archer_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 16, caller.getTeamNum());
 	BuildRespawnMenuFor(this, caller);
 }
 

--- a/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
+++ b/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
@@ -9,8 +9,6 @@
 void onInit(CBlob@ this)
 {
 	this.CreateRespawnPoint("ruins", Vec2f(0.0f, 16.0f));
-	AddIconToken("$knight_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 12);
-	AddIconToken("$archer_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 16);
 	AddIconToken("$change_class$", "/GUI/InteractionIcons.png", Vec2f(32, 32), 12, 2);
 	//TDM classes
 	addPlayerClass(this, "Knight", "$knight_class_icon$", "knight", "Hack and Slash.");
@@ -64,6 +62,9 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
+	AddIconToken("$knight_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 12, caller.getTeamNum());
+	AddIconToken("$archer_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 16, caller.getTeamNum());
+	
 	if (!canSeeButtons(this, caller)) return;
 
 	if (canChangeClass(this, caller))


### PR DESCRIPTION
## Status

- **READY**

## Description
Lets several icons use team colors to change their coloration. Class hud icons, class change icons, and archer arrow buttons are affected which weren't previously.
_some examples_
![Changing Class](https://user-images.githubusercontent.com/68350259/108289621-f3b2cf80-714b-11eb-9d83-6e5ee725ca67.png)
![Archer Arrows](https://user-images.githubusercontent.com/68350259/108289636-fad9dd80-714b-11eb-83ee-2603dcd3f899.png)


## Steps to Test or Reproduce
Play as an archer/knight on a team other than team 0 to see the new colors.