### PR TITLE
crates collide with players and arrows again

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -183,7 +183,7 @@ void Land(CBlob@ this)
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
-	return blob.getShape().isStatic() && !blob.hasTag("parachute");
+	return (blob.getShape().isStatic() || blob.getPlayer() !is null || blob.hasTag("projectile")) && !blob.hasTag("parachute");
 }
 
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

simple change that allows players to stand on crates again, as well as use them as cover against archers.  #956  unintentionally removed this, and i think it was good