### PR TITLE
Improve voting UI

### DIFF
--- a/Rules/CommonScripts/VoteCommon.as
+++ b/Rules/CommonScripts/VoteCommon.as
@@ -221,10 +221,18 @@ void Vote(VoteObject@ vote, CPlayer@ p, bool favour)
 		{
 			vote.current_no++;
 		}
-
+		
+		bool should_show_votes;
 		CPlayer@ player = getLocalPlayer();
-		bool should_show_votes = (player.isDev() || player.isGuard() || getNet().isServer()
+		if (player is null)
+		{
+			should_show_votes = getNet().isServer();
+		}
+		else
+		{
+			should_show_votes = (player.isDev() || player.isGuard() || getNet().isServer()
 			|| getSecurity().checkAccess_Feature(player, "admin_color") || player.isRCON());
+		}
 		
 		string text = getTranslatedString("--- {USER} Voted {DECISION} ---")
 						.replace("{USER}", p.getUsername())

--- a/Rules/CommonScripts/VoteCommon.as
+++ b/Rules/CommonScripts/VoteCommon.as
@@ -223,10 +223,15 @@ void Vote(VoteObject@ vote, CPlayer@ p, bool favour)
 		}
 
 		CPlayer@ player = getLocalPlayer();
-		bool is_admin = player.isDev() || player.isGuard() || isAdmin(player) || getSecurity().checkAccess_Feature(player, "admin_color") || player.isRCON();
-		string text = getTranslatedString("--- {USER} Voted {DECISION} ---").replace("{USER}", p.getUsername()).replace("{DECISION}", getTranslatedString(favour ? "In Favour" : "Against")), vote_message_colour();
-		print(text);
-		if (is_admin) // only let admins see what everyone votes
+		bool should_show_votes = (player.isDev() || player.isGuard() || getNet().isServer()
+			|| getSecurity().checkAccess_Feature(player, "admin_color") || player.isRCON());
+		
+		string text = getTranslatedString("--- {USER} Voted {DECISION} ---")
+						.replace("{USER}", p.getUsername())
+						.replace("{DECISION}", getTranslatedString(favour ? "In Favour" : "Against")),
+					vote_message_colour();
+		
+		if (should_show_votes) // only let admins see what everyone votes for
 			client_AddToChat(text);
 	}
 }

--- a/Rules/CommonScripts/VoteCommon.as
+++ b/Rules/CommonScripts/VoteCommon.as
@@ -226,12 +226,12 @@ void Vote(VoteObject@ vote, CPlayer@ p, bool favour)
 		CPlayer@ player = getLocalPlayer();
 		if (player is null)
 		{
-			should_show_votes = getNet().isServer();
+			should_show_votes = isServer();
 		}
 		else
 		{
-			should_show_votes = (player.isDev() || player.isGuard() || getNet().isServer()
-			|| getSecurity().checkAccess_Feature(player, "admin_color") || player.isRCON());
+			should_show_votes = (player.isDev() || player.isGuard()
+				|| isServer() || player.isMod() || player.isRCON());
 		}
 		
 		string text = getTranslatedString("--- {USER} Voted {DECISION} ---")

--- a/Rules/CommonScripts/VoteCommon.as
+++ b/Rules/CommonScripts/VoteCommon.as
@@ -222,12 +222,12 @@ void Vote(VoteObject@ vote, CPlayer@ p, bool favour)
 			vote.current_no++;
 		}
 
-		if (CanPlayerVote(vote, getLocalPlayer()) || getNet().isServer()) //include all in server logs
-		{
-
-
-			client_AddToChat(getTranslatedString("--- {USER} Voted {DECISION} ---").replace("{USER}", p.getUsername()).replace("{DECISION}", getTranslatedString(favour ? "In Favour" : "Against")), vote_message_colour());
-		}
+		CPlayer@ player = getLocalPlayer();
+		bool is_admin = player.isDev() || player.isGuard() || isAdmin(player) || getSecurity().checkAccess_Feature(player, "admin_color") || player.isRCON();
+		string text = getTranslatedString("--- {USER} Voted {DECISION} ---").replace("{USER}", p.getUsername()).replace("{DECISION}", getTranslatedString(favour ? "In Favour" : "Against")), vote_message_colour();
+		print(text);
+		if (is_admin) // only let admins see what everyone votes
+			client_AddToChat(text);
 	}
 }
 

