### PR TITLE
Sharks now drip water particles while they're on land.

### DIFF
--- a/Entities/Natural/Animals/Shark/Shark.as
+++ b/Entities/Natural/Animals/Shark/Shark.as
@@ -17,6 +17,24 @@ void onTick(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 
+	if (!blob.isInWater())
+	{
+		bool very_wet = (getGameTime() - blob.get_u32("last time in water")) < 20;
+		if (XORRandom(very_wet ? 4 : 15)==0)
+		{
+			float radius_x = 16.f;
+			float radius_y = 3.f;
+			getMap().SplashEffect(blob.getPosition()+Vec2f(-radius_x + XORRandom((radius_x*2+1)*100)*0.01f,
+														   -radius_y + XORRandom((radius_y*2+1)*100)*0.01f), 
+								  Vec2f(0, 2), 
+								  (very_wet ? 8.f : 3.f) + XORRandom(2));
+		}
+	}
+	else
+	{
+		blob.set_u32("last time in water", getGameTime());
+	}
+	
 	if (!blob.hasTag("dead"))
 	{
 		//scary chomping


### PR DESCRIPTION
## Status: Ready
I have tested the changes in localhost
I have tested the changes on a CTF server with 1 other person.

## How To Repro
Spawn a shark and spawn water (!spawnwater) or go on any shark map (Rayne_KingArthursPonds, Punk123_Chasm_Spasm, etc.).
Lure the shark in and out of the water to see the VFX.
Pickup the shark while it's on land, then go in and out of the water to see the VFX.

https://user-images.githubusercontent.com/26771587/128897786-98bcdc1f-3949-47e7-b295-3e43f8d8b099.mp4

## Changes
Modifies shark.as:
-   onTick(CSprite@ this): do SplashEffect on random ticks while not in water. More splashes and bigger splashes for 0.67 seconds after it exits water.

---

Note: Could change it so that it stops dripping eventually, for example after 30-120 seconds on land. Will do if requested.
