### PR TITLE
Fix magazine requirements

### DIFF
--- a/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -255,7 +255,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int team_num = 0, const stri
 		}
 		{
 			BuildBlock b(0, "magazine", "$magazine$", "Magazine");
-			AddRequirement(b.reqs, "blob", "mat_stone", "Wood", 20);
+			AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 20);
 			blocks[3].push_back(b);
 		}
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Magazine requires 20 stone but when you hover over it in build menu it shows that it needs 20 wood. This pr makes it show 20 stone as cost in build menu.

Image showing changes:
![image_2021-10-31_215007](https://user-images.githubusercontent.com/81253181/139597416-40b19f01-d3a8-4fe7-abb6-ae94fdd29d6d.png)
