### PR TITLE
[CTF Rebuild] Water changes, water arrow nerf

### DIFF
--- a/Entities/Common/Attacks/Hitters.as
+++ b/Entities/Common/Attacks/Hitters.as
@@ -73,3 +73,8 @@ bool isExplosionHitter(u8 type)
 {
 	return type == Hitters::bomb || type == Hitters::explosion || type == Hitters::mine || type == Hitters::bomb_arrow;
 }
+
+bool isWaterHitter(u8 type)
+{
+	return type == Hitters::water || type == Hitters::water_stun_force || type == Hitters::water_stun;
+}

--- a/Entities/Common/Attacks/KnockBack.as
+++ b/Entities/Common/Attacks/KnockBack.as
@@ -46,7 +46,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 	Vec2f f(x_side, y_side);
 
-	if (damage > 0.125f)
+	if (damage > 0.125f || isWaterHitter(customData))
 	{
 		this.AddForce(f * 40.0f * scale * Maths::Log(2.0f * (10.0f + (damage * 2.0f))));
 	}

--- a/Entities/Common/FireScripts/FireCommon.as
+++ b/Entities/Common/FireScripts/FireCommon.as
@@ -54,13 +54,3 @@ bool isIgniteHitter(u8 hitter)
 {
 	return hitter == Hitters::fire;
 }
-
-/**
- * Hitters that should put something out when hit
- */
-bool isWaterHitter(u8 hitter)
-{
-	return hitter == Hitters::water ||
-	       hitter == Hitters::water_stun ||
-	       hitter == Hitters::water_stun_force;
-}

--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -101,7 +101,7 @@ void InitCosts()
 
 	//ArcherShop.as
 	CTFCosts::arrows =                      ReadCost(cfg, "cost_arrows"             , 15);
-	CTFCosts::waterarrows =                 ReadCost(cfg, "cost_waterarrows"        , 20);
+	CTFCosts::waterarrows =                 ReadCost(cfg, "cost_waterarrows"        , 25);
 	CTFCosts::firearrows =                  ReadCost(cfg, "cost_firearrows"         , 30);
 	CTFCosts::bombarrows =                  ReadCost(cfg, "cost_bombarrows"         , 50);
 

--- a/Entities/Common/Includes/Costs.as
+++ b/Entities/Common/Includes/Costs.as
@@ -101,7 +101,7 @@ void InitCosts()
 
 	//ArcherShop.as
 	CTFCosts::arrows =                      ReadCost(cfg, "cost_arrows"             , 15);
-	CTFCosts::waterarrows =                 ReadCost(cfg, "cost_waterarrows"        , 25);
+	CTFCosts::waterarrows =                 ReadCost(cfg, "cost_waterarrows"        , 15);
 	CTFCosts::firearrows =                  ReadCost(cfg, "cost_firearrows"         , 30);
 	CTFCosts::bombarrows =                  ReadCost(cfg, "cost_bombarrows"         , 50);
 

--- a/Entities/Common/Includes/SplashWater.as
+++ b/Entities/Common/Includes/SplashWater.as
@@ -95,7 +95,7 @@ Vec2f getBombForce(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 h
 	Vec2f offset = hit_blob_pos - pos;
 	f32 distance = offset.Length();
 	//set the scale (2 step)
-	scale = (distance > (radius * 0.7)) ? 1.0f : 1.0f;
+	scale = (distance > (radius * 0.7)) ? 0.5f : 1.0f;
 	//the force, copy across
 	Vec2f bombforce = offset;
 	bombforce.Normalize();

--- a/Entities/Common/Includes/SplashWater.as
+++ b/Entities/Common/Includes/SplashWater.as
@@ -95,7 +95,7 @@ Vec2f getBombForce(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 h
 	Vec2f offset = hit_blob_pos - pos;
 	f32 distance = offset.Length();
 	//set the scale (2 step)
-	scale = (distance > (radius * 0.7)) ? 0.5f : 1.0f;
+	scale = (distance > (radius * 0.7)) ? 1.0f : 1.0f;
 	//the force, copy across
 	Vec2f bombforce = offset;
 	bombforce.Normalize();

--- a/Entities/Industry/CTFShops/CTFCosts.cfg
+++ b/Entities/Industry/CTFShops/CTFCosts.cfg
@@ -25,7 +25,7 @@
 
 	#archer shop
 	cost_arrows                     = 15
-	cost_waterarrows                = 20
+	cost_waterarrows                = 25
 	cost_firearrows                 = 30
 	cost_bombarrows                 = 50
 

--- a/Entities/Industry/CTFShops/CTFCosts.cfg
+++ b/Entities/Industry/CTFShops/CTFCosts.cfg
@@ -25,7 +25,7 @@
 
 	#archer shop
 	cost_arrows                     = 15
-	cost_waterarrows                = 25
+	cost_waterarrows                = 15
 	cost_firearrows                 = 30
 	cost_bombarrows                 = 50
 

--- a/Entities/Materials/Ammunition/MaterialWaterArrow.as
+++ b/Entities/Materials/Ammunition/MaterialWaterArrow.as
@@ -6,7 +6,7 @@ void onInit(CBlob@ this)
     this.set_u16('decay time', 180);
   }
 
-  this.maxQuantity = 2;
+  this.maxQuantity = 1;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Materials/Ammunition/MaterialWaterArrow.cfg
+++ b/Entities/Materials/Ammunition/MaterialWaterArrow.cfg
@@ -19,7 +19,7 @@ $sprite_animation_start                = *start*
 $sprite_animation_default_name         = default
 u16 sprite_animation_default_time      = 0
 u8 sprite_animation_default_loop       = 0
-@u16 sprite_animation_default_frames   = 20; 28;
+@u16 sprite_animation_default_frames   = 20;
 
 $sprite_animation_end                  = *end*
 


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] water arrows come in stack of 1 instead of 2
[changed] new cost of water arrow: 15 instead of 10
[added] knockback from water bombs and water arrows
[changed] splash from water buckets now does a bit of knockback

