### PR TITLE
Improved pickup with bad ping

### DIFF
--- a/Entities/Common/Controls/PickupCommon.as
+++ b/Entities/Common/Controls/PickupCommon.as
@@ -1,0 +1,367 @@
+#include "StandardControlsCommon.as"
+
+void GatherPickupBlobs(CBlob@ this)
+{
+	CBlob@[]@ pickupBlobs;
+	this.get("pickup blobs", @pickupBlobs);
+	pickupBlobs.clear();
+	CBlob@[] blobsInRadius;
+
+	if (this.getMap().getBlobsInRadius(this.getPosition(), this.getRadius() + 50.0f, @blobsInRadius))
+	{
+		for (uint i = 0; i < blobsInRadius.length; i++)
+		{
+			CBlob @b = blobsInRadius[i];
+
+			if (b.canBePickedUp(this))
+			{
+				pickupBlobs.push_back(b);
+			}
+		}
+	}
+}
+
+CBlob@ GetBetterAlternativePickupBlobs(CBlob@[] available_blobs, CBlob@ reference)
+{
+	if (reference is null)
+		return reference;
+
+	CBlob@[] blobsInRadius;
+	const string ref_name = reference.getName();
+	const u32 ref_quantity = reference.getQuantity();
+	Vec2f ref_pos = reference.getPosition();
+
+	CBlob @result = reference;
+
+	for (uint i = 0; i < available_blobs.length; i++)
+	{
+		CBlob @b = available_blobs[i];
+		Vec2f b_pos = b.getPosition();
+		if ((b_pos - ref_pos).Length() > 10.0f)
+			continue;
+
+		const string name = b.getName();
+		const u32 quantity = b.getQuantity();
+		if (name == ref_name && quantity > ref_quantity)
+			@result = @b;
+	}
+
+	return result;
+}
+
+void ClearPickupBlobs(CBlob@ this)
+{
+	this.clear("pickup blobs");
+}
+
+void FillAvailable(CBlob@ this, CBlob@[]@ available, CBlob@[]@ pickupBlobs)
+{
+	for (uint i = 0; i < pickupBlobs.length; i++)
+	{
+		CBlob @b = pickupBlobs[i];
+
+		if (b !is this && canBlobBePickedUp(this, b))
+		{
+			available.push_back(b);
+		}
+	}
+}
+
+f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
+{
+	u32 gameTime = getGameTime();
+
+	const string thisname = this.getName(),
+		name = b.getName();
+	u32 unpackTime = b.get_u32("unpack time");
+
+	const bool same_team = b.getTeamNum() == this.getTeamNum();
+	const bool material = b.hasTag("material");
+
+	// Military scale factor constants, NOT including military resources
+	const float factor_military = 0.4f,
+		factor_military_team = 0.6f,
+		factor_military_useful = 0.3f,
+		factor_military_lit = 0.2f,
+		factor_military_important = 0.15f,
+		factor_military_critical = 0.1f;
+
+	// Resource scale factor constants
+	const float factor_resource_boring = 0.7f,
+		factor_resource_useful = 0.5f,
+		factor_resource_useful_rare = 0.45f,
+		factor_resource_strategic = 0.4f,
+		factor_resource_critical = 0.3f;
+
+	// Generic scale factor constants
+	const float factor_very_boring = 1.0f,
+		factor_common = 0.9f,
+		factor_boring = 0.8f,
+		factor_important = 0.025f,
+		factor_very_important = 0.01f,
+		factor_super_important = 0.001f;
+
+	//// MISC ////
+
+	// Special stuff such as flags
+	if (b.hasTag("special"))
+	{
+		return factor_super_important;
+	}
+
+	//// MILITARY ////
+	{
+		// special mine check for unarmed enemy mines
+		if (name == "mine" && b.hasTag("mine_priming") && !same_team)
+		{
+			return factor_important;
+		}
+
+		// Military stuff we don't want to pick up when in the same team and always considered lit
+		if (name == "mine" || name == "bomb" || name == "waterbomb")
+		{
+			// Make an exception to the team rule: when the explosive is the holder's
+			bool mine = b.getDamageOwnerPlayer() is this.getPlayer();
+
+			return (same_team && !mine) ? factor_military_team : factor_military_lit;
+		}
+
+		bool exploding = b.hasTag("exploding");
+
+		// Kegs, really matters when lit (exploding)
+		// But we still want a high priority so bombjumping with kegs is easier
+		if (name == "keg")
+		{
+			return exploding ? factor_very_important : factor_military_important;
+		}
+
+		// Regular military stuff
+		if (name == "boulder" || name == "saw")
+		{
+			return factor_military;
+		}
+
+		if (name == "drill")
+		{
+			return thisname == "builder" ? factor_military_useful : factor_military;
+		}
+
+		if (name == "crate")
+		{
+			if (same_team)
+			{
+				return factor_military_team;
+			}
+
+			// Consider crates useful usually but unpacking enemy crates important
+			return (unpackTime > gameTime && !same_team) ? factor_military_important : factor_military_useful;
+		}
+
+		// Other exploding stuff we don't recognize
+		if (exploding)
+		{
+			return factor_military_lit;
+		}
+	}
+
+	//// MATERIALS ////
+	if (material)
+	{
+		const bool builder = (thisname == "builder");
+
+		if (name == "mat_gold")
+		{
+			return factor_resource_strategic;
+		}
+
+		if (name == "mat_stone")
+		{
+			return builder ? factor_resource_useful_rare : factor_resource_boring;
+		}
+
+		if (name == "mat_wood")
+		{
+			return builder ? factor_resource_useful : factor_resource_boring;
+		}
+
+		const bool knight = (thisname == "knight");
+
+		if (name == "mat_bombs" || name == "mat_waterbombs")
+		{
+			return knight ? factor_resource_useful : factor_resource_boring;
+		}
+
+		const bool archer = (thisname == "archer");
+
+		if (name == "mat_arrows")
+		{
+			// Lower priority for regular arrows when the archer has more than 15 in the inventory
+			return archer && !this.hasBlob("mat_arrows", 15) ? factor_resource_useful : factor_resource_boring;
+		}
+
+		if (name == "mat_waterarrows" || name == "mat_firearrows" || name == "mat_bombarrows")
+		{
+			return archer ? factor_resource_useful_rare : factor_resource_boring;
+		}
+	}
+
+	//// MISC ////
+	if (name == "food" || name == "heart" || (name == "fishy" && b.hasTag("dead"))) // Wait, is there a better way to do that?
+	{
+		float factor_full_life = (thisname == "archer" ? factor_resource_useful : factor_resource_boring);
+		return this.getHealth() < this.getInitialHealth() ? factor_resource_critical : factor_full_life;
+	}
+
+	//low priority
+	if (name == "log" || b.hasTag("tree"))
+	{
+		return factor_boring;
+	}
+
+	if (name == "bucket" && b.get_u8("filled") > 0)
+	{
+		return factor_resource_useful;
+	}
+
+
+	// super low priority, dead stuff - sick of picking up corpses
+	if (b.hasTag("dead"))
+	{
+		return factor_very_boring;
+	}
+
+	return factor_common;
+}
+
+f32 getPriorityPickupScale(CBlob@ this, CBlob@ b, f32 scale)
+{
+	return scale * getPriorityPickupScale(this, b);
+}
+
+CBlob@ getClosestAimedBlob(CBlob@ this, CBlob@[] available)
+{
+	CBlob@ closest;
+	float lowestScore = 16.0f; // TODO provide better sorting routines in the interface
+
+	for (int i = 0; i < available.length; ++i)
+	{
+		CBlob@ current = available[i];
+
+		float cursorDistance = (this.getAimPos() - current.getPosition()).Length();
+
+		float radius = current.getRadius();
+		if (radius > 3.0f && cursorDistance > current.getRadius() * 1.5f)
+		{
+			continue;
+		}
+
+		if (cursorDistance < lowestScore)
+		{
+			lowestScore = cursorDistance;
+			@closest = @current;
+		}
+	}
+
+	return closest;
+}
+
+CBlob@ getClosestBlob(CBlob@ this)
+{
+	CBlob@ closest;
+
+	CBlob@[]@ pickupBlobs;
+	if (this.get("pickup blobs", @pickupBlobs))
+	{
+		Vec2f pos = this.getPosition();
+
+		CBlob@[] available;
+		FillAvailable(this, available, pickupBlobs);
+
+		if (!isTapPickup(this))
+		{
+			CBlob@ closestAimed = getClosestAimedBlob(this, available);
+			if (closestAimed !is null)
+			{
+				return closestAimed;
+			}
+		}
+
+		float closestScore = 999999.9f;
+
+		for (uint i = 0; i < available.length; ++i)
+		{
+			CBlob @b = available[i];
+			Vec2f bpos = b.getPosition();
+
+			float maxDist = Maths::Max(this.getRadius() + b.getRadius() + 20.0f, 36.0f);
+
+			float dist = (bpos - pos).getLength();
+			float factor = dist / maxDist;
+			float score = getPriorityPickupScale(this, b, factor);
+
+			if (score < closestScore)
+			{
+				closestScore = score;
+				@closest = @b;
+			}
+		}
+
+		if (closest !is null) {
+			@closest = @GetBetterAlternativePickupBlobs(available, closest);
+		}
+	}
+
+	return closest;
+}
+
+bool canBlobBePickedUp(CBlob@ this, CBlob@ blob)
+{
+	float maxDist = Maths::Max(this.getRadius() + blob.getRadius() + 20.0f, 36.0f);
+
+	Vec2f pos = this.getPosition() + Vec2f(0.0f, -this.getRadius() * 0.9f);
+	Vec2f pos2 = blob.getPosition();
+
+	Vec2f ray = pos2 - pos;
+	bool canRayCast = false;
+
+	CMap@ map = getMap();
+
+	HitInfo@[] hitInfos;
+	if(map.getHitInfosFromRay(pos, -ray.getAngle(), ray.Length(), this, hitInfos))
+	{
+		for (int i = 0; i < hitInfos.length; i++)
+		{
+			HitInfo@ hi = hitInfos[i];
+			CBlob@ b = hi.blob;
+
+			// collide with anything that isn't a platform
+			// could do proper platform direction check but probably not needed
+			if (b !is null && b !is this && b !is blob && b.isCollidable() && b.getShape().isStatic() && !b.isPlatform())
+			{
+				canRayCast = false;
+				break;
+
+			}
+
+			if(map.isTileSolid(hi.tile))
+			{
+				canRayCast = false;
+				break;
+			}
+
+			// if our blob isn't in the list that means the ray stopped at a block
+			if (b is blob)
+			{
+				canRayCast = true;
+			}
+		}
+
+	} else {
+		canRayCast = true;
+	}
+
+	return (((pos2 - pos).getLength() <= maxDist)
+	        && !blob.isAttached() && !blob.hasTag("no pickup")
+	        && (canRayCast || this.isOverlapping(blob)) //overlapping fixes "in platform" issue
+	       );
+}

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -300,7 +300,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 				DoThrow(owner, carried, pos, vector, vel);
 			}
 		}
