### PR TITLE
Propagate bans

### DIFF
--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -53,6 +53,7 @@ scripts                                           = KAG.as;
 													ColoredNameToggle.as;
 													RegrowPlants.as;
 													ResetQuarry.as;
+													PropagateBans.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0

--- a/Rules/Challenge/gamemode.cfg
+++ b/Rules/Challenge/gamemode.cfg
@@ -39,6 +39,7 @@
 										 TauntMenu.as;
 										 BindingsMenu.as;
 										 ColoredNameToggle.as;
+										 PropagateBans.as;
 
 no_shadowing                                      = 0
 

--- a/Rules/CommonScripts/PropagateBans.as
+++ b/Rules/CommonScripts/PropagateBans.as
@@ -1,6 +1,8 @@
 // This script works with an external program that propagates bans to other connected servers
 // This ensures banned players get banned on all other connected servers
 
+#define SERVER_ONLY
+
 void onBan(const string username, const int minutes, const string reason)
 {
 	tcpr("BAN " + username + " " + minutes + " " + reason);

--- a/Rules/CommonScripts/PropagateBans.as
+++ b/Rules/CommonScripts/PropagateBans.as
@@ -1,0 +1,12 @@
+// This script works with an external program that propagates bans to other connected servers
+// This ensures banned players get banned on all other connected servers
+
+void onBan(const string username, const int minutes, const string reason)
+{
+	tcpr("BAN " + username + " " + minutes + " " + reason);
+}
+
+void onUnban(const string username)
+{
+	tcpr("UNBAN " + username);
+}

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -50,6 +50,7 @@ scripts                                           = KAG.as;
 													TauntMenu.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
+													PropagateBans.as;
 
 daycycle_speed                                    = 10
 daycycle_start                                    = 0.3

--- a/Rules/SmallCTF/gamemode.cfg
+++ b/Rules/SmallCTF/gamemode.cfg
@@ -53,6 +53,7 @@ scripts                                           = KAG.as;
 													ColoredNameToggle.as;
 													RegrowPlants.as;
 													ResetQuarry.as;
+													PropagateBans.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0

--- a/Rules/TDM/gamemode.cfg
+++ b/Rules/TDM/gamemode.cfg
@@ -50,6 +50,7 @@ scripts                                           = KAG.as;
 													TauntMenu.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
+													PropagateBans.as;
 
 no_shadowing                                      = 1
 

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -50,6 +50,7 @@
                                          BindingsMenu.as;
                                          ColoredNameToggle.as;
                                          RegrowPlants.as;
+                                         PropagateBans.as;
 
     daycycle_speed                     = 15			# 1 day = X minutes; / 0 no cycle
     daycycle_start                     = 0.5        # 0.0 midnight; 0.5 - midday; 1.0 midnight


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Bans and unbans are sent out via TCPR to an [external program](https://github.com/eps0003/kag-propagate-bans) that propagates them to all other connected servers. The goal is for this to be used for all official servers.

Demonstration:

https://user-images.githubusercontent.com/30195802/110904625-671bbb80-835d-11eb-89bf-beaab49151a9.mp4



## Steps to Test or Reproduce

1. Run two or more servers
2. Compile and run the program with the info of each server
3. Ban/unban someone on one of the servers
