### PR TITLE
Allow moving spectator camera when voting for new map in CTF

### DIFF
--- a/Rules/CommonScripts/Spectator.as
+++ b/Rules/CommonScripts/Spectator.as
@@ -21,11 +21,6 @@ void SetTargetPlayer(CPlayer@ p)
 
 void Spectator(CRules@ this)
 {
-	if (this.isGameOver() && this.hasScript("PostGameMapVotes"))
-	{
-		return; //prevent camera movement while map voting
-	}
-
 	CCamera@ camera = getCamera();
 	CControls@ controls = getControls();
 

--- a/Rules/CommonScripts/Spectator.as
+++ b/Rules/CommonScripts/Spectator.as
@@ -134,7 +134,11 @@ void Spectator(CRules@ this)
 	}
 	else if (!waitForRelease && controls.isKeyPressed(KEY_LBUTTON) && camera.getTarget() is null) //classic-like held mouse moving
 	{
-		pos += ((mousePos - pos) / 8.0f) * getRenderApproximateCorrectionFactor();
+		// prevent camera moving when clicking to vote for map
+		if (!this.isGameOver() && !this.hasScript("PostGameMapVotes"))
+		{
+			pos += ((mousePos - pos) / 8.0f) * getRenderApproximateCorrectionFactor();
+		}
 	}
 
 	if (targetPlayer() !is null)


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Makes it so that you can move the spectator camera when voting for a new map in CTF. Resolves #1026

## Steps to Test or Reproduce
- Finish a CTF match
- Die or switch to spectator
- Vote for a map
- Move around as spectator
