### PR TITLE
Improved lighting bombs with bad ping

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1074,6 +1074,9 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("get bomb"))
 	{
+		if (this.getCarriedBlob() !is null)
+			return;
+
 		const u8 bombType = params.read_u8();
 		if (bombType >= bombTypeNames.length)
 			return;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Simple fix that just prevents the client from lighting a bomb from the player's inventory if they are holding something. However, the client now needs to wait for the round trip to the server and back before they can throw the bomb. Ideally, the client should tell the server to try to light or throw a bomb and the server decides, but that would require a bit of refactoring. At least this is an improvement from before.

Resolves #1037.

## Steps to Test or Reproduce

1. Run and join a dedicated server
2. Run [clumsy](https://jagt.github.io/clumsy/) with 200ms lag
3. Attempt to light two bombs in quick succession