### PR TITLE
[modified] Enabled + fixed builder quickswap to last block (tap F)

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -42,7 +42,7 @@ const u8 GRID_PADDING = 12;
 const Vec2f MENU_SIZE(3, 4);
 const u32 SHOW_NO_BUILD_TIME = 90;
 
-const bool QUICK_SWAP_ENABLED = false;
+const bool QUICK_SWAP_ENABLED = true;
 
 void onInit(CInventory@ this)
 {

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -240,7 +240,7 @@ void onTick(CBlob@ this)
 				{
 					server_PutIn(this, this, carryBlob);
 				}
-				else
+				else if (this.get_bool("release click")) // we haven't already clicked the menu
 				{
 					// send cycle command
 					CBitStream params;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Builders can tap F to cycle to last block, like other classes can cycle ammo types

Quickswap for builders was added a while ago, but quickly reverted because of a bug: if you opened + clicked the menu to select an option _really fast_, it still counted as a "tap" and thus immediately cancelled the selection you clicked on. So it kind of broke the game for some good builders who used the click method. The bug was actually preexisting for quickswap in general, but knights and archers would never actually click on the buttons that fast. Anyway it's fixed now

## Steps to Test or Reproduce

- Be builder
- Select a block (stone for instance)
- Select another block (like door)
- Tap F - switches back to first block

To see that it's not bugged:
- Be builder
- Select stone block (or whatever) in build menu
- Open build menu with F, click on ladder, and release F quickly
- It should select ladder without quickswapping back to previous block