-		else if (pickBlob !is null)
+		else if (pickBlob !is null && !pickBlob.isInInventory())
 		{
 			this.server_Pickup(pickBlob);
 		}

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -1,12 +1,10 @@
 // Standard menu player controls
 // add to blob and sprite
 
-#include "StandardControlsCommon.as"
 #include "ThrowCommon.as"
 #include "WheelMenuCommon.as"
 #include "KnockedCommon.as"
-
-const u32 PICKUP_ERASE_TICKS = 80;
+#include "PickupCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -15,10 +13,10 @@ void onInit(CBlob@ this)
 	CBlob@[] closestblobs;
 	this.set("closest blobs", closestblobs);
 
-//	this.addCommandID("detach"); in StandardControls
-
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
+
+	this.addCommandID("custom pickup");
 
 	AddIconToken("$filled_bucket$", "Bucket.png", Vec2f(16, 16), 1);
 
@@ -137,8 +135,6 @@ void onTick(CBlob@ this)
 	{
 		TapPickup(this);
 
-		CBlob @carryBlob = this.getCarriedBlob();
-
 		if (this.isAttached()) // default drop from attachment
 		{
 			int count = this.getAttachmentPointCount();
@@ -156,13 +152,6 @@ void onTick(CBlob@ this)
 					break;
 				}
 			}
