### PR TITLE
Custom head auto uploading

### DIFF
--- a/Entities/Characters/Scripts/RunnerHead.as
+++ b/Entities/Characters/Scripts/RunnerHead.as
@@ -124,6 +124,9 @@ CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 	int headsPackIndex = getHeadsPackIndex(headIndex);
 	HeadsPack@ pack = getHeadsPackByIndex(headsPackIndex);
 	string texture_file = pack.filename;
+	
+	// Custom head texture
+	CSpriteLayer@ head = null;
 
 	bool override_frame = false;
 
@@ -137,14 +140,23 @@ CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 		//accolade custom head handling
 		//todo: consider pulling other custom head stuff out to here
 		if (player !is null && !player.isBot())
-		{
-			Accolades@ acc = getPlayerAccolades(player.getUsername());
-			if (acc.hasCustomHead())
+		{	
+			// Can we load player's custom png
+			if (Texture::exists("CustomHead-"+player.getUsername()))
 			{
-				texture_file = acc.customHeadTexture;
-				headIndex = acc.customHeadIndex;
-				headsPackIndex = 0;
-				override_frame = true;
+				@head = this.addTexturedSpriteLayer("head", "CustomHead-"+player.getUsername(), 16, 16);
+			}
+			else
+			{
+				// Does player have a static head file inside
+				Accolades@ acc = getPlayerAccolades(player.getUsername());
+				if (acc.hasCustomHead())
+				{
+					texture_file = acc.customHeadTexture;
+					headIndex = acc.customHeadIndex;
+					headsPackIndex = 0;
+					override_frame = true;
+				}
 			}
 		}
 	}
@@ -156,10 +168,10 @@ CSpriteLayer@ LoadHead(CSprite@ this, int headIndex)
 	int team = doTeamColour(headsPackIndex) ? blob.getTeamNum() : 0;
 	int skin = doSkinColour(headsPackIndex) ? blob.getSkinNum() : 0;
 
-	//add new head
-	CSpriteLayer@ head = this.addSpriteLayer("head", texture_file, 16, 16, team, skin);
+	// add new head if custom head hasnt been set
+	if (head is null)
+		@head = this.addSpriteLayer("head", texture_file, 16, 16, team, skin);
 
-	//
 	headIndex = headIndex % 256; // wrap DLC heads into "pack space"
 
 	// figure out head frame

--- a/Rules/CommonScripts/PatronSupport.as
+++ b/Rules/CommonScripts/PatronSupport.as
@@ -148,7 +148,6 @@ ImageData@ deserializeHeadStream(CBitStream@ params)
 
 void Client_SendCustomHead(CRules@ this)
 {
-
 	if (!isClient() || !Texture::createFromFile("TempHead", PNG_FILENAME))
 		return;
 
@@ -191,6 +190,7 @@ void Client_SendCustomHead(CRules@ this)
 	
 	// Add head texture locally (Server does not send the stream back to us)
 	AddHeadTexture(getLocalPlayer(), data);
+	Texture::destroy("TempHead");
 }
 
 

