### PR TITLE
Builders can now place backwalls into closed doors.

### DIFF
--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -95,11 +95,11 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 		//cant build wood on stone background
 		return false;
 	}
-	else if (map.isTileSolid(backtile) || map.hasTileSolidBlobs(backtile))
+	else if (map.isTileSolid(backtile))
 	{
-		if (!buildSolid && !map.hasTileSolidBlobsNoPlatform(backtile) && !map.isTileSolid(backtile))
+		if (!buildSolid && !map.isTileSolid(backtile))
 		{
-			//skip onwards, platforms don't block backwall
+			//skip onwards, platforms and doors don't block backwall
 		}
 		else
 		{


### PR DESCRIPTION
## Status: Ready
I have tested the changes in localhost
I have tested the changes on a CTF server with 1 other person.

## How To Repro
Place a wooden door.
Ensure the door is closed by standing outside of the door.
Place a stone backwall into the door.

https://user-images.githubusercontent.com/26771587/128899042-1bb50a90-ecb0-4d59-a9dc-60970e063190.mp4

## Changes
Modifies PlacementCommon.as:
- isBuildableAtPos: remove `|| map.hasTileSolidBlobs(backtile)` and `!map.hasTileSolidBlobsNoPlatform(backtile)` from the conditions checking for solid tiles and blobs; they now only check for solid *tiles* (lines 98-102);