-		}
-		else if (carryBlob !is null && !carryBlob.hasTag("custom drop") && (!carryBlob.hasTag("temp blob")))
-		{
-			ClearPickupBlobs(this);
-			client_SendThrowCommand(this);
-			this.set_bool("release click", false);
-
 		}
 		else
 		{
@@ -240,19 +229,12 @@ void onTick(CBlob@ this)
 			CBlob@[]@ closestBlobs;
 			this.get("closest blobs", @closestBlobs);
 			closestBlobs.clear();
+
 			CBlob@ closest = getClosestBlob(this);
 			if (closest !is null)
 			{
 				closestBlobs.push_back(closest);
-				/*
-				if (this.isKeyJustPressed(key_action1))	// pickup
-				{
-					server_Pickup(this, this, closest);
-					this.set_bool("release click", false);
-				}
-				*/
 			}
-
 		}
 
 		if (this.isKeyJustReleased(key_pickup))
@@ -261,380 +243,68 @@ void onTick(CBlob@ this)
 			{
 				CBlob@[]@ closestBlobs;
 				this.get("closest blobs", @closestBlobs);
-				if (closestBlobs.length > 0)
+
+				CBlob@ pickBlob;
+
+				if (!closestBlobs.empty())
 				{
-					server_Pickup(this, this, closestBlobs[0]);
+					@pickBlob = closestBlobs[0];
 				}
+
+				CBitStream params;
+				params.write_netid(this.getNetworkID());
+				params.write_bool(pickBlob !is null);
+
+				if (pickBlob !is null)
+				{
+					params.write_netid(pickBlob.getNetworkID());
+				}
+
+				params.write_Vec2f(this.getPosition());
+				params.write_Vec2f(this.getAimPos() - this.getPosition());
+				params.write_Vec2f(this.getVelocity());
+
+				this.SendCommand(this.getCommandID("custom pickup"), params);
 			}
