### PR TITLE
quarry works on gamemodes that don't have ResetQuarry.as

### DIFF
--- a/Entities/Industry/CTFShops/Quarry/Quarry.as
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.as
@@ -80,10 +80,12 @@ void onInit(CBlob@ this)
 
 	//commands
 	this.addCommandID("add fuel");
+	string current_output = "current_quarry_output_" + this.getTeamNum();
+	CRules@ rules = getRules();
 
-	if (getRules().get_s32("current_quarry_output_" + this.getTeamNum()) == -1)
+	if (!rules.exists(current_output) || rules.get_s32(current_output) == -1)
 	{
-		getRules().set_s32("current_quarry_output_" + this.getTeamNum(), initial_output);
+		rules.set_s32("current_quarry_output_" + this.getTeamNum(), initial_output);
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Title. Initial output would get set only if current output was -1, which was only possible if gamemode had ResetQuarry.as, otherwise current output vars would not exist. Fixed by allowing quarry to set initial output vars if they don't exist yet