### PR TITLE
Allow seeds to be loaded into catapult and show correct icon for seeds and food

### DIFF
--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -1,7 +1,8 @@
 void onInit(CBlob@ this)
 {
 	this.Tag("ignore_saw");
-	
+	this.Tag("use inventory icon");
+
 	if (this.exists("food name"))
 	{
 		this.setInventoryName(this.get_string("food name"));
@@ -16,6 +17,13 @@ void onInit(CBlob@ this)
 	this.getSprite().SetFrameIndex(index);
 	this.SetInventoryIcon(this.getSprite().getConsts().filename, index, Vec2f(16, 16));
 	this.server_setTeamNum(0); // blue fishy like in sprite sheet
+
+	// add icon to be used when loading into catapult
+	string iconName = "$" + this.getInventoryName() + "$";
+	if (!GUI::hasIconName(iconName))
+	{
+		AddIconToken(iconName, this.getSprite().getConsts().filename, Vec2f(16, 16), index);
+	}
 
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -1,7 +1,6 @@
 void onInit(CBlob@ this)
 {
 	this.Tag("ignore_saw");
-	this.Tag("use inventory icon");
 
 	if (this.exists("food name"))
 	{

--- a/Entities/Natural/Seed/Seed.as
+++ b/Entities/Natural/Seed/Seed.as
@@ -34,15 +34,16 @@ void onInit(CBlob@ this)
 	{
 		u8 spriteIndex = this.get_u8("sprite index");
 
+		if (spriteIndex < seed_names.length)
+		{
+			this.setInventoryName(seed_names[spriteIndex]);
+		}
+
 		if (spriteIndex < seed_sprites.length)
 		{
 			LoadSprite(this, seed_sprites[spriteIndex], spriteIndex);
 		}
 
-		if (spriteIndex < seed_names.length)
-		{
-			this.setInventoryName(seed_names[spriteIndex]);
-		}
 	}
 	else
 	{
@@ -66,6 +67,7 @@ void onInit(CBlob@ this)
 
 	this.Tag("place norotate");
 	this.Tag("pushedByDoor");
+	this.Tag("use inventory icon");
 
 	this.getCurrentScript().tickFrequency = OPT_TICK;
 }
@@ -100,6 +102,13 @@ void LoadSprite(CBlob@ this, string filename, u8 spriteIndex)
 
 		sprite.SetAnimation(anim);
 		this.SetInventoryIcon(filename, anim.getFrame(0), Vec2f(frameWidth, frameHeight));
+		
+		// add icon to be used when loading into catapult
+		string iconName = "$" + this.getInventoryName() + "$";
+		if (!GUI::hasIconName(iconName))
+		{
+			AddIconToken(iconName, filename, Vec2f(frameWidth, frameHeight), anim.getFrame(0));
+		}
 	}
 }
 

--- a/Entities/Natural/Seed/Seed.as
+++ b/Entities/Natural/Seed/Seed.as
@@ -67,7 +67,6 @@ void onInit(CBlob@ this)
 
 	this.Tag("place norotate");
 	this.Tag("pushedByDoor");
-	this.Tag("use inventory icon");
 
 	this.getCurrentScript().tickFrequency = OPT_TICK;
 }

--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -413,14 +413,14 @@ bool Vehicle_AddLoadAmmoButton(CBlob@ this, CBlob@ caller)
 	{
 		// put in what is carried
 		CBlob@ carryObject = caller.getCarriedBlob();
-		if (carryObject !is null && (!carryObject.isSnapToGrid() || carryObject.getName() == "seed"))  // not spikes or door, allow seeds
+		if (carryObject !is null && !carryObject.hasTag("temp blob"))
 		{
 			CBitStream callerParams;
 			callerParams.write_u16(caller.getNetworkID());
 			callerParams.write_u16(carryObject.getNetworkID());
 
 			string iconName = "$" + carryObject.getName() + "$";
-			if (carryObject.hasTag("use inventory icon"))
+			if (GUI::hasIconName("$" + carryObject.getInventoryName() + "$"))
 			{
 				iconName = "$" + carryObject.getInventoryName() + "$";
 			}

--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -413,12 +413,19 @@ bool Vehicle_AddLoadAmmoButton(CBlob@ this, CBlob@ caller)
 	{
 		// put in what is carried
 		CBlob@ carryObject = caller.getCarriedBlob();
-		if (carryObject !is null && !carryObject.isSnapToGrid())  // not spikes or door
+		if (carryObject !is null && (!carryObject.isSnapToGrid() || carryObject.getName() == "seed"))  // not spikes or door, allow seeds
 		{
 			CBitStream callerParams;
 			callerParams.write_u16(caller.getNetworkID());
 			callerParams.write_u16(carryObject.getNetworkID());
-			caller.CreateGenericButton("$" + carryObject.getName() + "$", getMagAttachmentPoint(this).offset, this, this.getCommandID("putin_mag"), getTranslatedString("Load {ITEM}").replace("{ITEM}", carryObject.getInventoryName()), callerParams);
+
+			string iconName = "$" + carryObject.getName() + "$";
+			if (carryObject.hasTag("use inventory icon"))
+			{
+				iconName = "$" + carryObject.getInventoryName() + "$";
+			}
+
+			caller.CreateGenericButton(iconName, getMagAttachmentPoint(this).offset, this, this.getCommandID("putin_mag"), getTranslatedString("Load {ITEM}").replace("{ITEM}", carryObject.getInventoryName()), callerParams);
 			return true;
 		}
 		else  // nothing in hands - take automatic


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Allows seeds to be loaded into catapult and makes the correct icon show for them and food when loading.

## Steps to Test or Reproduce
-Spawn in a catapult
-Load different types of seeds
-Wow, it shows the correct icon
-Load different foods (Cake, Bread, Cooked Fish or Cooked Steak)
-Wow, it shows the correct icon
