### PR TITLE
Set heart owner to killer

### DIFF
--- a/Entities/Items/Heart/DropHeartOnDeath.as
+++ b/Entities/Items/Heart/DropHeartOnDeath.as
@@ -31,6 +31,7 @@ void dropHeart(CBlob@ this)
 			{
 				Vec2f vel(XORRandom(2) == 0 ? -2.0 : 2.0f, -5.0f);
 				heart.setVelocity(vel);
+				heart.set_u16("healer", killer.getNetworkID());
 			}
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When a player is killed and drops a heart, killer immediately becomes it's owner. Lets players gain coins for leaving hearts on the ground for others without picking them up beforehand.