### PR TITLE
[fix] Game freezing while trying to join a server

### DIFF
--- a/Entities/Natural/Trees/TreeSync.as
+++ b/Entities/Natural/Trees/TreeSync.as
@@ -61,9 +61,9 @@ void InitTree(CBlob@ this, TreeVars@ vars)
 		// recreate growth
 		u8 grown_times = this.get_u8("grown_times");
 
-		while (vars.grown_times < grown_times)
+		for (int a = vars.grown_times; a < grown_times; a++)
 		{
-			DoGrow(this, vars);
+			DoGrow(this, var);
 		}
 
 		if (this.exists("last_grew_time"))

--- a/Entities/Natural/Trees/TreeSync.as
+++ b/Entities/Natural/Trees/TreeSync.as
@@ -63,7 +63,7 @@ void InitTree(CBlob@ this, TreeVars@ vars)
 
 		for (int a = vars.grown_times; a < grown_times; a++)
 		{
-			DoGrow(this, var);
+			DoGrow(this, vars);
 		}
 
 		if (this.exists("last_grew_time"))


### PR DESCRIPTION
# How does this happen?
This happens when a tree is covered by a tile. This does not happen often in vanilla (but has done in the past), but mostly happens on modded servers. When a client joins the game, they get stuck in a while loop trying to call DoGrow, except it wont work because the tree refuses to grow due to the tile blocking it. 

# How does this fix it?
Client will attempt to call do grow a finite amount of times before stopping. Ideally we add some custom logic in DoGrow for when your client is joining to ignore tiles, but for such a rare edge case I feel like this is fitting enough.