### PR TITLE
[CTF Rebuild] Natural chicken spawning and chicken buff

### DIFF
--- a/Entities/Natural/Animals/Chicken/Chicken.cfg
+++ b/Entities/Natural/Animals/Chicken/Chicken.cfg
@@ -109,7 +109,7 @@ $name                                = chicken
 									   FleshHit.as;
 									   LandAnimal.as;
 									   Chicken.as;
-f32 health                           = 0.5
+f32 health                           = 2.0
 # looks & behaviour inside inventory
 $inventory_name                      = Chicken
 $inventory_icon                      = -             # default

--- a/Rules/CommonScripts/RegrowPlants.as
+++ b/Rules/CommonScripts/RegrowPlants.as
@@ -230,6 +230,10 @@ void onTick(CRules@ this)
 		CMap@ map = getMap();
 		float tilesize = map.tilesize;
 
+		CBlob@[] chicken_list;
+		getBlobsByName("chicken", chicken_list);
+		u16 chicken_count = chicken_list.size();
+
 		for (int i = 1; i < dirt_tiles.size(); i++)
 		{
 			TileInfo tinfo = dirt_tiles[i];
@@ -279,6 +283,14 @@ void onTick(CRules@ this)
 					{
 						server_CreateBlob(plants_stuff[plant], -1, tinfo.coords - Vec2f(0,tilesize));
 					}
+				}
+
+				random_grow = XORRandom(10000) * 0.0001f;
+
+				if (random_grow <= chicken_grow_chance && chicken_count < chicken_limit)
+				{
+					server_CreateBlob("chicken", -1, tinfo.coords - Vec2f(0,tilesize));
+					chicken_count++;
 				}
 			}
 		}

--- a/Rules/CommonScripts/RegrowPlants.as
+++ b/Rules/CommonScripts/RegrowPlants.as
@@ -10,6 +10,8 @@ const f32 grass_grow_chance = 0.015f;
 const f32 bush_grow_chance = 0.003f;
 const f32 flower_grow_chance = 0.0005f;
 const f32 grain_grow_chance = flower_grow_chance + 0.0005f; //add flower chance to prevent them from overriding each other
+const f32 chicken_grow_chance = 0.001f; // chickens are plants don't @ me
+const u8 chicken_limit = 10; 
 
 const f32 moss_stone_chance = 0.002f;
 


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] chickens have more health 
[added] added natural chicken spawning with a limit of 10 chickens per map
