### PR TITLE
Force all players to be a builder until the last 20 seconds of warmup

### DIFF
--- a/Entities/Common/Respawning/OneClassAvailable.as
+++ b/Entities/Common/Respawning/OneClassAvailable.as
@@ -35,15 +35,24 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		CBitStream params;
 		write_classchange(params, caller.getNetworkID(), cfg);
 
-		CButton@ button = caller.CreateGenericButton(
-		"$change_class$",                           // icon token
-		this.get_Vec2f("class offset"),             // button offset
-		this,                                       // button attachment
-		SpawnCmd::changeClass,                      // command id
-		getTranslatedString("Swap Class"),                               // description
-		params);                                    // bit stream
+		if (!getRules().hasTag("class switching disabled"))
+		{
+			CButton@ button = caller.CreateGenericButton(
+			"$change_class$",                           // icon token
+			this.get_Vec2f("class offset"),             // button offset
+			this,                                       // button attachment
+			SpawnCmd::changeClass,                      // command id
+			getTranslatedString("Change Class"),                               // description
+			params);                                    // bit stream
 
-		button.enableRadius = this.get_u8("class button radius");
+			button.enableRadius = this.get_u8("class button radius");
+		}
+		else
+		{
+			CButton@ button = caller.CreateGenericButton("$change_class$", this.get_Vec2f("class offset"), this, 0, getTranslatedString("Class Switching Disabled"), params);
+			button.SetEnabled(false);
+		}
+
 	}
 }
 

--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -47,7 +47,7 @@ void BuildRespawnMenuFor(CBlob@ this, CBlob @caller)
 
 	if (caller !is null && caller.isMyPlayer() && classes !is null)
 	{
-		CGridMenu@ menu = CreateGridMenu(caller.getScreenPos() + Vec2f(24.0f, caller.getRadius() * 1.0f + 48.0f), this, Vec2f(classes.length * CLASS_BUTTON_SIZE, CLASS_BUTTON_SIZE), getTranslatedString("Swap class"));
+		CGridMenu@ menu = CreateGridMenu(caller.getScreenPos() + Vec2f(24.0f, caller.getRadius() * 1.0f + 48.0f), this, Vec2f(classes.length * CLASS_BUTTON_SIZE, CLASS_BUTTON_SIZE), getTranslatedString("Change Class"));
 		if (menu !is null)
 		{
 			addClassesToMenu(this, menu, caller.getNetworkID());

--- a/Entities/Industry/Hall/Hall.as
+++ b/Entities/Industry/Hall/Hall.as
@@ -377,33 +377,45 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	if (!canSeeButtons(this, caller) || !caller.isOverlapping(this))
 		return;
 
-	if (this.getTeamNum() != 255)
+	if (!canChangeClass(this, caller))
+		return;
+	
+	if (this.getTeamNum() == 255)
+		return;
+	
+	CBitStream params;
+	params.write_u16(caller.getNetworkID());
+
+	if (!getRules().hasTag("class switching disabled"))
 	{
-		CBitStream params;
-		params.write_u16(caller.getNetworkID());
+		caller.CreateGenericButton("$change_class$", Vec2f(12, 7), this, buildSpawnMenu, getTranslatedString("Change Class"));
+	}
+	else
+	{
+		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(12, 7), this, 0, getTranslatedString("Class Switching Disabled"));
+		button.SetEnabled(false);
+	}
 
-		caller.CreateGenericButton("$change_class$", Vec2f(12, 7), this, buildSpawnMenu, getTranslatedString("Change class"));
+	if (caller.getName() == "builder")
+	{
+		Vec2f buttonpos = this.hasTag("script added") ? Vec2f(0, -7) : Vec2f(-12, -7);
 
-		if (caller.getName() == "builder")
+		const u16 goldCount = caller.getBlobCount("mat_gold");
+		if (goldCount >= MIGRANT_COST)
 		{
-			Vec2f buttonpos = this.hasTag("script added") ? Vec2f(0, -7) : Vec2f(-12, -7);
-
-			const u16 goldCount = caller.getBlobCount("mat_gold");
-			if (goldCount >= MIGRANT_COST)
+			//buy migrant button
+			CButton@ button = caller.CreateGenericButton("$migrant$", buttonpos, this, this.getCommandID(buymigrantcmd), getTranslatedString("Buy a worker for {MIGRANT_COST} Gold").replace("{MIGRANT_COST}", "" + MIGRANT_COST), params);
+		}
+		else
+		{
+			CButton@ button = caller.CreateGenericButton("$migrant$", buttonpos, this, 0, getTranslatedString("Buy worker: Requires {MIGRANT_COST} Gold").replace("{MIGRANT_COST}", "" + MIGRANT_COST));
+			if (button !is null)
 			{
-				//buy migrant button
-				CButton@ button = caller.CreateGenericButton("$migrant$", buttonpos, this, this.getCommandID(buymigrantcmd), getTranslatedString("Buy a worker for {MIGRANT_COST} Gold").replace("{MIGRANT_COST}", "" + MIGRANT_COST), params);
-			}
-			else
-			{
-				CButton@ button = caller.CreateGenericButton("$migrant$", buttonpos, this, 0, getTranslatedString("Buy worker: Requires {MIGRANT_COST} Gold").replace("{MIGRANT_COST}", "" + MIGRANT_COST));
-				if (button !is null)
-				{
-					button.SetEnabled(false);
-				}
+				button.SetEnabled(false);
 			}
 		}
 	}
+
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)

