### PR TITLE
More server-side checks for correct blob/block placement

### DIFF
--- a/Entities/Common/Building/BlobPlacement.as
+++ b/Entities/Common/Building/BlobPlacement.as
@@ -58,7 +58,7 @@ bool serverBlobCheck(CBlob@ blob, CBlob@ blobToPlace, Vec2f cursorPos)
 	CMap@ map = getMap();
 	Tile backtile = map.getTile(cursorPos);
 
-	if (map.isTileBedrock(backtile.type) || map.isTileSolid(backtile.type) && map.isTileGroundStuff(backtile.type)) 
+	if (map.isTileBedrock(backtile.type) || map.isTileSolid(backtile.type))
 		return false;
 
 	// Make sure we actually have support at our cursor pos
@@ -78,6 +78,17 @@ bool serverBlobCheck(CBlob@ blob, CBlob@ blobToPlace, Vec2f cursorPos)
 			return false;
 	}
 
+	CBlob @blobAtPos = map.getBlobAtPosition(cursorPos + Vec2f(1, 1));
+
+	// Are we trying to place a blob on a door/ladder/platform/bridge (usually due to lag)?
+	if (blobAtPos !is null && (
+		blobAtPos.hasTag("door") || 
+		blobAtPos.getName() == "wooden_platform" || 
+		blobAtPos.getName() == "ladder" || 
+		blobAtPos.getName() == "bridge"))
+	{
+		return false;
+	}
 
 	return true;
 } 

--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -29,15 +29,6 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 	bool hasReqs = hasRequirements(inv, bc.reqs, missing);
 	bool passesChecks = serverTileCheck(this, index, cursorPos);
 
-	if (!validTile)
-		warn(name + " tried to place an invalid tile");
-
-	if (!hasReqs)
-		warn(name + " tried to place a tile without having correct resoruces");
-
-	if (!passesChecks)
-		warn(name + " tried to place tile in an invalid way");
-
 	if (validTile && hasReqs && passesChecks)
 	{
 		DestroyScenary(cursorPos, cursorPos);
@@ -86,6 +77,25 @@ bool serverTileCheck(CBlob@ blob, u8 tileIndex, Vec2f cursorPos)
 
 		if (map.getSectorAtPosition(pos, "no build") !is null)
 			return false;
+	}
+
+	BuildBlock @blockToPlace = getBlockByIndex(blob, tileIndex);
+	// Are we trying to place a tile on the same tile (usually due to lag)?
+	if (backtile.type == blockToPlace.tile)
+	{
+		return false;
+	}
+
+	CBlob @blobAtPos = map.getBlobAtPosition(cursorPos + Vec2f(1, 1));
+
+	// Are we trying to place a solid tile on a door/ladder/platform/bridge (usually due to lag)?
+	if (blobAtPos !is null && map.isTileSolid(blockToPlace.tile) && (
+		blobAtPos.hasTag("door") || 
+		blobAtPos.getName() == "wooden_platform" || 
+		blobAtPos.getName() == "ladder" || 
+		blobAtPos.getName() == "bridge"))
+	{
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

- Removed the warn prints (they were there for finding hackers more easily, but it just prints a lot in every single match)
- Added a check to prevent blob-inside-blob placement
- Added a check to prevent placing the same tile in the same tilespace a few times in a row when lagging (eg. you could try to place a stone backwall on one tilespace 4 times and lose 8 stone)
- Modified a check to prevent blob-inside-block and block-inside-blob placement

## Steps to Test or Reproduce

Get a 333 ping friend to join a server with you

Make them spam left mouse button while having a stone block/door selected in the spot of a door you're about to destroy; place a block or a door in the same spot after destroying it. Currently it'd result in a door and a block occupying the same spot, but it's fixed in this PR.

Go on a 333 ping server and try to place 4 stone backwalls in the same spot; you will get 8 stone taken away from you. Fixed with this PR
