### PR TITLE
Added a HUD element that shows coins gained and coins lost next to the player inventory at the bottom of the screen.

### DIFF
--- a/Entities/Common/GUI/ActorHUDStartPos.as
+++ b/Entities/Common/GUI/ActorHUDStartPos.as
@@ -50,6 +50,12 @@ void DrawInventoryOnHUD(CBlob@ this, Vec2f tl)
 	}
 }
 
+class Coin_Info
+{
+    int count, delta;
+	int changed_time;
+};
+
 void DrawCoinsOnHUD(CBlob@ this, const int coins, Vec2f tl, const int slot)
 {
 	if (coins > 0)
@@ -57,5 +63,45 @@ void DrawCoinsOnHUD(CBlob@ this, const int coins, Vec2f tl, const int slot)
 		GUI::DrawIconByName("$COIN$", tl + Vec2f(0 + slot * 40, 0));
 		GUI::SetFont("menu");
 		GUI::DrawText("" + coins, tl + Vec2f(4 + slot * 40 , 24), color_white);
+	}
+
+	if (this !is null)
+	{
+		CPlayer@ player = this.getPlayer();
+		if (player !is null)
+		{
+			Coin_Info@ info;
+			if (!player.exists("coin_info"))
+			{
+				Coin_Info coin_info;
+				coin_info.count = 0;
+				coin_info.delta = 0;
+				coin_info.changed_time = 0;
+				@info = @coin_info;
+				player.set("coin_info", @info);
+			}
+			else
+				player.get("coin_info", @info);
+			if (info is null) return; // should never happen to be null
+
+			if (info.count != coins)
+			{
+				if (info.delta != coins - info.count) // NOTE(hobey): coins just changed
+				{
+					info.changed_time = getGameTime();
+					info.delta = coins - info.count;
+				}
+				else if (info.changed_time + 30 < getGameTime()) // NOTE(hobey): after a while, stop displaying the HUD
+				{
+					info.count = coins;
+					info.delta = 0;
+					return;
+				}
+
+				GUI::DrawIconByName("$COIN$", tl + Vec2f(0 + slot * 40, -48-24));
+				GUI::SetFont("menu");
+				GUI::DrawText((info.delta > 0 ? "+" : "") + info.delta, tl + Vec2f(4 + slot * 40 , -48), (info.delta > 0) ? SColor(255, 0, 255, 0) : SColor(255, 255, 0, 0));
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Status: Ready
I have tested the changes in localhost
I have tested the changes on a CTF server with 1 other person.

## Demo/HowToRepro:
Use the !coins chat command.
Notice a HUD element popping up displaying `+100` next to your inventory at the bottom of the screen.

You can also test the other ways of gaining and losing coins.
  
Gaining coins: 
- Damaging enemy players
- Killing enemy players
- Healing teammate players
- Picking up the little coindrop particles on the ground after a player with coins dies
- Building blocks
- Capping flags / Winning  
  
Losing coins:
- Dying
- Teamkilling
- Buying items

https://user-images.githubusercontent.com/26771587/128892592-e49e35b0-5bcd-4643-b77b-b4d9747a11c7.mp4

https://user-images.githubusercontent.com/26771587/128892606-0c8c0a30-8d81-497a-9ece-b6a2aafa9a82.mp4

https://user-images.githubusercontent.com/26771587/128892617-55f6b994-8caf-4090-a448-1f7440cc075f.mp4


## Changes
Modifies ActorHUDStartPos.as:
- added Coin_Info structure which holds data necessary to draw the coin HUD
- DrawCoinsOnHUD:
        init the coin_info if the property doesn't exist yet, otherwise get the prop (lines 73-84);
        update the coin_info if coins change to start displaying the coin HUD; then, one second after the coins changed, update again to stop displaying the coin HUD (lines 89-99);
        draw the coin HUD (lines 101-103);

---

Note:
I decided to put the coin HUD next to the inventory hud (since that's where your current coins are displayed). It would also makes sense to put it in the center of the screen next to the HUD that displays +100 Wood +30 Stone when you pickup/drop materials or items. I will merge those coin HUD and the item HUD into one if requested.