--- a/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
+++ b/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
@@ -65,28 +65,19 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	AddIconToken("$knight_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 12, caller.getTeamNum());
 	AddIconToken("$archer_class_icon$", "GUI/MenuItems.png", Vec2f(32, 32), 16, caller.getTeamNum());
 	
-	if (!canSeeButtons(this, caller)) return;
-
-	if (canChangeClass(this, caller))
+	if (canSeeButtons(this, caller) && canChangeClass(this, caller))
 	{
-		if (false)//isInRadius(this, caller))
+		CBitStream params;
+		params.write_u16(caller.getNetworkID());
+
+		if (!getRules().hasTag("class switching disabled"))
 		{
-			BuildRespawnMenuFor(this, caller);
+			caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, this.getCommandID("class menu"), getTranslatedString("Change Class"), params);
 		}
 		else
 		{
-			CBitStream params;
-			params.write_u16(caller.getNetworkID());
-			if (!getRules().hasTag("class switching disabled"))
-			{
-				caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, this.getCommandID("class menu"), getTranslatedString("Change Class"), params);
-			}
-			else
-			{
-				CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, 0, getTranslatedString("Class Switching Disabled"), params);
-				button.SetEnabled(false);
-			}
-
+			CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, 0, getTranslatedString("Class Switching Disabled"), params);
+			button.SetEnabled(false);
 		}
 	}
 

--- a/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
+++ b/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
@@ -69,7 +69,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	if (canChangeClass(this, caller))
 	{
-		if (isInRadius(this, caller))
+		if (false)//isInRadius(this, caller))
 		{
 			BuildRespawnMenuFor(this, caller);
 		}
@@ -77,7 +77,16 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		{
 			CBitStream params;
 			params.write_u16(caller.getNetworkID());
-			caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, this.getCommandID("class menu"), getTranslatedString("Change class"), params);
+			if (!getRules().hasTag("class switching disabled"))
+			{
+				caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, this.getCommandID("class menu"), getTranslatedString("Change Class"), params);
+			}
+			else
+			{
+				CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, 6), this, 0, getTranslatedString("Class Switching Disabled"), params);
+				button.SetEnabled(false);
+			}
+
 		}
 	}
 

--- a/Entities/Special/Tent/TentLogic.as
+++ b/Entities/Special/Tent/TentLogic.as
@@ -47,16 +47,31 @@ void onTick(CBlob@ this)
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
+	if (caller.getTeamNum() != this.getTeamNum()) return;
 
 	// button for runner
 	// create menu for class change
-	if (canChangeClass(this, caller) && caller.getTeamNum() == this.getTeamNum())
+
+	if (canChangeClass(this, caller))
 	{
-		caller.CreateGenericButton("$change_class$", Vec2f(0, 0), this, buildSpawnMenu, getTranslatedString("Swap Class"));
+		if (!getRules().hasTag("class switching disabled"))
+		{
+			caller.CreateGenericButton("$change_class$", Vec2f(0, 0), this, buildSpawnMenu, getTranslatedString("Change Class"));
+		}
+		else
+		{
+			CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, 0), this, 0, getTranslatedString("Class Switching Disabled"));
+			button.SetEnabled(false);
+		}
 	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	onRespawnCommand(this, cmd, params);
