### PR TITLE
Allow shooting hearts with arrows like food

### DIFF
--- a/Entities/Items/Heart/Heart.as
+++ b/Entities/Items/Heart/Heart.as
@@ -3,6 +3,5 @@ void onInit(CBlob@ this)
 	this.set_string("eat sound", "/Heart.ogg");
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 	this.server_SetTimeToDie(40);
-	this.Tag("ignore_arrow");
 	this.Tag("ignore_saw");
 }

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -365,7 +365,7 @@ bool specialArrowHit(CBlob@ blob)
 {
 	string bname = blob.getName();
 	return (bname == "fishy" && blob.hasTag("dead") || bname == "food"
-		|| bname == "steak" || bname == "grain"/* || bname == "heart"*/); //no egg because logic
+		|| bname == "steak" || bname == "grain" || bname == "heart"); //no egg because logic
 }
 
 void Pierce(CBlob @this, CBlob@ blob = null)


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Makes it so that you can shoot hearts as an archer like you can with food. Resolves #1017

## Steps to Test or Reproduce
- Spawn in a heart
- Throw and shoot it
