### PR TITLE
You can no longer accidentally pick up a corpse

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -563,8 +563,8 @@ CBlob@ getClosestBlob(CBlob@ this)
 		{
 			CBlob @b = available[i];
 			Vec2f bpos = b.getPosition();
-			// consider corpse center to be lower than it actually is because otherwise centers of player and corpse will be on same level,
-			// which makes corpse priority skyrocket if player standing too close 
+			// consider corpse center to be lower than it actually is because otherwise centers of player and corpse are on the same level,
+			// which makes corpse priority skyrocket if player is standing too close 
 			if (b.hasTag("dead")) bpos += Vec2f(0, 6.0f);
 
 			float maxDist = Maths::Max(this.getRadius() + b.getRadius() + 20.0f, 36.0f);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

 - increased factor_very_boring to 10
 - getClosestAimedBlob() requires player's cursor to be closer to corpses than to other blobs. This compensates for corpse's large radius and makes them less likely to get in the way of other blobs that are nearby
 - getClosestBlob() considers corpse center to be lower than it actually is. Because player and corpse are same size, their centers can get extremely close, which makes corpse priority skyrocket to very high (low) numbers even if priority factor is set to a high number.
 
Basically it should be impossible to pick up a corpse unless you're either aiming directly at it or there's nothing else to pick up