### PR TITLE
ballista tth infinite gold exploit fix

### DIFF
--- a/Entities/Common/Building/GoldBuilding.as
+++ b/Entities/Common/Building/GoldBuilding.as
@@ -10,6 +10,8 @@ void onDie(CBlob@ this)
 			50;
 	if (drop_amount == 0) return;
 
+	if (getRules().gamemode_name == "TTH") return; // ballistas and warboats should not drop gold in TTH because they're produced in factories there
+
 	CBlob@ blob = server_CreateBlobNoInit('mat_gold');
 
 	if (blob !is null)


### PR DESCRIPTION
## Status

(pick one)

- **AMOGUS**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes the issue where you could get infinite gold in TTH due to ballistas dropping gold on death even when not costing gold.