--- a/Rules/CommonScripts/PatronSupport.as
+++ b/Rules/CommonScripts/PatronSupport.as
@@ -149,43 +149,43 @@ ImageData@ deserializeHeadStream(CBitStream@ params)
 void Client_SendCustomHead(CRules@ this)
 {
 
-    if (!isClient() || !Texture::createFromFile("TempHead", PNG_FILENAME))
-        return;
+	if (!isClient() || !Texture::createFromFile("TempHead", PNG_FILENAME))
+		return;
 
-    ImageData@ data = Texture::data("TempHead");
+	ImageData@ data = Texture::data("TempHead");
 
-    if (data.height() != 16 || data.width() != 64)
-    {
-        error("Could not send " + PNG_FILENAME + ", ensure the width is 64 pixels, and height is 16");
+	if (data.height() != 16 || data.width() != 64)
+	{
+		error("Could not send " + PNG_FILENAME + ", ensure the width is 64 pixels, and height is 16");
 		Texture::destroy("TempHead");
-        return;
-    }
+		return;
+	}
 
-    // Each frame is 16x16
-    // We send each frame instead of each 64x16
-    CBitStream stream = CBitStream();
+	// Each frame is 16x16
+	// We send each frame instead of each 64x16
+	CBitStream stream = CBitStream();
 	stream.write_u8(CustomCmdType::SENDING_HEAD);
 	stream.write_u16(getLocalPlayer().getNetworkID());
 
-    SColor color = color_white;
-    
-    for (int h = 0; h < 16; h++)
-    {
-        for (int w = 0; w < 48; w++)
-        {
-            color = data.get(w, h);
+	SColor color = color_white;
+	
+	for (int h = 0; h < 16; h++)
+	{
+		for (int w = 0; w < 48; w++)
+		{
+			color = data.get(w, h);
 
-            stream.write_u8(color.getAlpha());
+			stream.write_u8(color.getAlpha());
 
-            // Don't send colour if alpha is too low
-            if (color.getAlpha() > ALPHA_IGNORE_LIMIT)
-            {
-                stream.write_u8(color.getRed());
-                stream.write_u8(color.getGreen());
-                stream.write_u8(color.getBlue());
-            }
-        }
-    }
+			// Don't send colour if alpha is too low
+			if (color.getAlpha() > ALPHA_IGNORE_LIMIT)
+			{
+				stream.write_u8(color.getRed());
+				stream.write_u8(color.getGreen());
+				stream.write_u8(color.getBlue());
+			}
+		}
+	}
 
 	this.SendCommand(this.getCommandID("SendCustomHead"), stream);
 	

--- a/Rules/CommonScripts/PatronSupport.as
+++ b/Rules/CommonScripts/PatronSupport.as
@@ -1,19 +1,19 @@
-const string PNG_FILENAME = "CustomHead.png";
+//// Handles patron user's joining a full server & sending over custom heads
+
+const string PNG_FILENAME = "CustomHead.png"; // File to search for when looking for custom head
+const string BIT_STREAM_NAME = "HeadBitStream-"; // CBitStream get/set name (+player.getUsername())
+const string CUSTOM_TEXTURE_NAME = "CustomHead-"; // Texture name for custom head (+player.getUsername())
+const int ALPHA_IGNORE_LIMIT = 50; // Any alpha pixel at or below this will not send the RGB value to server/clients
 const int PATRON_EXTRA_SLOTS = 2;
 
-enum CustomHeadCmd
+namespace CustomCmdType
 {
-	// Server -> Client - Can send customhead notice
-	CAN_SEND_HEAD = 0,
-	// Client -> Server - Sending png to server
-	SENDING_HEAD,
-	// Server -> Client - Sending texture to add to a player
-	HEAD_TO_PLAYER,
-}
-
-void onInit(CRules@ this)
-{
-	this.addCommandID("SendCustomHead");
+	enum SubCommands
+	{
+		CAN_SEND_HEAD = 0, // Server -> Client - Let's client know they can send their head
+		SENDING_HEAD, // Client -> Server - Server process client's head
+		HEAD_TO_PLAYER,
+	}
 }
 
 //extra patron slots handling
@@ -36,11 +36,11 @@ int onProcessFullJoin(CRules@ this, APIPlayer@ user)
 
 void onNewPlayerJoin(CRules@ this, CPlayer@ player)
 {
-
 	if (!isClient())
 		return;
 
 	u16 tier = this.get_u16("supportTier " + player.getUsername());
+
 	if (tier >= SUPPORT_TIER_ROYALGUARD && // if we are high enough in the tier list
 		this.getSpectatorTeamNum() == player.getTeamNum() && // and we are a spectator
 		getPlayersCount_NotSpectator() + PATRON_EXTRA_SLOTS <= sv_maxplayers) // and there are still free slots for us
@@ -48,57 +48,48 @@ void onNewPlayerJoin(CRules@ this, CPlayer@ player)
 		player.server_setTeamNum(255); // server will auto balance them
 	}
 
+	// Is client allowed to have a custom head?
 	if (tier >= SUPPORT_TIER_ROUNDTABLE)
 	{
+		// Let them know they can send us a head
 		CBitStream stream = CBitStream();
-		stream.write_u8(CAN_SEND_HEAD);
+		stream.write_u8(CustomCmdType::CAN_SEND_HEAD);
 
 		this.SendCommand(this.getCommandID("SendCustomHead"), stream, player);
 	}
 
 	// Check to see if there are any custom head's currently in game
-	// if so, send it to our player
+	// If so, send it to the new guy
 	for (int a = 0; a < getPlayerCount(); a++)
 	{
 		CPlayer@ p = getPlayer(a);
+
 		if (p is null)
 			continue;
 
-		if (this.exists("head-bitstream-"+player.getUsername()))
+		if (this.exists(BIT_STREAM_NAME + player.getUsername()))
 		{
 			CBitStream@ stream;
+			this.get_CBitStream(BIT_STREAM_NAME + player.getUsername(), stream);
 
-			this.get_CBitStream("head-bitstream-"+player.getUsername(), stream);
 			this.SendCommand(this.getCommandID("SendCustomHead"), stream, player);
 		}
 	}
-
-
 }
 
 void onPlayerLeave(CRules@ this, CPlayer@ player)
 {
 	if (isServer())
 	{
-		if (this.exists("head-bitstream-"+player.getUsername()))
-			this.set_CBitStream("head-bitstream-"+player.getUsername(), CBitStream());
+		if (this.exists(BIT_STREAM_NAME + player.getUsername()))
+			this.set_CBitStream(BIT_STREAM_NAME + player.getUsername(), CBitStream());
 	}
 
 	if (isClient())
 	{
-		if (Texture::exists("CustomHead-"+player.getUsername()))
-			Texture::destroy("CustomHead-"+player.getUsername());
+		if (Texture::exists(CUSTOM_TEXTURE_NAME + player.getUsername()))
+			Texture::destroy(CUSTOM_TEXTURE_NAME + player.getUsername());
 	}
-}
-
-// TEMP
-void onTick(CRules@ this)
-{
-    CControls@ controls = getControls();
-    if (controls.ActionKeyPressed(AK_MAP))
-    {
-        client_SendCustomHead(this);
-    }
 }
 
 void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
