### PR TITLE
[fixed] frames added to door animation unrestricted

### DIFF
--- a/Entities/Structures/Door/SwingDoor.as
+++ b/Entities/Structures/Door/SwingDoor.as
@@ -187,6 +187,11 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	if (customData == Hitters::bomb)
 		damage *= 1.3f;
 
+	return damage;
+}
+
+void onHealthChange(CBlob@ this, f32 oldHealth)
+{
 	CSprite @sprite = this.getSprite();
 
 	if (sprite !is null)
@@ -197,9 +202,11 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 		if (destruction_anim !is null)
 		{
-			if ((this.getHealth() - damage) < this.getInitialHealth())
+			f32 newHealth = this.getHealth();
+
+			if (newHealth < this.getInitialHealth())
 			{
-				f32 ratio = (this.getHealth() - damage * getRules().attackdamage_modifier) / this.getInitialHealth();
+				f32 ratio = newHealth / this.getInitialHealth();
 
 				if (ratio <= 0.0f)
 				{
@@ -216,15 +223,13 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 		Animation @close_anim = sprite.getAnimation("close");
 		u8 lastframe = close_anim.getFrame(close_anim.getFramesCount() - 1);
-		if (lastframe < frame)
+		if (lastframe < frame) // if our current final frame is less damaged than our door actually is
 		{
-			close_anim.AddFrame(frame);
+			close_anim.RemoveFrame(lastframe);
+			close_anim.AddFrame(frame); // replace the final frame by a more damaged one
 		}
 	}
-
-	return damage;
 }
-
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixed door closing animation.

When a door closes, it will play the following frames: 2 -> 1 -> 0. 0 being the frame of an undamaged closed door.

When a door takes damage (frame 4 to 6, 6 being the final frame before the door is destroyed), the animation is supposed to change to: 2 -> 1 -> 4(/5/6). Currently, rather than replacing the final door frame, it will only add frames to the animation. Right now on production a fully damaged door closing will play the following animation: 2 -> 1 -> 0 -> 4 -> 5 -> 6.

After this PR, it will simply play 2 -> 1 -> 6 when the door is nearly destroyed.

Additionally, moved animation stuff to onHealthChange, as there is no reason to do this in onHit, this means calculating "future health" is no longer necessary, this is in line with other blob blocks (thanks bunnie)
