### PR TITLE
Fix divide-by-zero in VehicleGUI when max_charge_time is zero

### DIFF
--- a/Entities/Vehicles/Common/VehicleGUI.as
+++ b/Entities/Vehicles/Common/VehicleGUI.as
@@ -30,7 +30,7 @@ void onRender(CSprite@ this)
 		if (!v.getCurrentAmmo().infinite_ammo)
 			drawAmmoCount(blob, v);
 
-		if (blob.getName() != "mounted_bow")
+		if (v.getCurrentAmmo().max_charge_time > 0)
 		{
 			drawChargeBar(blob, v);
 			drawCooldownBar(blob, v);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Fixes divide-by-zero error in VehicleGUI.as and therefore allows non-default vehicles to use instant-fire ammo (that is, ammo with max_charge_time = 0).

## Steps to Test or Reproduce
When you add a custom vehicle without charge delay it crashes when trying to fire because of progressbar percent division. The original code worked for mounted bow because it was explicitly excluded. 


