### PR TITLE
Fixed a bug where a red arrow would sometimes appear in the HUD at wrong times as builder.

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -508,7 +508,7 @@ void onRender(CSprite@ this)
 							}
 						}
 					}
-					else
+					else if (blob.getCarriedBlob() is null || blob.getCarriedBlob().hasTag("temp blob")) // only display the red arrow while we are building
 					{
 						const f32 maxDist = getMaxBuildDistance(blob) + 8.0f;
 						Vec2f norm = aimPos2D - myPos;


### PR DESCRIPTION
## Status: Ready
I have tested the changes in localhost
I have tested the changes on a CTF server with 1 other person.

## Demo/How to reproduce:
1. Switch to builder.
2. Select wood block in the build menu (or any tile; blob blocks don't trigger the issue).
3. Left Click somewhere out of placement range. Notice the red arrow indicating you can't build that far away from your body.
4. Take any item out of your inventory (picking up items off the ground doesn't trigger the bug).
5. Left Click anywhere. Notice the red arrow appears even though you aren't building.

https://user-images.githubusercontent.com/26771587/128890676-506e5b93-e840-44eb-907b-078714275247.mp4

Note that you can also reproduce the bug by buying an item in step 4, or by taking an item out of an storage/crate/etc. (because those actions also attach an item to your hand without pressing c); only pickup doesn't trigger the bug because pressing c forces you out of building mode.

## Changes
modified BuilderInventory.as:
    onRender(CSprite@ this): The code is currently drawing the red arrow while the player isn't building sometimes. Fixed by adding an if statement that double checks that the player really is building before drawing the red arrow. `if (blob.getCarriedBlob() is null || blob.getCarriedBlob().hasTag("temp blob"))` line 511

## Explanation

Basically the code on line 438-521 works like this:
If we are holding left click and we are building, and if placement failed (which the code determins by checking all the placement failure bools set in the BlockCursor struct) then draw a visualization of the failure/problem to the player.
But, the code that handles taking an item out of your inventory doesn't set bc.blockActive to false, which causes your client to think that you're still building (that's what happens at step 4 in `Demo/How to reproduce`).
The condition I added checks (in a cumbersome way) that you really are still building. The condition should probably be moved further up in the code, for example right after `if (bc !is null) { if (bc.blockActive || bc.blobActive) {` lines 450-452.
But for some reason, the problem only seems to happen with the red "Too far away" arrow, so I'm fine with this fix.

Another idea would be to add a piece of code that sets bc.blockActive to false in an onAttach() hook somewhere in buildercode, but that kind of change feels like it could mess up switching between blocks and items in some laggy scenario when playing on a server, so again, in my opinion, this PR is the correct way to fix the bug.


---

Thanks to RA for complaining enough about this bug that I got curious why it happened!
