### PR TITLE
[modified] Team bombs disable saws when milled (no sawjumps)

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -125,10 +125,11 @@ void Blend(CBlob@ this, CBlob@ tobeblended)
 
 	tobeblended.Tag("sawed");
 
-	// on saw player or dead body - disable the saw
+	// on saw player or dead body or team bomb - disable the saw
 	if (
 		(tobeblended.getPlayer() !is null || //player
-		(tobeblended.hasTag("flesh") && tobeblended.hasTag("flesh"))) && //dead body
+		(tobeblended.getName() == "bomb") || // bomb
+		(tobeblended.hasTag("flesh"))) && //dead body
 		tobeblended.getTeamNum() == this.getTeamNum()) //same team as saw
 	{
 		CBitStream params;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

An alternative to #1153 

Saws will turn off after detonating one teammate's bomb, effectively preventing sawjumps while allowing most "normal" usage of saws to pop bombs. Enemy saws will not turn off

## Steps to Test or Reproduce

- Get saw
- Throw a bomb in there
