### PR TITLE
Improved classes animation

### DIFF
--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -381,7 +381,7 @@ void onTick(CSprite@ this)
 		{
 			shiny.RotateBy(10, Vec2f());
 
-			shiny_offset.RotateBy(this.isFacingLeft() ?  shiny_angle : -shiny_angle);
+			shiny_offset.RotateBy(this.isFacingLeft() ?  shiny_angle : -shiny_angle, Vec2f(3, -2));
 			shiny.SetOffset(shiny_offset);
 		}
 	}
@@ -422,15 +422,18 @@ void DrawBow(CSprite@ this, CBlob@ blob, ArcherInfo@ archer, f32 armangle, const
 			animname = "fired";
 		}
 
-		u16 frontframe = 0;
-		f32 temp = Maths::Min(archer.charge_time, ArcherParams::ready_time);
-		f32 ready_tween = temp / ArcherParams::ready_time;
-		armangle = armangle * ready_tween;
-		armOffset = Vec2f(-1.0f, 4.0f + config_offset + 2.0f * (1.0f - ready_tween));
-		setArmValues(frontarm, true, armangle, 0.1f, animname, Vec2f(-4.0f * sign, 0.0f), armOffset);
-		frontarm.animation.frame = frontframe;
+		if (archer.charge_state != ArcherParams::legolas_charging)
+		{
+			u16 frontframe = 0;
+			f32 temp = Maths::Min(archer.charge_time, ArcherParams::ready_time);
+			f32 ready_tween = temp / ArcherParams::ready_time;
+			armangle = armangle * ready_tween;
+			armOffset = Vec2f(-1.0f, 4.0f + config_offset + 2.0f * (1.0f - ready_tween));
+			setArmValues(frontarm, true, armangle, 0.1f, animname, Vec2f(-4.0f * sign, 0.0f), armOffset);
+			frontarm.animation.frame = frontframe;
 
-		setArmValues(arrow, false, 0, 0, "default", Vec2f(), Vec2f());
+			setArmValues(arrow, false, 0, 0, "default", Vec2f(), Vec2f());
+		}
 	}
 	else if (archer.charge_state == ArcherParams::readying)
 	{
@@ -461,8 +464,8 @@ void DrawBow(CSprite@ this, CBlob@ blob, ArcherInfo@ archer, f32 armangle, const
 		if (archer.charge_state == ArcherParams::legolas_ready)
 		{
 			needs_shiny = true;
-			shiny_offset = Vec2f(-12.0f, 0.0f);   //TODO:
-			shiny_angle = armangle;
+			shiny_offset = Vec2f(-13.0f, -2.5f);
+			shiny_angle = arrowangle;
 		}
 	}
 	else

--- a/Entities/Characters/Knight/Knight.cfg
+++ b/Entities/Characters/Knight/Knight.cfg
@@ -251,10 +251,10 @@ f32 sprite_offset_y                               = -4
 
 #flammable anims
   # on_fire_run
-  $sprite_animation_on_fire_run_name              = on_fire
-  u16 sprite_animation_on_fire_run_time           = 3
-  u8_sprite_animation_on_fire_run_loop            = 1
-  @u16 sprite_animation_on_fire_run_frames        = 25; 26; 27; 28;
+  #$sprite_animation_on_fire_run_name              = on_fire
+  #u16 sprite_animation_on_fire_run_time           = 3
+  #u8_sprite_animation_on_fire_run_loop            = 1
+  #@u16 sprite_animation_on_fire_run_frames        = 25; 26; 27; 28;
 
   $sprite_animation_end                           = *end*
 

--- a/Entities/Common/FireScripts/FireAnim.as
+++ b/Entities/Common/FireScripts/FireAnim.as
@@ -47,7 +47,7 @@ void onTick(CSprite@ this)
 			fire.SetAnimation("smallfire");
 
 			//set the "on fire" animation if it exists (eg wave arms around)
-			if (this.getAnimation("on_fire") !is null)
+			if (this.getAnimation("on_fire") !is null && !blob.hasTag("dead"))
 			{
 				this.SetAnimation("on_fire");
 			}


### PR DESCRIPTION
## Status

- **READY**

## Description

I noticed visual bugs on each of the classes, which are:
- Knight sprite "blinks" when on fire.
- Builder plays the 'on_fire' animation even while dead.
- Archer's bow sprite "blinks" every time three arrows are charged.
- Archer's 'shiny' sprite is not properly placed or rotated around the bow.

This PR fixes these minor visual anomalies.

## Steps to Test or Reproduce

1) Set a knight on fire, look at the knight's body closely to see any blinks.
2) Set a builder on fire and let them die, check and see if the builder plays the on_fire animation while dead.
3) Become an archer and charge the bow till it hits three arrows, check for animation smoothness- and position of the 'shiny'.

##
Visuals for archer with fixes-

https://user-images.githubusercontent.com/68350259/143735108-3c0d868c-4aa2-4714-ac65-cdeb8b553c11.mp4



