### PR TITLE
Fix arrow type cycling

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -409,9 +409,17 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		moveVars.walkFactor *= 0.75f;
 		moveVars.canVault = false;
 
-		const bool just_action1 = this.isKeyJustPressed(key_action1);
+		bool just_action1 = this.isKeyJustPressed(key_action1);
 
 		//	printf("charge_state " + charge_state );
+		if (hasarrow && charge_state == ArcherParams::no_arrows)
+		{
+			// (when key_action1 is down) reset charge state when:
+			// * the player has picks up arrows when inventory is empty
+			// * the player switches arrow type while charging bow
+			charge_state = ArcherParams::not_aiming;
+			just_action1 = true;
+		}
 
 		if ((just_action1 || this.wasKeyPressed(key_action2) && !pressed_action2) &&
 		        (charge_state == ArcherParams::not_aiming || charge_state == ArcherParams::fired || charge_state == ArcherParams::stabbing))


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Different (better? not hardcoded?) implementation of the same fix for PR #865 ("Abandoned").

This change should: 
* charge bow properly when out of normal arrows and picking up new ones (additional fix)
* fix cycling special arrow types after being out of other types

Fixes three issues:

1. Cycling from no-arrow to special-arrow type quickly now actually cycles, starts charging bow etc. Fixes #576.
2. While charging, cycling from no-arrow type to has-arrow type will cycle and start charging.
3. When having no arrows in inventory, while holding down the mouse, start charging the bow when picking up normal arrows.

## Steps to Test or Reproduce

* as archer get normal arrows and one special arrow 
* shoot a normal 
* drop the normal arrows in inventory, so you don't have any more normal 
* try shooting a normal arrow and notice the empty-bow draw 
* then 
  * (1) start charging the empty bow, cycle to the special arrow. Notice it starts charging without having to cancel first.
  * (2) in quick succession start charging the empty bow, stop charging, cycle, start charging again. Notice the special arrow is now charging. (this is the timing issue)
  * (3) (additional fix) walk over the normal arrows you threw away, to pick them up. Notice the charging of a normal arrow starts