+
 			ClearPickupBlobs(this);
 		}
 	}
 }
 
-void GatherPickupBlobs(CBlob@ this)
+void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
-	CBlob@[]@ pickupBlobs;
-	this.get("pickup blobs", @pickupBlobs);
-	pickupBlobs.clear();
-	CBlob@[] blobsInRadius;
+	if (!isServer()) return;
 
-	if (this.getMap().getBlobsInRadius(this.getPosition(), this.getRadius() + 50.0f, @blobsInRadius))
+	if (cmd == this.getCommandID("custom pickup"))
 	{
-		for (uint i = 0; i < blobsInRadius.length; i++)
-		{
-			CBlob @b = blobsInRadius[i];
+		CBlob@ carried = this.getCarriedBlob();
 
-			if (b.canBePickedUp(this))
+		CBlob@ owner = getBlobByNetworkID(params.read_netid());
+		if (owner is null) return;
+
+		CBlob@ pickBlob;
+		if (params.read_bool())
+		{
+			@pickBlob = getBlobByNetworkID(params.read_netid());
+		}
+
+		if (carried !is null)
+		{
+			Vec2f pos = params.read_Vec2f();
+			Vec2f vector = params.read_Vec2f();
+			Vec2f vel = params.read_Vec2f();
+
+			if (!carried.hasTag("custom throw"))
 			{
-				pickupBlobs.push_back(b);
+				DoThrow(owner, carried, pos, vector, vel);
 			}
 		}
-	}
-}
-
-CBlob@ GetBetterAlternativePickupBlobs(CBlob@[] available_blobs, CBlob@ reference)
-{
-	if (reference is null)
-		return reference;
-
-	CBlob@[] blobsInRadius;
-	const string ref_name = reference.getName();
-	const u32 ref_quantity = reference.getQuantity();
-	Vec2f ref_pos = reference.getPosition();
-
-	CBlob @result = reference;
-
-	for (uint i = 0; i < available_blobs.length; i++)
-	{
-		CBlob @b = available_blobs[i];
-		Vec2f b_pos = b.getPosition();
-		if ((b_pos - ref_pos).Length() > 10.0f)
-			continue;
-
-		const string name = b.getName();
-		const u32 quantity = b.getQuantity();
-		if (name == ref_name && quantity > ref_quantity)
-			@result = @b;
-	}
-
-	return result;
-}
-
-void ClearPickupBlobs(CBlob@ this)
-{
-	this.clear("pickup blobs");
-}
-
-void FillAvailable(CBlob@ this, CBlob@[]@ available, CBlob@[]@ pickupBlobs)
-{
-	for (uint i = 0; i < pickupBlobs.length; i++)
-	{
-		CBlob @b = pickupBlobs[i];
-
-		if (b !is this && canBlobBePickedUp(this, b))
+		else if (pickBlob !is null)
 		{
-			available.push_back(b);
+			this.server_Pickup(pickBlob);
 		}
 	}
-}
-
-f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
-{
-	u32 gameTime = getGameTime();
-
-	const string thisname = this.getName(),
-		name = b.getName();
-	u32 unpackTime = b.get_u32("unpack time");
-
-	const bool same_team = b.getTeamNum() == this.getTeamNum();
-	const bool material = b.hasTag("material");
-
-	// Military scale factor constants, NOT including military resources
-	const float factor_military = 0.4f,
-		factor_military_team = 0.6f,
-		factor_military_useful = 0.3f,
-		factor_military_lit = 0.2f,
-		factor_military_important = 0.15f,
-		factor_military_critical = 0.1f;
-
-	// Resource scale factor constants
-	const float factor_resource_boring = 0.7f,
-		factor_resource_useful = 0.5f,
-		factor_resource_useful_rare = 0.45f,
-		factor_resource_strategic = 0.4f,
-		factor_resource_critical = 0.3f;
-
-	// Generic scale factor constants
-	const float factor_very_boring = 1.0f,
-		factor_common = 0.9f,
-		factor_boring = 0.8f,
-		factor_important = 0.025f,
-		factor_very_important = 0.01f,
-		factor_super_important = 0.001f;
-
-	//// MISC ////
-
-	// Special stuff such as flags
-	if (b.hasTag("special"))
-	{
-		return factor_super_important;
-	}
-
-	//// MILITARY ////
-	{
-		// special mine check for unarmed enemy mines
-		if (name == "mine" && b.hasTag("mine_priming") && !same_team)
-		{
-			return factor_important;
-		}
-
-		// Military stuff we don't want to pick up when in the same team and always considered lit
-		if (name == "mine" || name == "bomb" || name == "waterbomb")
-		{
-			// Make an exception to the team rule: when the explosive is the holder's
-			bool mine = b.getDamageOwnerPlayer() is this.getPlayer();
-
-			return (same_team && !mine) ? factor_military_team : factor_military_lit;
-		}
-
-		bool exploding = b.hasTag("exploding");
-
-		// Kegs, really matters when lit (exploding)
-		// But we still want a high priority so bombjumping with kegs is easier
-		if (name == "keg")
-		{
-			return exploding ? factor_very_important : factor_military_important;
-		}
-
-		// Regular military stuff
-		if (name == "boulder" || name == "saw")
-		{
-			return factor_military;
-		}
-
-		if (name == "drill")
-		{
-			return thisname == "builder" ? factor_military_useful : factor_military;
-		}
-
-		if (name == "crate")
-		{
-			if (same_team)
-			{
-				return factor_military_team;
-			}
-
-			// Consider crates useful usually but unpacking enemy crates important
-			return (unpackTime > gameTime && !same_team) ? factor_military_important : factor_military_useful;
-		}
-
-		// Other exploding stuff we don't recognize
-		if (exploding)
-		{
-			return factor_military_lit;
-		}
-	}
-
-	//// MATERIALS ////
-	if (material)
-	{
-		const bool builder = (thisname == "builder");
-
-		if (name == "mat_gold")
-		{
-			return factor_resource_strategic;
-		}
-
-		if (name == "mat_stone")
-		{
-			return builder ? factor_resource_useful_rare : factor_resource_boring;
-		}
-
-		if (name == "mat_wood")
-		{
-			return builder ? factor_resource_useful : factor_resource_boring;
-		}
-
-		const bool knight = (thisname == "knight");
-
-		if (name == "mat_bombs" || name == "mat_waterbombs")
-		{
-			return knight ? factor_resource_useful : factor_resource_boring;
-		}
-
-		const bool archer = (thisname == "archer");
-
-		if (name == "mat_arrows")
-		{
-			// Lower priority for regular arrows when the archer has more than 15 in the inventory
-			return archer && !this.hasBlob("mat_arrows", 15) ? factor_resource_useful : factor_resource_boring;
-		}
-
-		if (name == "mat_waterarrows" || name == "mat_firearrows" || name == "mat_bombarrows")
-		{
-			return archer ? factor_resource_useful_rare : factor_resource_boring;
-		}
-	}
-
-	//// MISC ////
-	if (name == "food" || name == "heart" || (name == "fishy" && b.hasTag("dead"))) // Wait, is there a better way to do that?
-	{
-		float factor_full_life = (thisname == "archer" ? factor_resource_useful : factor_resource_boring);
-		return this.getHealth() < this.getInitialHealth() ? factor_resource_critical : factor_full_life;
-	}
-
-	//low priority
-	if (name == "log" || b.hasTag("tree"))
-	{
-		return factor_boring;
-	}
-
-	if (name == "bucket" && b.get_u8("filled") > 0)
-	{
-		return factor_resource_useful;
-	}
-
-
-	// super low priority, dead stuff - sick of picking up corpses
-	if (b.hasTag("dead"))
-	{
-		return factor_very_boring;
-	}
-
-	return factor_common;
-}
-
-f32 getPriorityPickupScale(CBlob@ this, CBlob@ b, f32 scale)
-{
-	return scale * getPriorityPickupScale(this, b);
-}
-
-CBlob@ getClosestAimedBlob(CBlob@ this, CBlob@[] available)
-{
-	CBlob@ closest;
-	float lowestScore = 16.0f; // TODO provide better sorting routines in the interface
-
-	for (int i = 0; i < available.length; ++i)
-	{
-		CBlob@ current = available[i];
-
-		float cursorDistance = (this.getAimPos() - current.getPosition()).Length();
-
-		float radius = current.getRadius();
-		if (radius > 3.0f && cursorDistance > current.getRadius() * 1.5f)
-		{
-			continue;
-		}
-
-		if (cursorDistance < lowestScore)
-		{
-			lowestScore = cursorDistance;
-			@closest = @current;
-		}
-	}
-
-	return closest;
-}
-
-CBlob@ getClosestBlob(CBlob@ this)
-{
-	CBlob@ closest;
-
-	CBlob@[]@ pickupBlobs;
-	if (this.get("pickup blobs", @pickupBlobs))
-	{
-		Vec2f pos = this.getPosition();
-
-		CBlob@[] available;
-		FillAvailable(this, available, pickupBlobs);
-
-		if (!isTapPickup(this))
-		{
-			CBlob@ closestAimed = getClosestAimedBlob(this, available);
-			if (closestAimed !is null)
-			{
-				return closestAimed;
-			}
-		}
-
-		float closestScore = 999999.9f;
-
-		for (uint i = 0; i < available.length; ++i)
-		{
-			CBlob @b = available[i];
-			Vec2f bpos = b.getPosition();
-
-			float maxDist = Maths::Max(this.getRadius() + b.getRadius() + 20.0f, 36.0f);
-
-			float dist = (bpos - pos).getLength();
-			float factor = dist / maxDist;
-			float score = getPriorityPickupScale(this, b, factor);
-
-			if (score < closestScore)
-			{
-				closestScore = score;
-				@closest = @b;
-			}
-		}
-
-		if (closest !is null) {
-			@closest = @GetBetterAlternativePickupBlobs(available, closest);
-		}
-	}
-
-	return closest;
-}
-
-bool canBlobBePickedUp(CBlob@ this, CBlob@ blob)
-{
-	float maxDist = Maths::Max(this.getRadius() + blob.getRadius() + 20.0f, 36.0f);
-
-	Vec2f pos = this.getPosition() + Vec2f(0.0f, -this.getRadius() * 0.9f);
-	Vec2f pos2 = blob.getPosition();
-
-	Vec2f ray = pos2 - pos;
-	bool canRayCast = false;
-
-	CMap@ map = getMap();
-
-	HitInfo@[] hitInfos;
-	if(map.getHitInfosFromRay(pos, -ray.getAngle(), ray.Length(), this, hitInfos))
-	{
-		for (int i = 0; i < hitInfos.length; i++)
-		{
-			HitInfo@ hi = hitInfos[i];
-			CBlob@ b = hi.blob;
-
-			// collide with anything that isn't a platform
-			// could do proper platform direction check but probably not needed
-			if (b !is null && b !is this && b !is blob && b.isCollidable() && b.getShape().isStatic() && !b.isPlatform())
-			{
-				canRayCast = false;
-				break;
-
-			}
-
-			if(map.isTileSolid(hi.tile))
-			{
-				canRayCast = false;
-				break;
-			}
-
-			// if our blob isn't in the list that means the ray stopped at a block
-			if (b is blob)
-			{
-				canRayCast = true;
-			}
-		}
-
-	} else {
-		canRayCast = true;
-	}
-
-	return (((pos2 - pos).getLength() <= maxDist)
-	        && !blob.isAttached() && !blob.hasTag("no pickup")
-	        && (canRayCast || this.isOverlapping(blob)) //overlapping fixes "in platform" issue
-	       );
 }
 
 void onInit(CSprite@ this)

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
 