@@ -110,24 +101,24 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 
 	switch (type)
 	{
-		case CAN_SEND_HEAD:
+		case CustomCmdType::CAN_SEND_HEAD:
 			if (isClient())
-				client_SendCustomHead(this);
+				Client_SendCustomHead(this);
 		break;
 
-		case SENDING_HEAD:
+		case CustomCmdType::SENDING_HEAD:
 			if (isServer())
-				server_ProcessHead(this, params);
+				Server_ProcessHead(this, params);
 		break;
 
-		case HEAD_TO_PLAYER:
+		case CustomCmdType::HEAD_TO_PLAYER:
 			if (isClient())
-				client_HeadToPlayer(this, params);
+				Client_HeadToPlayer(this, params);
 		break;
 	}
 }
 
-ImageData@ DeseralizeHead(CBitStream@ params)
+ImageData@ deserializeHeadStream(CBitStream@ params)
 {
 	ImageData head(64, 16);
 
@@ -140,7 +131,7 @@ ImageData@ DeseralizeHead(CBitStream@ params)
 			u8 green = 0;
 			u8 blue = 0;
 
-			if (alpha > 50)
+			if (alpha > ALPHA_IGNORE_LIMIT)
 			{
 				red = params.read_u8();
 				green = params.read_u8();
@@ -155,26 +146,25 @@ ImageData@ DeseralizeHead(CBitStream@ params)
 }
 
 
-void client_SendCustomHead(CRules@ this)
+void Client_SendCustomHead(CRules@ this)
 {
-	//TMEP
-	Texture::destroy("customhead");
 
-    if ( !isClient() || !Texture::createFromFile("customhead", PNG_FILENAME))
+    if (!isClient() || !Texture::createFromFile("TempHead", PNG_FILENAME))
         return;
 
-    ImageData@ data = Texture::data("customhead");
+    ImageData@ data = Texture::data("TempHead");
 
     if (data.height() != 16 || data.width() != 64)
     {
         error("Could not send " + PNG_FILENAME + ", ensure the width is 64 pixels, and height is 16");
+		Texture::destroy("TempHead");
         return;
     }
 
     // Each frame is 16x16
     // We send each frame instead of each 64x16
     CBitStream stream = CBitStream();
-	stream.write_u8(SENDING_HEAD);
+	stream.write_u8(CustomCmdType::SENDING_HEAD);
 	stream.write_u16(getLocalPlayer().getNetworkID());
 
     SColor color = color_white;
@@ -188,7 +178,7 @@ void client_SendCustomHead(CRules@ this)
             stream.write_u8(color.getAlpha());
 
             // Don't send colour if alpha is too low
-            if (color.getAlpha() > 50)
+            if (color.getAlpha() > ALPHA_IGNORE_LIMIT)
             {
                 stream.write_u8(color.getRed());
                 stream.write_u8(color.getGreen());
@@ -198,38 +188,39 @@ void client_SendCustomHead(CRules@ this)
     }
 
 	this.SendCommand(this.getCommandID("SendCustomHead"), stream);
+	
+	// Add head texture locally (Server does not send the stream back to us)
 	AddHeadTexture(getLocalPlayer(), data);
 }
 
 
-void server_ProcessHead(CRules@ this, CBitStream@ params)
+void Server_ProcessHead(CRules@ this, CBitStream@ params)
 {
 	CPlayer@ player = getPlayerByNetworkId(params.read_u16());
 
 	if (player is null)
 		return;
 
-	string pat_username = player.getUsername();
+	string streamUsername = player.getUsername();
 
-	if (this.get_u16("supportTier " + pat_username) <= SUPPORT_TIER_ROUNDTABLE)
+	if (this.get_u16("supportTier " + streamUsername) <= SUPPORT_TIER_ROUNDTABLE)
 	{
-		warn("Player " + pat_username + " has attempted to give us a custom head without having patreon..");
+		warn("Player " + streamUsername + " has attempted to give us a custom head without having correct patreon tier...");
 		return;
 	}
 
 	CBitStream stream = CBitStream();
-	stream.write_u8(HEAD_TO_PLAYER);
+	stream.write_u8(CustomCmdType::HEAD_TO_PLAYER);
 	stream.write_u16(player.getNetworkID());
 	stream.writeBitStream(params);
 
-	this.set_CBitStream("head-bitstream-"+pat_username, stream);
-
+	this.set_CBitStream(BIT_STREAM_NAME + streamUsername, stream);
 
 	for (int a = 0; a < getPlayerCount(); a++)
 	{
 		CPlayer@ p = getPlayer(a);
 
-		if (p is null || p.getUsername() == pat_username)
+		if (p is null || p.getUsername() == streamUsername)
 			continue;
 		
 		this.SendCommand(this.getCommandID("SendCustomHead"), stream, player);
@@ -237,18 +228,18 @@ void server_ProcessHead(CRules@ this, CBitStream@ params)
 }
 
 
-void client_HeadToPlayer(CRules@ this, CBitStream params)
+void Client_HeadToPlayer(CRules@ this, CBitStream params)
 {
 	CPlayer@ player = getPlayerByNetworkId(params.read_u16());
 
 	if (player is null)
 		return;
 
-	AddHeadTexture(player, DeseralizeHead(params));
+	AddHeadTexture(player, deserializeHeadStream(params));
 }
 
 void AddHeadTexture(CPlayer@ player, ImageData@ data)
 {
-	Texture::createFromData("CustomHead-"+player.getUsername(), data);
+	Texture::createFromData(CUSTOM_TEXTURE_NAME + player.getUsername(), data);
 }
 

--- a/Rules/CommonScripts/PatronSupport.as
+++ b/Rules/CommonScripts/PatronSupport.as
@@ -1,8 +1,22 @@
-#define SERVER_ONLY
-//implementation of patron-related rules-side extra functionality
+const string PNG_FILENAME = "CustomHead.png";
+const int PATRON_EXTRA_SLOTS = 2;
+
+enum CustomHeadCmd
+{
+	// Server -> Client - Can send customhead notice
+	CAN_SEND_HEAD = 0,
+	// Client -> Server - Sending png to server
+	SENDING_HEAD,
+	// Server -> Client - Sending texture to add to a player
+	HEAD_TO_PLAYER,
+}
+
+void onInit(CRules@ this)
+{
+	this.addCommandID("SendCustomHead");
+}
 
 //extra patron slots handling
-const int PATRON_EXTRA_SLOTS = 2;
 int onProcessFullJoin(CRules@ this, APIPlayer@ user)
 {
 	this.set_u16("supportTier " + user.username, user.supportTier);
@@ -20,13 +34,186 @@ int onProcessFullJoin(CRules@ this, APIPlayer@ user)
 	return -1;
 }
 
-// If a patreon joins and is on spec team, lets sort this out
-void onNewPlayerJoin( CRules@ this, CPlayer@ player )
+
+void onNewPlayerJoin(CRules@ this, CPlayer@ player)
 {
-	if (this.get_u16("supportTier " + player.getUsername()) >= SUPPORT_TIER_ROYALGUARD && // if we are high enough in the tier list
+	u16 tier = this.get_u16("supportTier " + player.getUsername());
+	if (tier >= SUPPORT_TIER_ROYALGUARD && // if we are high enough in the tier list
 		this.getSpectatorTeamNum() == player.getTeamNum() && // and we are a spectator
 		getPlayersCount_NotSpectator() + PATRON_EXTRA_SLOTS <= sv_maxplayers) // and there are still free slots for us
 	{
 		player.server_setTeamNum(255); // server will auto balance them
 	}
+
+	if (tier >= SUPPORT_TIER_ROUNDTABLE)
+	{
+		CBitStream stream = CBitStream();
+		stream.write_u8(CAN_SEND_HEAD);
+
+		this.SendCommand(this.addCommandID("SendCustomHead"), stream, player);
+	}
+
 }
+
+// TEMP
+void onTick(CRules@ this)
+{
+    CControls@ controls = getControls();
+    if (controls.ActionKeyPressed(AK_MAP))
+    {
+        client_SendCustomHead(this);
+    }
+}
+
+void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
+{
+	if (this.getCommandID("SendCustomHead") != cmd)
+		return;
+
+	u8 type = params.read_u8();
+
+	switch (type)
+	{
+		case CAN_SEND_HEAD:
+			if (isClient())
+				client_SendCustomHead(this);
+		break;
+
+		case SENDING_HEAD:
+			if (isServer())
+				server_ProcessHead(this, params);
+		break;
+
+		case HEAD_TO_PLAYER:
+			if (isClient())
+				client_HeadToPlayer(this, params);
+		break;
+	}
+}
+
+ImageData@ DeseralizeHead(CBitStream@ params)
+{
+	ImageData head(64, 16);
+
+	
+	for (int h = 0; h < 16; h++)
+	{
+		for (int w = 0; w < 48; w++)
+		{
+			u8 alpha = params.read_u8();
+			u8 red = 0;
+			u8 green = 0;
+			u8 blue = 0;
+
+			if (alpha > 50)
+			{
+				red = params.read_u8();
+				green = params.read_u8();
+				blue = params.read_u8();
+			}
+
+			head.put(w, h, SColor(alpha, red, green, blue));
+		}
+	}
+
+	return head;
+}
+
+
+void client_SendCustomHead(CRules@ this)
+{
+	//TMEP
+	Texture::destroy("customhead");
+
+    if ( !isClient() || !Texture::createFromFile("customhead", PNG_FILENAME))
+        return;
+
+    ImageData@ data = Texture::data("customhead");
+
+    if (data.height() != 16 || data.width() != 64)
+    {
+        print("Could not send " + PNG_FILENAME + ", ensure the width is 64 pixels, and height is 16");
+        return;
+    }
+
+    // Each frame is 16x16
+    // We send each frame instead of each 64x16
+    CBitStream stream = CBitStream();
+	stream.write_u8(SENDING_HEAD);
+	stream.write_u16(getLocalPlayer().getNetworkID());
+
+    SColor color = color_white;
+    
+    for (int h = 0; h < 16; h++)
+    {
+        for (int w = 0; w < 48; w++)
+        {
+            color = data.get(w, h);
+
+            stream.write_u8(color.getAlpha());
+
+            // Don't send colour if alpha is too low
+            if (color.getAlpha() > 50)
+            {
+                stream.write_u8(color.getRed());
+                stream.write_u8(color.getGreen());
+                stream.write_u8(color.getBlue());
+            }
+        }
+    }
+
+	this.SendCommand(this.getCommandID("SendCustomHead"), stream);
+	AddHeadTexture(getLocalPlayer(), data);
+}
+
+
+void server_ProcessHead(CRules@ this, CBitStream@ params)
+{
+	CPlayer@ player = getPlayerByNetworkId(params.read_u16());
+
+	if (player is null)
+		return;
+
+	string pat_username = player.getUsername();
+
+	if (this.get_u16("supportTier " + pat_username) <= SUPPORT_TIER_ROUNDTABLE)
+	{
+		warn("Player " + pat_username + " has attempted to give us a custom head without having patreon..");
+		return;
+	}
+
+	CBitStream stream = CBitStream();
+	stream.write_u8(HEAD_TO_PLAYER);
+	stream.write_u16(player.getNetworkID());
+	stream.writeBitStream(params);
+
+	this.set_CBitStream("head-bitstream-"+pat_username, stream);
+
+
+	for (int a = 0; a < getPlayerCount(); a++)
+	{
+		CPlayer@ p = getPlayer(a);
+
+		if (p is null || p.getUsername() == pat_username)
+			continue;
+		
+		this.SendCommand(this.getCommandID("SendCustomHead"), stream, player);
+	}
+}
+
+
+void client_HeadToPlayer(CRules@ this, CBitStream params)
+{
+	CPlayer@ player = getPlayerByNetworkId(params.read_u16());
+
+	if (player is null)
+		return;
+
+	AddHeadTexture(player, DeseralizeHead(params));
+}
+
+void AddHeadTexture(CPlayer@ player, ImageData@ data)
+{
+	Texture::createFromData("CustomHead-"+player.getUsername(), data);
+}
+


### PR DESCRIPTION
## Description:
Patreon user's can use their heads without having to wait for an update.

## Status:
- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## What does this do:
- When a player joins, server sends them a cmd telling them to send their head (if they are allowed to)
- Player searches for `CustomHead.png` and checks the size (64x16)
- Player will send alpha of every pixel (48x16) (note: we do not need to do full 64x16 since last frame is not used)
  - if pixel > 50 alpha (needs tweaking), client also sends rgb
- Server keeps a copy of the head, and will send it to every client (and new client that joins)

Notes: 
- Players who have won a permanent head without patreon can still use their custom heads (However the head still needs to be put inside CustomHeads folder like before (so it requires an update))

Needs doing:
- Validate that it works with multiple people

Future stuff:
- Cache player heads on client(?)
- Put a template CustomHead.png somewhere in the base folder for user's to write over
- Toggle to force user heads to default locally (binded to f6 or something) and save to cache folder
- Admin toggle to force player's head to default (binded to f6 or something)


