### PR TITLE
Fix RegrowPlants not working

### DIFF
--- a/Rules/CommonScripts/RegrowPlants.as
+++ b/Rules/CommonScripts/RegrowPlants.as
@@ -175,7 +175,7 @@ void onInit(CRules@ this)
 
 void onRestart(CRules@ this)
 {
-	next_check_time = 0;
+	next_check_time = min_random_time;
 	// refill TileInfo arrays with info for the newly loaded map
 	dirt_tiles.clear();
 	castle_tiles.clear();

--- a/Rules/CommonScripts/RegrowPlants.as
+++ b/Rules/CommonScripts/RegrowPlants.as
@@ -97,7 +97,7 @@ class TileInfo
 			luck += 0.15f;
 		}
 
-		if (map.isTileGrass(tile_left.type))
+		if (map.isTileGrass(tile_right.type))
 		{
 			luck += 0.15f;
 		}

--- a/Rules/CommonScripts/RegrowPlants.as
+++ b/Rules/CommonScripts/RegrowPlants.as
@@ -175,6 +175,7 @@ void onInit(CRules@ this)
 
 void onRestart(CRules@ this)
 {
+	next_check_time = 0;
 	// refill TileInfo arrays with info for the newly loaded map
 	dirt_tiles.clear();
 	castle_tiles.clear();


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

next_check_time was being set to gametime, so in next matches it didnt work until the match time reached the gametime it was last set at
