### PR TITLE
Shieldbash consistency, knockback force scales with velocity

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1446,14 +1446,18 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 
 					Vec2f force = Vec2f(shieldVars.direction.x * this.getMass(), -this.getMass()) * 3.0f;
 
-					vellen = Maths::Min(vellen, 8.0f);
+					// scale knockback with knight's velocity
+
+					vellen = Maths::Min(vellen, 8.0f); // cap on velocity so enemies don't get launched too much
 
 					if (vellen < 3.5f)
 					{
+						// roughly the same weak knockback at low velocity
 						force *= Maths::Pow(vellen, 1.0f / 3.0f) / 2;
 					}
 					else
 					{
+						// scale linearly at higher velocity
 						force *= (vellen - 3.5f) / 6 + 0.759f;
 					}
 

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -426,7 +426,7 @@ void onTick(CBlob@ this)
 		}
 	}
 
-	if (!swordState && getNet().isServer())
+	if (!swordState)
 	{
 		knight_clear_actor_limits(this);
 	}
@@ -1407,8 +1407,8 @@ bool isSliding(KnightInfo@ knight)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
-	//return if we didn't collide or if it's teamie
-	if (blob is null || !solid || this.getTeamNum() == blob.getTeamNum())
+	// return if we collided with map, solid (door/platform), or something non-fleshy (like a boulder)
+	if (blob is null || !solid || !blob.hasTag("flesh") || this.getTeamNum() == blob.getTeamNum())
 	{
 		return;
 	}
@@ -1430,6 +1430,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 		{
 			Vec2f pos = this.getPosition();
 			Vec2f vel = this.getOldVelocity();
+			f32 vellen = vel.getLength();
 			vel.Normalize();
 
 			//printf("nor " + vel * normal );
@@ -1439,12 +1440,25 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 				//printf("shi " + shieldVars.direction * normal );
 				if (shieldVars.direction * normal < 0.0f)
 				{
+					//print("" + vellen);
 					knight_add_actor_limit(this, blob);
 					this.server_Hit(blob, pos, vel, 0.0f, Hitters::shield);
 
 					Vec2f force = Vec2f(shieldVars.direction.x * this.getMass(), -this.getMass()) * 3.0f;
 
+					vellen = Maths::Min(vellen, 8.0f);
+
+					if (vellen < 3.5f)
+					{
+						force *= Maths::Pow(vellen, 1.0f / 3.0f) / 2;
+					}
+					else
+					{
+						force *= (vellen - 3.5f) / 6 + 0.759f;
+					}
+
 					blob.AddForce(force);
+					force *= 0.5f;
 					this.AddForce(Vec2f(-force.x, force.y));
 				}
 			}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Currently, shieldbashing a thing adds it to knight actor limit to prevent you from shieldbashing multiple things at once. Serverside, this list is cleared the next tick, but clientside it clears only at the start of a jab/slash. Stun from shieldbash is applied serverside and works correctly, but knockback is clientside, and because of that it doesn't always work. 

You can reproduce this by shieldbashing an enemy player on a server multiple times in a row. Only first shieldbash will knock the enemy back, other ones will only stun them, but not apply knockback. Then if you slash/jab anywhere, shieldbash will work on them correctly again.

This is fixed by simply clearing actor limits on client as well as server. It should_not cause issues (and we didn't notice any during testing), because all other code that checks for actor limits only runs on server anyways.

Shieldbash knockback now scales with shieldbashing player's speed and is in most cases weaker than it was before. This is done to make the shieldbash+jab combo still possible to do on flat terrain. Also being able to throw players around so easily with almost no momentum didn't make much sense to me anyways. It also now pushes the shieldbashing player back with less force for the same reasons.

Also you can now shieldbash only things with "flesh" tag, which prevents you from shieldbashing your own boulders for movement (do they not properly change team or what?), as well as enemy crates and other weird stuff.

tldr knockback consistent, things are thrown around less, rip boulder+tramp meta