-	this.addCommandID("custom pickup");
+	this.addCommandID("pickup item");
 
 	AddIconToken("$filled_bucket$", "Bucket.png", Vec2f(16, 16), 1);
 
@@ -264,7 +264,7 @@ void onTick(CBlob@ this)
 				params.write_Vec2f(this.getAimPos() - this.getPosition());
 				params.write_Vec2f(this.getVelocity());
 
-				this.SendCommand(this.getCommandID("custom pickup"), params);
+				this.SendCommand(this.getCommandID("pickup item"), params);
 			}
 
 			ClearPickupBlobs(this);
@@ -276,7 +276,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
 	if (!isServer()) return;
 
-	if (cmd == this.getCommandID("custom pickup"))
+	if (cmd == this.getCommandID("pickup item"))
 	{
 		CBlob@ carried = this.getCarriedBlob();
 

--- a/Entities/Common/Throwing/ActivateHeldObject.as
+++ b/Entities/Common/Throwing/ActivateHeldObject.as
@@ -15,8 +15,6 @@
 
 #include "ThrowCommon.as";
 
-const f32 DEFAULT_THROW_VEL = 6.0f;
-
 void onInit(CBlob@ this)
 {
 	if (!this.exists("names to activate"))
@@ -120,59 +118,4 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			//this.Tag( carried.getName() + " done throw" );
 		}
 	}