--- a/Rules/CommonScripts/VoteCore.as
+++ b/Rules/CommonScripts/VoteCore.as
@@ -3,7 +3,7 @@
 #include "VoteCommon.as"
 
 //extended vote functionality
-const Vec2f dim(200, 100);
+const Vec2f dim(200, 116);
 
 Vec2f getTopLeft()
 {
@@ -53,17 +53,19 @@ void onRender(CRules@ this)
 
 	GUI::DrawText(getTranslatedString("Reason: {REASON}").replace("{REASON}", getTranslatedString(vote.reason)), tl + Vec2f(3, 3 + text_dim.y * 2), color_white);
 	GUI::DrawText(getTranslatedString("Cast by: {USER}").replace("{USER}", vote.byuser), tl + Vec2f(3, 3 + text_dim.y * 3), color_white);
-	GUI::DrawText(getTranslatedString("[O] - Yes"), tl + Vec2f(20, 3 + text_dim.y * 4), SColor(0xff30bf30));
-	GUI::DrawText(getTranslatedString("[P] - No"), tl + Vec2f(120, 3 + text_dim.y * 4), SColor(0xffbf3030));
+	GUI::DrawText(getTranslatedString("For: ") + vote.current_yes, tl + Vec2f(20, 3 + text_dim.y * 4), color_white);
+	GUI::DrawText(getTranslatedString("Against: ") + vote.current_no, tl + Vec2f(110, 3 + text_dim.y * 4), color_white);
+	GUI::DrawText(getTranslatedString("[O] - Yes"), tl + Vec2f(20, 3 + text_dim.y * 5), SColor(0xff30bf30));
+	GUI::DrawText(getTranslatedString("[P] - No"), tl + Vec2f(120, 3 + text_dim.y * 5), SColor(0xffbf3030));
 
 	if (can_force_pass)
 	{
-		GUI::DrawText(getTranslatedString("Ctrl+O Pass"), tl + Vec2f(3, 3 + text_dim.y * 5), SColor(0xff30bf30));
+		GUI::DrawText(getTranslatedString("Ctrl+O Pass"), tl + Vec2f(3, 3 + text_dim.y * 6), SColor(0xff30bf30));
 	}
 
 	if (can_cancel)
 	{
-		GUI::DrawText(getTranslatedString("Ctrl+P Cancel"), tl + Vec2f(95, 3 + text_dim.y * 5), SColor(0xffbf3030));
+		GUI::DrawText(getTranslatedString("Ctrl+P Cancel"), tl + Vec2f(95, 3 + text_dim.y * 6), SColor(0xffbf3030));
 	}
 
 	GUI::DrawText(getTranslatedString("Click to close ({TIMELEFT}s)").replace("{TIMELEFT}", "" + Maths::Ceil(vote.timeremaining / 30.0f)), br - Vec2f(175, 7 + text_dim.y), color_white);
@@ -151,8 +153,6 @@ void onTick(CRules@ this)
 		CBitStream params;
 		params.write_u16(id);
 		rules.SendCommand(rules.getCommandID(favour ? vote_yes_id : vote_no_id), params);
-
-		g_have_voted = true;
 	}
 }
 


### PR DESCRIPTION
## Status
**READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Resolves #837
- Stops the vote window from disappearing when you vote
- Allows admins to force votes they've already voted in
- Shows the amount of votes for and against in the vote window
- Removes "player voted for/against" chat spam (still shown for admins, devs, guards, and the server logs)

## Steps to Test
As an admin:
- Start a vote
- Vote normally for/against
- See that there's a chat message about your vote
- Force vote for/against

As a normal player:
- Start a vote
- Vote for something
- See that vote window shows your vote
- See that there's no chat message about your vote
- Try to make a second vote
- Click on the vote menu to make it disappear
