### PR TITLE
Dead enemy bodies open team bridges

### DIFF
--- a/Entities/Characters/Scripts/RunnerDeath.as
+++ b/Entities/Characters/Scripts/RunnerDeath.as
@@ -91,6 +91,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		// disable tags
 		this.Untag("shielding");
 		this.Untag("player");
+		this.Tag("dead player");
 		this.getShape().getVars().isladder = false;
 		this.getShape().getVars().onladder = false;
 		this.getShape().checkCollisionsAgain = true;

--- a/Entities/Structures/Platform/Bridge.as
+++ b/Entities/Structures/Platform/Bridge.as
@@ -177,7 +177,7 @@ bool canOpen(CBlob@ this, CBlob@ blob)
 {
 	if (this.getTeamNum() != blob.getTeamNum()
 		&& blob.getShape().getConsts().collidable
-		&& (blob.hasTag("player") || blob.hasTag("vehicle")))
+		&& (blob.hasTag("player") || blob.hasTag("dead") || blob.hasTag("vehicle")))
 	{
 		return true;
 

--- a/Entities/Structures/Platform/Bridge.as
+++ b/Entities/Structures/Platform/Bridge.as
@@ -177,7 +177,7 @@ bool canOpen(CBlob@ this, CBlob@ blob)
 {
 	if (this.getTeamNum() != blob.getTeamNum()
 		&& blob.getShape().getConsts().collidable
-		&& (blob.hasTag("player") || blob.hasTag("dead") || blob.hasTag("vehicle")))
+		&& (blob.hasTag("player") || blob.hasTag("dead player") || blob.hasTag("vehicle")))
 	{
 		return true;
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

A very simple change that allows dead enemy bodies to open team bridges. This can allow players to throw bodies onto enemy bridges in hopes of opening them underneath an enemy.

## Steps to Test or Reproduce

1. Place team bridges
2. Swap team
3. Spike yourself to death
4. Throw your dead corpse onto the bridges