### PR TITLE
[fixed] workaround for class swap button disappearing on closeby ballis

### DIFF
--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -245,7 +245,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		{
 			Vehicle_AddLoadAmmoButton(this, caller);
 		}
-		if (!isAnotherRespawnClose(this) && !isFlipped(this))
+		if (/*!isAnotherRespawnClose(this) &&*/ !isFlipped(this))
 		{
 			caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change class"));
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
 
## Description

Class swap buttons were disabled in the main branch when a spawn point was near a given ballista. This seems to be too aggressive at the moment so let's remove that for now, shouldn't be a big deal.
