### PR TITLE
Added 2 new buttons to the Construct menu of Workshops that place stone backwalls in and around the shop.

### DIFF
--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -37,6 +37,8 @@ namespace CTFCosts
 
 	//CommonBuilderBlocks.as
 	s32 workshop_wood;
+	
+	s32 backwalls_inside_shop_stone, backwalls_around_shop_stone;
 }
 
 //// TTH COSTS ////
@@ -149,6 +151,9 @@ void InitCosts()
 	//CommonBuilderBlocks.as
 	CTFCosts::workshop_wood =               ReadCost(cfg, "cost_workshop_wood"      , 150);
 
+	CTFCosts::backwalls_inside_shop_stone = ReadCost(cfg, "cost_backwalls_inside_shop_stone", 30);
+	CTFCosts::backwalls_around_shop_stone = ReadCost(cfg, "cost_backwalls_around_shop_stone", 40);
+	
 	// war costs ///////////////////////////////////////////////////////////////
 
 	//load config

--- a/Entities/Common/Includes/Descriptions.as
+++ b/Entities/Common/Includes/Descriptions.as
@@ -90,5 +90,8 @@ namespace Descriptions
 
 	//Magic Scrolls
 	scroll_carnage             = getTranslatedString("This magic scroll when cast will turn all nearby enemies into a pile of bloody gibs."),
-	scroll_drought             = getTranslatedString("This magic scroll will evaporate all water in a large surrounding orb.");
+	scroll_drought             = getTranslatedString("This magic scroll will evaporate all water in a large surrounding orb."),
+
+	backkwalls_inside_shop     = getTranslatedString("Place up to 15 stone backwalls INSIDE the 5x3 area of the shop."),
+	backkwalls_around_shop     = getTranslatedString("Place up to 20 stone backwalls AROUND the 5x3 area of the shop, leaving solid blocks as they are.");
 }

--- a/Entities/Industry/CTFShops/CTFCosts.cfg
+++ b/Entities/Industry/CTFShops/CTFCosts.cfg
@@ -65,3 +65,6 @@
 
 	#builder
 	cost_workshop_wood              = 150
+
+	cost_antifire_inside_shop_stone = 30
+	cost_antifire_around_shop_stone = 40


### PR DESCRIPTION
## Status: Ready
I have tested the changes in localhost
I have tested the changes on a CTF server with 1 other person.

## Demo/HowToRepro
Switch to builder.
Place a workshop AKA building AKA empty shop.
Enter the workshop menu.
Press the 2 new buttons in the workshop menu.
The first button should place stone backwalls INSIDE the 5x3 area of the workshop.
The second button should place stone backwalls AROUND the 5x3 area of the workshop, leaving any solid blocks as they are.
Pressing the buttons again should NOT consume any stone unless there are backwalls to repair. Stone should be consumed for each backwall actually placed.

https://user-images.githubusercontent.com/26771587/128896357-a3339dd2-5838-4ddd-a9c4-f38b96801eb2.mp4

https://user-images.githubusercontent.com/26771587/128896374-13b1dfe9-d494-43e2-a415-fbd32ce865f5.mp4

## Changes
Modifies Costs.as, CTFCosts.cfg, Descriptions.as:
  -  added backwalls_inside_shop_stone, backwalls_around_shop_stone values;
          to the CTFCosts{} struct.
          to InitCosts().
          to CTFCosts.cfg.
          to Descriptions.as.
---
Modifies Building.as:
  - onInit: added the 2 new buttons to the construct menu; added the button icon.
  - onCommand:
        if the construct button the player pressed was one of the 2 backwall buttons, item will be null, since we set `s.spawnNothing = true;`. (see Shop.as lines 182-189 for s.spawnNothing logic)  
        Instead, "shop made item" will receive the item name through params. (lines 121-125)
        setup the list of places to place the stonebackwalls. (lines 126-184)
        place stonebackwalls in all the requested places, unless it's occupied by solid blocks or already has full hp stone backwalls. (lines 185-200)
        give back stone for all the tile locations that were occupied. (lines 200-213)
---

Note: There's was a part of the code in Building.as onCommand that tries to "open factory menu immediately after making a factory out of a workshop". I'm not sure if that's supposed to be from the WAR or the TTH gamemode (in TTH you just place the factory directly). I left the code as it is and tried to test TTH both without the changes and with them, but I think the code wasn't meant for TTH or broke quite some time ago.
