### PR TITLE
Script-side support for staging off-screen tick throttling

### DIFF
--- a/Entities/Common/Scripts/OffscreenThrottle.as
+++ b/Entities/Common/Scripts/OffscreenThrottle.as
@@ -1,0 +1,49 @@
+// Add this script to the script list of a blob to allow it to skip ticks when offscreen.
+// This is useful to improve performance.
+//
+// This does significantly more than just not calling onTick hooks!
+// Nearly _nothing_ will be done to update the blob while it is throttled.
+// This should really only be used on somewhat static blobs (which, in particular, do _not_ increment a counter onTick!).
+//
+// NOTE: This optimization will *not* be done on servers, but it will be done in localhost.
+//       This is acceptable for vanilla, but you may want to override this behavior in a mod.
+
+uint32 throttleDuration(CBlob@ blob)
+{
+	const bool client = isClient(), server = isServer();
+	const bool localhost = client && server;
+
+	// Do not perform throttling on the server-side
+	if (server && !localhost)
+	{
+		return 0;
+	}
+
+	// Just in case, give a few ticks for the blob to initialize
+	if (blob.getTickSinceCreated() < 5)
+	{
+		return 0;
+	}
+
+	const float margin = 96.0f;
+	if (!isPointOnScreen(blob.getPosition(), margin))
+	{
+		return 15;
+	}
+
+	return 0;
+}
+
+#ifdef STAGING
+void onTick(CBlob@ blob)
+{
+	blob.throttleInterval = throttleDuration(blob);
+
+	/*
+	if (blob.throttleInterval != 0)
+	{
+		print("throttling " + blob.getName() + " for " + blob.throttleInterval);
+	}
+	*/
+}
+#endif

--- a/Entities/Items/Lantern/Lantern.cfg
+++ b/Entities/Items/Lantern/Lantern.cfg
@@ -60,6 +60,7 @@ $name                                             = lantern
 													Activatable.as;
 													SetTeamToCarrier.as;
 													DecayIfSpammed;
+													OffscreenThrottle.as;
 f32 health                                        = 1.0
 $inventory_name                                   = Lantern
 $inventory_icon                                   = -

--- a/Entities/Items/Log/Log.cfg
+++ b/Entities/Items/Log/Log.cfg
@@ -79,7 +79,8 @@ $name                                  = log
 										 isFlammable.as;
 										 Wooden.as;
 										 Log.as;
-										 GenericHit.as;							 
+										 GenericHit.as;
+										 OffscreenThrottle.as;						 
 f32_health                             = 1.2
 # looks & behaviour inside inventory
 $inventory_name                        = Wood Log

--- a/Entities/Materials/MaterialStandard.as
+++ b/Entities/Materials/MaterialStandard.as
@@ -13,6 +13,8 @@
 
 void onInit(CBlob@ this)
 {
+  this.AddScript("OffscreenThrottle.as");
+
   if (getNet().isServer())
   {
     this.server_setTeamNum(-1);

--- a/Entities/Natural/Bushes/Bush.cfg
+++ b/Entities/Natural/Bushes/Bush.cfg
@@ -75,7 +75,8 @@ $name                                  = bush
 										 NoPickupWhenGrown.as;
 										 AlignToTiles.as;
 										 PlantHitEffects.as;
-										 IsFlammable.as;									 
+										 IsFlammable.as;
+										 OffscreenThrottle.as;					 
 f32 health                             = 1.0
 # looks & behaviour inside inventory
 $inventory_name                        = Bush

--- a/Entities/Structures/Door/StoneDoor.cfg
+++ b/Entities/Structures/Door/StoneDoor.cfg
@@ -100,6 +100,7 @@ $name                                      = stone_door
                        CollapseMissingAdjacent.as;
 											 TileBackground.as;
 											 GenericOnStatic.as;
+                       OffscreenThrottle.as;
 f32 health                                 = 5.0
 # looks & behaviour inside inventory
 $inventory_name                            = Stone Door

--- a/Entities/Structures/Door/SwingDoor.cfg
+++ b/Entities/Structures/Door/SwingDoor.cfg
@@ -101,6 +101,7 @@ $name                                      = wooden_door
             											 FallOnNoSupport.as;
             											 TileBackground.as;
             											 GenericOnStatic.as;
+                                   OffscreenThrottle.as;
 f32 health                                 = 3.5
 # looks & behaviour inside inventory
 $inventory_name                            = Wooden Door

--- a/Entities/Structures/Platform/WoodenPlatform.cfg
+++ b/Entities/Structures/Platform/WoodenPlatform.cfg
@@ -90,6 +90,7 @@ $name                                      = wooden_platform
 											 TileBackground.as;
 											 GenericOnStatic.as;
 											 BombResistant.as;
+											 OffscreenThrottle.as;
 f32 health                                 = 2.5
 # looks & behaviour inside inventory
 $inventory_name                            = Wooden Platform

--- a/Entities/Structures/Trap/TrapBlock.cfg
+++ b/Entities/Structures/Trap/TrapBlock.cfg
@@ -78,6 +78,7 @@ $name                                  = trap_block
 										 FallOnNoSupport.as;
 										 TileBackground.as;
 										 GenericOnStatic.as;
+									 	 OffscreenThrottle.as;
 f32 health                             = 2.5
 # looks & behaviour inside inventory
 $inventory_name                        = Trap Block


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

Staging exposes a `throttleInterval` field to `CBlob` which allows scripts to skip ticking of blobs entirely by only ticking every N ticks. It aims for maximal overhead reduction by cutting ticking much earlier than script ticking intervals would allow. The engine also attempts to spread out entity throttling in order to reduce tick time fluctuation.  
However, this remains largely experimental because skipping ticks on the client-side could have many unintended side effects. Currently, Staging uses that `throttleInterval` unconditionally but it may be disabled by default behind an `autoconfig.cfg` switch until this is largely proven to be stable.

I tested client-side throttling with a proof-of-concept on live release servers in busy matches, and found this to allow for significant tick time reduction.

This PR provides the required script-side infrastructure to allow blobs to opt in for tick throttling through a very simple and generic ruleset, through a newly introduced `OffscreenThrottle.as` script. It also enables that support for several static blobs.  
By default, tick throttling is performed on all clients, including localhost. Mods can trivially override this behavior.

On release KAG, this PR causes no functional change.  
This can be applied to current Release servers, and will only apply to Staging clients.

## Steps to Test or Reproduce

- Use the Staging build
- Join a local server (localhost or dedicated works)
- Press F5
- Click "Debug windows", then "Blobs"
- Certain blobs that are out of the screen (doors, bushes, platforms, etc.) should show up as `ThrXXX` (ticking only every XXX ticks). You should see "waves" of these going to `Ok` for a single tick.