### PR TITLE
Sponges no longer dry underwater

### DIFF
--- a/Entities/Items/Sponge/SpongeDryInAir.as
+++ b/Entities/Items/Sponge/SpongeDryInAir.as
@@ -11,10 +11,13 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
-	u8 absorbed = this.get_u8(ABSORBED_PROP);
-	absorbed = Maths::Max(0, absorbed - slow_frequency);
-	this.set_u8(ABSORBED_PROP, absorbed);
-	this.Sync(ABSORBED_PROP, true);
+    if (not this.isInWater())
+    {
+        u8 absorbed = this.get_u8(ABSORBED_PROP);
+        absorbed = Maths::Max(0, absorbed - slow_frequency);
+        this.set_u8(ABSORBED_PROP, absorbed);
+        this.Sync(ABSORBED_PROP, true);
+    }
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes issue #1050, sponges no longer dry underwater, only when in air

## Steps to Test or Reproduce

Toss one sponge underwater and one on dry ground
The sponge on dry ground will dry, the one underwater will not