-}
-
-
-// THROW
-
-void DoThrow(CBlob@ this, CBlob@ carried, Vec2f pos, Vec2f vector, Vec2f selfVelocity)
-{
-	f32 ourvelscale = 0.0f;
-
-	if (this.get_bool("throw uses ourvel"))
-	{
-		ourvelscale = this.get_f32("throw ourvel scale");
-	}
-
-	Vec2f vel = getThrowVelocity(this, vector, selfVelocity, ourvelscale);
-
-	if (carried !is null)
-	{
-		if (carried.hasTag("medium weight"))
-		{
-			vel *= 0.6f;
-		}
-		else if (carried.hasTag("heavy weight"))
-		{
-			vel *= 0.3f;
-		}
-
-		if (carried.server_DetachFrom(this))
-		{
-			carried.setVelocity(vel);
-
-			CShape@ carriedShape = carried.getShape();
-			if (carriedShape !is null)
-			{
-				carriedShape.checkCollisionsAgain = true;
-				carriedShape.ResolveInsideMapCollision();
-			}
-		}
-	}
-}
-
-Vec2f getThrowVelocity(CBlob@ this, Vec2f vector, Vec2f selfVelocity, f32 this_vel_affect = 0.1f)
-{
-	Vec2f vel = vector;
-	f32 len = vel.Normalize();
-	vel *= DEFAULT_THROW_VEL;
-	vel *= this.get_f32("throw scale");
-	vel += selfVelocity * this_vel_affect; // blob velocity
-
-	f32 closeDist = this.getRadius() + 64.0f;
-	if (selfVelocity.getLengthSquared() < 0.1f && len < closeDist)
-	{
-		vel *= len / closeDist;
-	}
-	return vel;
 }

