### PR TITLE
Trampoline has 360 rotation

### DIFF
--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -47,23 +47,22 @@ void onTick(CBlob@ this)
 
 	if (point.isKeyPressed(key_action1))
 	{
+		// rotate in 45 degree steps
 		angle = Maths::Floor((angle + 22.5f) / 45) * 45;
 		this.setAngleDegrees(-angle);
 	}
 	else if (point.isKeyPressed(key_action2))
 	{
+		// set angle to what was on previous tick
 		angle = this.get_f32("old angle");
 		this.setAngleDegrees(angle);
-		return;
 	}
 	else
 	{
+		// follow cursor normally
 		this.setAngleDegrees(-angle + 90);
 	}
 	
-
-	this.setAngleDegrees(-angle + 90);
-
 	this.set_f32("old angle", this.getAngleDegrees());
 }
 

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -43,19 +43,18 @@ void onTick(CBlob@ this)
 	ray.Normalize();
 	
 	f32 angle = ray.Angle();
-	CControls@ controls = holder.getControls();
 
-	if (point.isKeyPressed(key_action1))
-	{
-		// rotate in 45 degree steps
-		angle = Maths::Floor((angle + 22.5f) / 45) * 45;
-		this.setAngleDegrees(-angle);
-	}
-	else if (point.isKeyPressed(key_action2))
+	if (point.isKeyPressed(key_action2))
 	{
 		// set angle to what was on previous tick
 		angle = this.get_f32("old angle");
 		this.setAngleDegrees(angle);
+	}
+	else if (point.isKeyPressed(key_action1))
+	{
+		// rotate in 45 degree steps
+		angle = Maths::Floor((angle - 67.5f) / 45) * 45;
+		this.setAngleDegrees(-angle);
 	}
 	else
 	{

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -41,12 +41,30 @@ void onTick(CBlob@ this)
 
 	Vec2f ray = holder.getAimPos() - this.getPosition();
 	ray.Normalize();
-
+	
 	f32 angle = ray.Angle();
-	angle = angle > 135 || angle < 45? (holder.isFacingLeft()? 135 : 45) : 90;
-	angle -= 90;
+	CControls@ controls = holder.getControls();
 
-	this.setAngleDegrees(-angle);
+	if (point.isKeyPressed(key_action1))
+	{
+		angle = Maths::Floor((angle + 22.5f) / 45) * 45;
+		this.setAngleDegrees(-angle);
+	}
+	else if (point.isKeyPressed(key_action2))
+	{
+		angle = this.get_f32("old angle");
+		this.setAngleDegrees(angle);
+		return;
+	}
+	else
+	{
+		this.setAngleDegrees(-angle + 90);
+	}
+	
+
+	this.setAngleDegrees(-angle + 90);
+
+	this.set_f32("old angle", this.getAngleDegrees());
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1, Vec2f point2)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Attempt 2.
When held, trampoline freely rotates like drill. 
Holding lmb makes it rotate in 45 degree steps, and holding rmb prevents it from rotating completely (allows players to throw tramps at any angles in different directions and place horizontal tramps more easily)