### PR TITLE
[added] hover message on coin count change next to materials

### DIFF
--- a/Entities/Common/HoverMessage/DrawHoverMessages.as
+++ b/Entities/Common/HoverMessage/DrawHoverMessages.as
@@ -43,6 +43,23 @@ const string[] ignored_material_losses = {
 	"mat_waterbombs",
 };
 
+void updateCoinMessage(CPlayer@ player)
+{
+	const string prop_name = "old coin count";
+
+	if (player.exists(prop_name))
+	{
+		const int quantity_diff = player.getCoins() - player.get_u32(prop_name);
+
+		if (Maths::Abs(quantity_diff) > 0)
+		{
+			add_message(MaterialMessage("Coins", quantity_diff));
+		}
+	}
+
+	player.set_u32(prop_name, player.getCoins());
+}
+
 void onInit(CBlob@ this)
 {
 	this.getCurrentScript().tickFrequency = 5;
@@ -163,4 +180,6 @@ void onTick(CBlob@ this)
 	}
 
 	this.set(prop_string, @current_caches);
+	
+	updateCoinMessage(@player);
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

**Shows coin changes as part of the hover messages.**

This should be tested by more people as this could feel distracting, but in my testing hover messages are subtle enough that it is not an issue.

The fact it shows just next to materials makes it rather obvious what actions give you coins, such as building, fighting, and collecting coins - which is not necessarily obvious to a newbie since there is no other clear visual feedback, mind you. Plus it should help give some indication how much coins are actually earned.  
Since it aims towards fixing #1170, this should also help distinguishing coins and gold, because there has been various instances of newbies getting confused between the two.

This is implemented using a MaterialMessage, with the same timeout and category. The timeout being low could prove being an issue, and if it is, we could adjust it to increase it.

## Steps to Test or Reproduce

1. Join Sandbox or a local CTF server.
2. Earn coins through building, spend coins on stuff, etc.
3. Earned/lost coins should appear with behavior very similar to blob materials.
