### PR TITLE
[fixed] crates should collide with each other

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -184,7 +184,8 @@ void Land(CBlob@ this)
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
-	return (blob.getShape().isStatic() || blob.getPlayer() !is null || blob.hasTag("projectile")) && !blob.hasTag("parachute");
+	return (this.getName() == blob.getName())
+	    || ((blob.getShape().isStatic() || blob.hasTag("player") || blob.hasTag("projectile")) && !blob.hasTag("parachute"));
 }
 
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Crates wouldn't collide with each other in the current main branch.