### PR TITLE
Temporary "fix" for patreon joinfull not working with spectator slots

### DIFF
--- a/Rules/CommonScripts/TeamMenu.as
+++ b/Rules/CommonScripts/TeamMenu.as
@@ -74,7 +74,8 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 	CPlayer@ player = getPlayerByNetworkId(params.read_u16());
 	u8 team = params.read_u8();
 
-	if (player is getLocalPlayer())
+	// doesn't work yet
+	/*if (player is getLocalPlayer())
 	{
 		if (CanSwitchFromSpec(this, player, team))
 		{
@@ -85,6 +86,11 @@ void ReadChangeTeam(CRules@ this, CBitStream @params)
 			client_AddToChat("Game is currently full. Please wait for a new slot before switching teams.", ConsoleColour::GAME);
 			Sound::Play("NoAmmo.ogg");
 		}
+	}*/
+
+	if (player is getLocalPlayer())
+	{
+		ChangeTeam(player, team);
 	}
 }
 


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
 
## Description

Spectator slots do not work well with patreon slots - it doesn't take patreon into account at all: patrons do not have a joinreserved security feature (SwitchFromSpec.as) and setting their tier as a CRules property in onProcessFullJoin() (PatreonSupport.as) doesn't seem to work for some reason (adding prints into it doesnt seem to work either). Moreover, you take up both a reserved slot and a spectator slot when you're a patron for some reason.

If this PR gets merged, the functionality for spectating/patreon joinfull should stay the same as it was before the engine and base changes as long as the server does not have any spectator slots -- temporary fix to let patrons join full servers before we figure out what exactly is wrong

