### PR TITLE
Fishies now use their sprite as their inventory icon when they grow and when they die.

### DIFF
--- a/Entities/Natural/Animals/Fishy/Fishy.as
+++ b/Entities/Natural/Animals/Fishy/Fishy.as
@@ -29,6 +29,7 @@ void onTick(CSprite@ this)
 	CBlob@ blob = this.getBlob();
 
 	u8 age = Maths::Min(blob.get_u8("age"), 3);
+	u8 age_frame_index = (3-age)*4; // 4 ages, 4 sprite-variants per age (age 0 = old, age 3 = young)
 
 	if (!blob.hasTag("dead"))
 	{
@@ -38,15 +39,18 @@ void onTick(CSprite@ this)
 		        blob.isKeyPressed(key_down))
 		{
 			this.SetAnimation(anims[age][0]);
+			blob.SetInventoryIcon("Fishy.png", age_frame_index+1, Vec2f(16, 16)); // default anim frames are age_frame_index+0, age_frame_index+1, age_frame_index+2.
 		}
 		else
 		{
 			this.SetAnimation(anims[age][1]);
+			blob.SetInventoryIcon("Fishy.png", age_frame_index+0, Vec2f(16, 16)); // idle anim frames are age_frame_index+0.
 		}
 	}
 	else
 	{
 		this.SetAnimation(anims[age][2]);
+		blob.SetInventoryIcon("Fishy.png", age_frame_index+3, Vec2f(16, 16)); // dead anim frames are age_frame_index+3.
 	}
 }
 


### PR DESCRIPTION
## Status: Ready
I have tested the changes in localhost
I have tested the changes on a CTF server with 1 other person.

## Demo/HowToRepro
Spawn a fishy.
Put it in your inventory and notice the icon.

Take the fishy out and kill it.
Put it in your inventory and notice the new icon. (or check it at the inventory HUD at the bottom of your screen)

Spawn more fishies and spawn water (or go on a water map without sharks).
Wait for the fishies to grow.
Check their inventory icons.
Kill them and check their inventory icons.

https://user-images.githubusercontent.com/26771587/128897379-a72b92fa-117d-43e8-9159-5c9664e51b4b.mp4

## Remaining Issue:
    Fishies don't use their custom color.
    The inventory HUD at the bottom of the screen stacks dead and alive fishies together.

## Changes
Modifies Fishy.as
  -  onTick(CSprite@ this): use SetInventoryIcon to set icon depending on the anim type and fishy age.

