### PR TITLE
damaging stone and thick stone drop stone at feet like gold does

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1288,6 +1288,7 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 				{
 					bool ground = map.isTileGround(hi.tile);
 					bool dirt_stone = map.isTileStone(hi.tile);
+					bool dirt_thick_stone = map.isTileThickStone(hi.tile);
 					bool gold = map.isTileGold(hi.tile);
 					bool wood = map.isTileWood(hi.tile);
 					if (ground || wood || dirt_stone || gold)
@@ -1339,6 +1340,28 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 									//Material::fromTile(this, hi.tile, 1.f);
 
 									CBlob@ ore = server_CreateBlobNoInit("mat_gold");
+									if (ore !is null)
+									{
+										ore.Tag('custom quantity');
+	     								ore.Init();
+	     								ore.setPosition(hi.hitpos);
+	     								ore.server_SetQuantity(4);
+	     							}
+								}
+								else if (dirt_thick_stone)
+								{
+									CBlob@ ore = server_CreateBlobNoInit("mat_stone");
+									if (ore !is null)
+									{
+										ore.Tag('custom quantity');
+	     								ore.Init();
+	     								ore.setPosition(hi.hitpos);
+	     								ore.server_SetQuantity(6);
+	     							}
+								}
+								else if (dirt_stone)
+								{
+									CBlob@ ore = server_CreateBlobNoInit("mat_stone");
 									if (ore !is null)
 									{
 										ore.Tag('custom quantity');

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1338,37 +1338,30 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 									// Note: 0.1f damage doesn't harvest anything I guess
 									// This puts it in inventory - include MaterialCommon
 									//Material::fromTile(this, hi.tile, 1.f);
-
 									CBlob@ ore = server_CreateBlobNoInit("mat_gold");
 									if (ore !is null)
 									{
 										ore.Tag('custom quantity');
-	     								ore.Init();
-	     								ore.setPosition(hi.hitpos);
-	     								ore.server_SetQuantity(4);
-	     							}
-								}
-								else if (dirt_thick_stone)
-								{
-									CBlob@ ore = server_CreateBlobNoInit("mat_stone");
-									if (ore !is null)
-									{
-										ore.Tag('custom quantity');
-	     								ore.Init();
-	     								ore.setPosition(hi.hitpos);
-	     								ore.server_SetQuantity(6);
-	     							}
+										ore.Init();
+										ore.setPosition(hi.hitpos);
+										ore.server_SetQuantity(4);
+									}
 								}
 								else if (dirt_stone)
 								{
+									int quantity = 4;
+									if(dirt_thick_stone)
+									{
+										quantity = 6;
+									}
 									CBlob@ ore = server_CreateBlobNoInit("mat_stone");
 									if (ore !is null)
 									{
 										ore.Tag('custom quantity');
-	     								ore.Init();
-	     								ore.setPosition(hi.hitpos);
-	     								ore.server_SetQuantity(4);
-	     							}
+										ore.Init();
+										ore.setPosition(hi.hitpos);
+										ore.server_SetQuantity(quantity);
+									}
 								}
 							}
 						}


### PR DESCRIPTION
## Status

**READY**

## Description

Previously, when a knight hit dirt stone or dirt thick stone, it would not drop any of the stone mats. This PR make it so that when a knight damage a dirt stone or dirt thick stone, 4 or 6 stone mats are dropped at the feet of the knight.

## Steps to Test
Go knight, hit dirt stone, notice that 4 stone dropped at your feet.
Go knight, hit dirt thick stone, notice that 6 stone dropped at your feet.
