### PR TITLE
Bucket: prevent accidental splashing when clicking when inventory is open

### DIFF
--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -51,7 +51,11 @@ void onTick(CBlob@ this)
 		{
 			this.set_u8("water_delay", water_delay - 1);
 		}
-		else if (point.getOccupied() !is null && point.getOccupied().isMyPlayer() && point.getOccupied().isKeyJustPressed(key_action1) && !this.isInWater())
+		else if (point.getOccupied() !is null && 
+				 point.getOccupied().isMyPlayer() && 
+				 point.getOccupied().isKeyJustPressed(key_action1) && 
+				 !this.isInWater() &&
+				 !point.getOccupied().isKeyPressed(key_inventory)) // prevent splash when doing stuff with inventory
 		{
 			this.SendCommand(this.getCommandID("splash"));
 			this.set_u8("water_delay", 30);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This should fix accidentally splashing when the inventory is open, and clicking. This happens for example when trying to put away or take a bucket from inventory by clicking.

## Steps to Test or Reproduce

1. Get and hold a full bucket
2. Open your inventory
3. Try putting (or taking out) the bucket in the inventory by clicking
4. The bucket should now not splash water

