### PR TITLE
Ladder targeting is consistent between teams

### DIFF
--- a/Entities/Characters/Builder/BuilderHittable.as
+++ b/Entities/Characters/Builder/BuilderHittable.as
@@ -64,5 +64,7 @@ bool isUrgent( CBlob@ this, CBlob@ b )
 			//trees
 			b.getName().find("tree") != -1 ||
 			//spikes
-			b.getName() == "spikes";
+			b.getName() == "spikes" ||
+			//ladder
+			b.getName() == "ladder";
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Adding ladders to the list of "urgent" targets makes hitting them work the same for both teams: you can consistently target enemy ladders inside blocks and hit enemy ladders without overlapping them (like you already can do both with ladders of your own team).