+}
+
+void isTeamSwitchingBlocked(CBlob@ this)
+{
+
 }

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -245,9 +245,17 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		{
 			Vehicle_AddLoadAmmoButton(this, caller);
 		}
-		if (/*!isAnotherRespawnClose(this) &&*/ !isFlipped(this))
+		if (canChangeClass(this, caller) && !isFlipped(this))
 		{
-			caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change class"));
+			if (!getRules().hasTag("class switching disabled"))
+			{
+				caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change Class"));
+			}
+			else
+			{
+				CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, 0, getTranslatedString("Class Switching Disabled"));
+				button.SetEnabled(false);
+			}
 		}
 	}
 }

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -212,9 +212,17 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	if (caller.getTeamNum() == this.getTeamNum())
+	if (caller.getTeamNum() == this.getTeamNum() && canChangeClass(this, caller))
 	{
-		caller.CreateGenericButton("$change_class$", Vec2f(13, 4), this, buildSpawnMenu, getTranslatedString("Change class"));
+		if (!getRules().hasTag("class switching disabled"))
+		{
+			caller.CreateGenericButton("$change_class$", Vec2f(13, 4), this, buildSpawnMenu, getTranslatedString("Change Class"));	
+		}
+		else
+		{
+			CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(13, 4), this, 0, getTranslatedString("Class Switching Disabled"));
+			button.SetEnabled(false);	
+		}
 	}
 }
 

--- a/Rules/CTF/ctf_vars.cfg
+++ b/Rules/CTF/ctf_vars.cfg
@@ -9,6 +9,9 @@
 	#amount of pre-game time once there are enough players ingame
 	warmup_time = 180; #seconds
 
+	#amount of time from end of warmup that players can switch class
+	warmup_class_switch_time = 20; seconds
+
 	#amount of time before the game ends in a tie
 	#anything less than 0 means the game never ends
 	game_time = -1; #minutes

--- a/Rules/CommonScripts/RespawnSystem.as
+++ b/Rules/CommonScripts/RespawnSystem.as
@@ -30,7 +30,24 @@ shared class RespawnSystem
 
 		if (player !is null)
 		{
-			CBlob @newBlob = server_CreateBlob(p_info.blob_name, p_info.team, at);
+			string blob_name = p_info.blob_name;
+			CRules@ rules = getRules();
+
+			// if class switching disabled, respawn player as the default class
+			if (rules.hasTag("class switching disabled"))
+			{
+				if (rules.exists("default class"))
+				{
+					blob_name = rules.get_string("default class");
+				}
+				else
+				{
+					// if no default class set, switch to knight
+					blob_name = "knight";
+				}
+			}
+
+			CBlob @newBlob = server_CreateBlob(blob_name, p_info.team, at);
 			newBlob.server_SetPlayer(player);
 			player.server_setTeamNum(p_info.team);
 			return newBlob;

--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -835,6 +835,7 @@ void Reset(CRules@ this)
 	this.set("start_gametime", getGameTime() + core.warmUpTime);
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as
 	this.set_s32("restart_rules_after_game_time", (core.spawnTime < 0 ? 5 : 10) * 30 );
+	this.set_string("default class", "knight");
 }
 
 void onRestart(CRules@ this)

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -978,6 +978,8 @@ void Reset(CRules@ this)
 
 	core.gametime = getGameTime() + core.warmUpTime;
 
+	this.set_string("default class", "builder");
+
 	this.set("start_gametime", core.gametime);//is this legacy?
 
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This PR stops players from switching to other classes in build time until the last 20 seconds (changeable via ctf_vars.cfg). Resolves #738

It works by tagging CRules with "class switching disabled" which all class switching places like the tent, class shops, etc. check for. If switching is disabled, the button is greyed out and text is displayed saying that it's disabled. 

When class switching is disabled, the players will spawn in based on a CRules string property called "default class". If it isn't set, players will spawn in as knights.

The "class switching disabled" tag and "default class" string works for all gamemodes, which for example makes all knight or all archer TDM easy to do.

This PR also fixes the inconsistencies of the class swap buttons text, which is now "Change Class". Before it was that or "Swap Class" or one of the two but missing capitalisation.

Note: The text displaying when the builder only time ends is trash and should be changed but I can't think of better wording.

## Steps to Test or Reproduce

- Start a game, notice you spawn in as builder automatically
- Try to switch to another class, see class button is different and pressing it doesn't do anything
- See build time text
- Wait until the builder only time is over and see that you can now change classes again
