### PR TITLE
Reorder items in builder shop to put drill first

### DIFF
--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -32,22 +32,19 @@ void onInit(CBlob@ this)
 	int team_num = this.getTeamNum();
 
 	{
-		ShopItem@ s = addShopItem(this, "Lantern", "$lantern$", "lantern", Descriptions::lantern, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::lantern_wood);
+		ShopItem@ s = addShopItem(this, "Drill", "$drill$", "drill", Descriptions::drill, false);
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::drill_stone);
+		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::drill);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Bucket", "$bucket$", "bucket", Descriptions::bucket, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::bucket_wood);
+		ShopItem@ s = addShopItem(this, "Sponge", "$sponge$", "sponge", Descriptions::sponge, false);
+		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::sponge);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Filled Bucket", "$_buildershop_filled_bucket$", "filled_bucket", Descriptions::filled_bucket, false);
 		s.spawnNothing = true;
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::bucket_wood);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::filled_bucket);
-	}
-	{
-		ShopItem@ s = addShopItem(this, "Sponge", "$sponge$", "sponge", Descriptions::sponge, false);
-		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::sponge);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Boulder", "$boulder$", "boulder", Descriptions::boulder, false);
@@ -57,13 +54,16 @@ void onInit(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::boulder_stone);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Trampoline", getTeamIcon("trampoline", "Trampoline.png", team_num, Vec2f(32, 16), 3), "trampoline", Descriptions::trampoline, false);
-		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::trampoline_wood);
+		ShopItem@ s = addShopItem(this, "Lantern", "$lantern$", "lantern", Descriptions::lantern, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::lantern_wood);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Drill", "$drill$", "drill", Descriptions::drill, false);
-		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", CTFCosts::drill_stone);
-		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::drill);
+		ShopItem@ s = addShopItem(this, "Bucket", "$bucket$", "bucket", Descriptions::bucket, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::bucket_wood);
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Trampoline", getTeamIcon("trampoline", "Trampoline.png", team_num, Vec2f(32, 16), 3), "trampoline", Descriptions::trampoline, false);
+		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", CTFCosts::trampoline_wood);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Saw", getTeamIcon("saw", "VehicleIcons.png", team_num, Vec2f(32, 32), 3), "saw", Descriptions::saw, false);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This PR re-orders the builder shop, with the main goal of moving the drill from position 7 to 1. This lets you buy a drill with a much more comfortable hotkey (1 instead of 7). You can now press E → 1 → E → 1 on an empty shop to get a drill which is nice. The existing items in position 1 and 2 (lantern and empty bucket) are some of the least useful items in the game and so I think this makes sense. I've moved other items so that the layout of the shop still looks sensible - in particular filled bucket is kept on 3 to not break people's muscle memory.

Before:
![image](https://user-images.githubusercontent.com/6610341/143240829-46ab6b25-fe4e-436c-b98a-fdc235d5d757.png)

After:
![image](https://user-images.githubusercontent.com/6610341/143240574-93ebe726-06bf-4ae4-9f7e-0f7f32343a43.png)


## Steps to Test or Reproduce

Enter sandbox and create a builder shop.
