### PR TITLE
Also ignore emotes from ignored players

### DIFF
--- a/Entities/Common/Emotes/EmoteBubble.as
+++ b/Entities/Common/Emotes/EmoteBubble.as
@@ -43,9 +43,18 @@ void onTick(CBlob@ blob)
 		const u8 index = blob.get_u8("emote");
 		if (is_emote(blob, index) && !blob.hasTag("dead") && !blob.isInInventory())
 		{
-			blob.getCurrentScript().tickFrequency = 1;
 			if (emote !is null)
 			{
+				CPlayer@ player = blob.getPlayer();
+				if (player !is null && getSecurity().isPlayerIgnored(player))
+				{
+					// muted emote
+					print("Ignored emote from " + player.getUsername());
+					return;
+				}
+
+				blob.getCurrentScript().tickFrequency = 1;
+
 				emote.SetVisible(!isMouseOverEmote(emote));
 				emote.animation.frame = index;
 

--- a/Entities/Common/Emotes/EmotesCommon.as
+++ b/Entities/Common/Emotes/EmotesCommon.as
@@ -127,6 +127,18 @@ void set_emote(CBlob@ this, u8 emote, int time)
 		emote = Emotes::off;
 	}
 
+	// server side ignore
+	if (isServer()) 
+	{
+		CPlayer@ player = this.getPlayer();
+		if (player !is null && getSecurity().isPlayerIgnored(player))
+		{
+			// muted emote
+			print("Ignored emote from " + player.getUsername());
+			return;
+		}
+	}
+
 	this.set_u8("emote", emote);
 	this.set_u32("emotetime", getGameTime() + time);
 	bool client = this.getPlayer() !is null && this.isMyPlayer();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Ignored players can currently still spam emotes. This commit also mutes emotes for these players. 
Should work for server-wide and client-only ignores, similar to how chat ignore works.

Intended behavior:

- client-only ignore player: no emotes will show from this ignored player for you, nobody else is affected.
- server-wide ignore player: no emotes will be shown to anybody, not even the ignored player themself

Note that a "Ignored emote" message is left in the code, but is not needed in case.
