### PR TITLE
Admins can view inventories of players and other things while in spectator team

### DIFF
--- a/Rules/CTF/gamemode.cfg
+++ b/Rules/CTF/gamemode.cfg
@@ -54,6 +54,7 @@ scripts                                           = KAG.as;
 													RegrowPlants.as;
 													ResetQuarry.as;
 													PropagateBans.as;
+													AdminInvetoryView.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0

--- a/Rules/CommonScripts/AdminInventoryView.as
+++ b/Rules/CommonScripts/AdminInventoryView.as
@@ -1,6 +1,8 @@
 #define CLIENT_ONLY
 
-void onRender(CRules@ this)
+CBlob@ toDrawInventory = null;
+
+void onTick(CRules@ this) // pick which blob's inventory will be drawn_blobs only on game update
 {
 	CMap@ map = getMap();
 	if (map is null) return;
@@ -31,18 +33,32 @@ void onRender(CRules@ this)
 				CBlob@ blob = targets[i];
 				if (blob.getInventory() !is null)
 				{
-						DrawInventoryOfBlob(blob);
-						break;
+						@toDrawInventory = @blob;
+						return;
 				}
 			}
 		}	
+	}
+
+	@toDrawInventory = @null; // if we didn't get any blob, don't draw anything
+}
+
+void onRender(CRules@ this)
+{
+	if (toDrawInventory is null)
+	{
+		return;
+	}
+	else
+	{
+		DrawInventoryOfBlob(toDrawInventory);
 	}
 }
 
 void DrawInventoryOfBlob(CBlob@ this)
 {
 	CInventory@ inv = this.getInventory();
-	string[] drawn;
+	string[] drawn_blobs; // list of inventory blobs that we have already drawn
 	Vec2f tl = this.getInterpolatedScreenPos();
 	Vec2f offset (-40, -120);
 	u8 j = 0;
@@ -53,9 +69,9 @@ void DrawInventoryOfBlob(CBlob@ this)
 		CBlob@ item = inv.getItem(i);
 		const string name = item.getName();
 		
-		if (drawn.find(name) == -1)
+		if (drawn_blobs.find(name) == -1)
 		{
-			drawn.push_back(name);
+			drawn_blobs.push_back(name);
 
 			if (j % columns == 0 && j > 0)
 			{

--- a/Rules/CommonScripts/AdminInventoryView.as
+++ b/Rules/CommonScripts/AdminInventoryView.as
@@ -1,0 +1,79 @@
+#define CLIENT_ONLY
+
+void onRender(CRules@ this)
+{
+	CMap@ map = getMap();
+	if (map is null) return;
+
+	CPlayer@ player = getLocalPlayer();
+	if (player is null) return;
+
+	CControls@ controls = player.getControls();
+	if (controls is null) return;
+
+	Vec2f mouse_pos = controls.getMouseWorldPos();
+
+	if (!player.isMod())
+	{
+		this.RemoveScript("AdminInventoryView.as");
+		return;
+	}
+
+	if (player.getTeamNum() == this.getSpectatorTeamNum() && controls.isKeyPressed(KEY_LCONTROL))
+	{
+		CBlob@[] targets;
+		f32 radius = 32.0f;
+
+		if (map.getBlobsInRadius(mouse_pos, radius, @targets))
+		{
+			for (int i = 0; i < targets.length(); i++)
+			{
+				CBlob@ blob = targets[i];
+				if (blob.getInventory() !is null)
+				{
+						DrawInventoryOfBlob(blob);
+						break;
+				}
+			}
+		}	
+	}
+}
+
+void DrawInventoryOfBlob(CBlob@ this)
+{
+	CInventory@ inv = this.getInventory();
+	string[] drawn;
+	Vec2f tl = this.getInterpolatedScreenPos();
+	Vec2f offset (-40, -120);
+	u8 j = 0;
+	u8 columns = Maths::Ceil(Maths::Sqrt(inv.getItemsCount()));
+
+	for (int i = 0; i < inv.getItemsCount(); i++)
+	{
+		CBlob@ item = inv.getItem(i);
+		const string name = item.getName();
+		
+		if (drawn.find(name) == -1)
+		{
+			drawn.push_back(name);
+
+			if (j % columns == 0 && j > 0)
+			{
+				offset.x = -40;
+				offset.y += 60;
+			}
+			else if (j > 0) offset.x += 40;
+
+			j++;
+			Vec2f tempoffset(0,0);
+			if (item.hasTag("material")) tempoffset.x = 5;
+
+			const int quantity = this.getBlobCount(name);
+			string disp = "" + quantity;
+
+			GUI::DrawIcon(item.inventoryIconName, item.inventoryIconFrame, item.inventoryFrameDimension, tl + offset + tempoffset, 1.0f);
+			GUI::SetFont("menu");
+			GUI::DrawText(disp, tl + Vec2f(offset.x + 10, offset.y + 30), SColor(255, 255, 255, 255));
+		}
+	}
+}

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -51,6 +51,7 @@ scripts                                           = KAG.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
 													PropagateBans.as;
+													AdminInvetoryView.as;
 
 daycycle_speed                                    = 10
 daycycle_start                                    = 0.3

--- a/Rules/SmallCTF/gamemode.cfg
+++ b/Rules/SmallCTF/gamemode.cfg
@@ -54,6 +54,7 @@ scripts                                           = KAG.as;
 													RegrowPlants.as;
 													ResetQuarry.as;
 													PropagateBans.as;
+													AdminInvetoryView.as;
 
 # 1 day = X minutes; / 0 no cycle
 daycycle_speed                                    = 0

--- a/Rules/TDM/gamemode.cfg
+++ b/Rules/TDM/gamemode.cfg
@@ -51,6 +51,7 @@ scripts                                           = KAG.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
 													PropagateBans.as;
+													AdminInvetoryView.as;
 
 no_shadowing                                      = 1
 

--- a/Rules/WAR/gamemode.cfg
+++ b/Rules/WAR/gamemode.cfg
@@ -51,6 +51,7 @@
                                          ColoredNameToggle.as;
                                          RegrowPlants.as;
                                          PropagateBans.as;
+                                         AdminInvetoryView.as;
 
     daycycle_speed                     = 15			# 1 day = X minutes; / 0 no cycle
     daycycle_start                     = 0.5        # 0.0 midnight; 0.5 - midday; 1.0 midnight


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
- 
## Description

New pr with new branch because i fucked up the previous one. Fixed drawing everything only in rows of 2, script now removes itself if player is not admin.

Title. Hold left control and aim at a player or anything that has an inventory to see what's inside.
Works only in spectator team because i think it would be too big of a gameplay advantage to give to just admins, and it can be used for trolling too easily to give it to everyone.