### PR TITLE
You can now eat while stunned with hotkey, burger price increased to 30 coins

### DIFF
--- a/Entities/Characters/Scripts/EatFoodButton.as
+++ b/Entities/Characters/Scripts/EatFoodButton.as
@@ -12,7 +12,6 @@ void onTick(CBlob@ this)
 {
 	if (isServer() &&
 		this.isKeyJustPressed(key_eat) &&
-		!isKnocked(this) &&
 		this.getHealth() < this.getInitialHealth()
 	) {
 		CBlob @carried = this.getCarriedBlob();

--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -144,7 +144,7 @@ void InitCosts()
 	CTFCosts::beer =                        ReadCost(cfg, "cost_beer"               , 5);
 	CTFCosts::meal =                        ReadCost(cfg, "cost_meal"               , 10);
 	CTFCosts::egg =                         ReadCost(cfg, "cost_egg"                , 30);
-	CTFCosts::burger =                      ReadCost(cfg, "cost_burger"             , 20);
+	CTFCosts::burger =                      ReadCost(cfg, "cost_burger"             , 30);
 
 	//CommonBuilderBlocks.as
 	CTFCosts::workshop_wood =               ReadCost(cfg, "cost_workshop_wood"      , 150);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Currently you cannot eat by pressing V, but you can by taking an item out of your inventory (which requires a bit more clicks and mouse movement). While this may seem like a bug to some people, fixing it would change the balance of the game quite a bit - water would be harder to counter, you couldn't change your currently held item while stunned (eg take the drill out as a builder while stunned, or a lit bomb, which could be quite annoying). Moreover currently with quick enough reflexes you're able to survive a double slash if you heal quickly enough which can allow for skillful clutches. See discussion in #development from 11-13 April for more.

To compensate for this change, price of burgers is increased from 20 to 30 coins
