### PR TITLE
Make fire arrows hit like normal arrows, fix sound

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -289,14 +289,19 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 
 		if (dmg > 0.0f)
 		{
-			//determine the hit type
+			// determine the hit type
+			// fire arrows still act as normal arrows
 			const u8 hit_type =
-				(arrowType == ArrowType::fire) ? Hitters::fire :
 				(arrowType == ArrowType::bomb) ? Hitters::bomb_arrow :
 				Hitters::arrow;
 
 			//perform the hit and tag so that another doesn't happen
 			this.server_Hit(blob, point1, initVelocity, dmg, hit_type);
+
+			// for fire arrows, make fire
+			if (arrowType == ArrowType::fire && !this.hasTag("no_fire"))
+				this.server_Hit(blob, point1, initVelocity, 0.0f, Hitters::fire);
+			
 			this.Tag("collided");
 		}
 
@@ -510,10 +515,6 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 					this.getSprite().PlaySound("ArrowHitGround.ogg");
 				}
 			}
-		}
-		else if (arrowType != ArrowType::normal)
-		{
-			damage = 0.0f;
 		}
 
 		if (arrowType == ArrowType::fire)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This change makes fire arrows behave more like normal arrows, by first registering an arrow hit (so they will make a sound when hitting a knight's shield and allow stun when shooting fully charges) and then do the usual fire hit with, but with 0 initial damage, if not shielding.

I have also removed a redundant `damage = 0` for shield hits. This is already handled in `ShieldHit.as`, and seemed to not do much afaik.

## Steps to Test or Reproduce

Shoot a shielding knight with a fire arrow and notice the sound, and stun (for full charge), and no fire 
Shoot a non-shielding knight and notice the damage and fire 🔥, and possible stun 