--- a/Entities/Common/Throwing/ThrowCommon.as
+++ b/Entities/Common/Throwing/ThrowCommon.as
@@ -1,5 +1,7 @@
 //throwing common functionality.
 
+const f32 DEFAULT_THROW_VEL = 6.0f;
+
 void client_SendThrowOrActivateCommand(CBlob@ this)
 {
 	CBlob @carried = this.getCarriedBlob();
@@ -33,4 +35,56 @@ void server_ActivateCommand(CBlob@ this, CBlob@ blob)
 		blob.SendCommand(blob.getCommandID("activate"));
 		blob.Tag("activated");
 	}
+}
+
+void DoThrow(CBlob@ this, CBlob@ carried, Vec2f pos, Vec2f vector, Vec2f selfVelocity)
+{
+	f32 ourvelscale = 0.0f;
+
+	if (this.get_bool("throw uses ourvel"))
+	{
+		ourvelscale = this.get_f32("throw ourvel scale");
+	}
+
+	Vec2f vel = getThrowVelocity(this, vector, selfVelocity, ourvelscale);
+
+	if (carried !is null)
+	{
+		if (carried.hasTag("medium weight"))
+		{
+			vel *= 0.6f;
+		}
+		else if (carried.hasTag("heavy weight"))
+		{
+			vel *= 0.3f;
+		}
+
+		if (carried.server_DetachFrom(this))
+		{
+			carried.setVelocity(vel);
+
+			CShape@ carriedShape = carried.getShape();
+			if (carriedShape !is null)
+			{
+				carriedShape.checkCollisionsAgain = true;
+				carriedShape.ResolveInsideMapCollision();
+			}
+		}
+	}
+}
+
+Vec2f getThrowVelocity(CBlob@ this, Vec2f vector, Vec2f selfVelocity, f32 this_vel_affect = 0.1f)
+{
+	Vec2f vel = vector;
+	f32 len = vel.Normalize();
+	vel *= DEFAULT_THROW_VEL;
+	vel *= this.get_f32("throw scale");
+	vel += selfVelocity * this_vel_affect; // blob velocity
+
+	f32 closeDist = this.getRadius() + 64.0f;
+	if (selfVelocity.getLengthSquared() < 0.1f && len < closeDist)
+	{
+		vel *= len / closeDist;
+	}
+	return vel;
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The client no longer needs to wait for the player to pick up items to throw them. If you press C twice in quick succession while near an item with bad ping, you pick up and throw the item even though the item is yet to be picked up on the second press.

The downside to this is now items are thrown when C is released instead of on press. This only applies to C and not other controls that throw items like space.

This PR also moves some pickup methods into a new file called PickupCommon.as and throw methods into ThrowCommon.as so the code can potentially be reused.

## Steps to Test or Reproduce

1. Run and join a dedicated server
2. Run [clumsy](https://jagt.github.io/clumsy/) with 200ms lag
3. Attempt to pickup and throw items fast
4. Notice how you don't need to wait for items to visibly be in your hand to throw it
