### PR TITLE
temporary redflash fix

### DIFF
--- a/Entities/Common/Attacks/RedFlash.as
+++ b/Entities/Common/Attacks/RedFlash.as
@@ -1,6 +1,6 @@
 
 //Does the good old "red screen flash" when hit - put just before your script that actually does the hitting
-
+/*
 f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData )
 {
     if (this.isMyPlayer() && damage > 0)
@@ -10,4 +10,13 @@ f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hit
     }
 
     return damage;
+}*/
+
+void onHealthChange( CBlob@ this, f32 oldHealth )
+{
+	if (this.isMyPlayer() && this.getHealth() < oldHealth)
+    {
+        SetScreenFlash( 90, 120, 0, 0);
+        ShakeScreen( 9, 2, this.getPosition() );
+    }
 }

--- a/Entities/Common/Attacks/RedFlash.as
+++ b/Entities/Common/Attacks/RedFlash.as
@@ -1,5 +1,6 @@
 
 //Does the good old "red screen flash" when hit - put just before your script that actually does the hitting
+//onHit temporarily not working here
 /*
 f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData )
 {


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

In the newest build, the client no longer receives the damage float on the onHit hook; it's always 0. I don't know why it's happening and I don't know if it breaks anything else, but redflash doesn't work because of it, because damage is never > 0.

This can be fixed very easily by not using onHit, which this pr does.
