### PR TITLE
[CTF Rebuild] Drill balance changes

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -196,12 +196,6 @@ void onTick(CBlob@ this)
 
 		AimAtMouse(this, holder); // aim at our mouse pos
 
-		// cool faster if holder is moving
-		if (heat > 0 && holder.getShape().vellen > 0.01f && getGameTime() % 4 == 0)
-		{
-			heat--;
-		}
-
 		if (int(heat) >= heat_max - (heat_add * 1.5))
 		{
 			makeSteamPuff(this, 1.5f, 3, false);

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -23,6 +23,8 @@ const u8 heat_add_constructed = 2;
 const u8 heat_add_blob = 6;
 const u8 heat_cool_amount = 2;
 
+const f32 heat_reduction_water = 0.5f;
+
 const u8 heat_cooldown_time = 8;
 const u8 heat_cooldown_time_water = u8(heat_cooldown_time / 3);
 
@@ -44,7 +46,7 @@ void onInit(CSprite@ this)
 			anim.AddFrames(frames);
 		}
 		heat.SetAnimation(anim);
-		heat.SetRelativeZ(1.0f);
+		heat.SetRelativeZ(0.1f);
 		heat.SetVisible(false);
 		heat.setRenderStyle(RenderStyle::light);
 	}
@@ -438,7 +440,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 	if (customData == Hitters::water)
 	{
-		s16 current_heat = this.get_u8(heat_prop) - heat_max * 0.5f;
+		s16 current_heat = this.get_u8(heat_prop) - heat_max * heat_reduction_water;
 		if (current_heat < 0) current_heat = 0;
 		this.set_u8(heat_prop, current_heat);
 		makeSteamPuff(this);

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -14,6 +14,7 @@ const string buzz_prop = "drill timer";
 
 const string heat_prop = "drill heat";
 const u8 heat_max = 150;
+const u8 heat_drop = 140;
 const u8 high_damage_window = 40; // at how much heat before max drill deals increased damage
 
 const string last_drill_prop = "drill last active";
@@ -92,7 +93,7 @@ bool canBePutInInventory( CBlob@ this, CBlob@ inventoryBlob )
 
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {
-	return (this.get_u8(heat_prop) < heat_max - heat_add * 1.5f);
+	return (this.get_u8(heat_prop) < heat_drop);
 }
 
 void onThisRemoveFromInventory( CBlob@ this, CBlob@ inventoryBlob )
@@ -198,7 +199,7 @@ void onTick(CBlob@ this)
 
 		AimAtMouse(this, holder); // aim at our mouse pos
 
-		if (int(heat) >= heat_max - (heat_add * 1.5))
+		if (int(heat) >= heat_drop)
 		{
 			makeSteamPuff(this, 1.5f, 3, false);
 			this.server_Hit(holder, holder.getPosition(), Vec2f(), 0.25f, Hitters::burn, true);

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -44,7 +44,7 @@ void onInit(CSprite@ this)
 			anim.AddFrames(frames);
 		}
 		heat.SetAnimation(anim);
-		heat.SetRelativeZ(0.1f);
+		heat.SetRelativeZ(1.0f);
 		heat.SetVisible(false);
 		heat.setRenderStyle(RenderStyle::light);
 	}

--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -307,7 +307,7 @@ void onTick(CBlob@ this)
 
 								if (isServer())
 								{
-									if (heat_max - int(heat) < high_damage_window) // are we at high heat? more damamge!
+									if (int(heat) >= heat_max - high_damage_window) // are we at high heat? more damage!
 									{
 										attack_dam += 0.5f;
 									}


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[change] receives slightly more heat from hitting tiles like dirt and ore
[change] receives less heat from hitting blobs like players or doors
[change] increased max heat
[change] slower cool down 
[change] water buckets now cool 50% of drill heat instead of 70%
[change] you can't pick up overheated drills anymore (previously you could and have them instantly drop to the ground]
[change] drills now ignore bushes