### PR TITLE
Fix bad snapshot error that was caused by archer changing class on tent or other respawn points

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -37,6 +37,7 @@ void onInit(CBlob@ this)
 	this.getSprite().SetEmitSound("Entities/Characters/Archer/BowPull.ogg");
 	this.addCommandID("shoot arrow");
 	this.addCommandID("pickup arrow");
+	this.addCommandID("has arrows");
 	this.getShape().getConsts().net_threshold_multiplier = 0.5f;
 
 	this.addCommandID(grapple_sync_cmd);
@@ -342,7 +343,12 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		if (hasarrow != this.get_bool("has_arrow"))
 		{
 			this.set_bool("has_arrow", hasarrow);
-			this.Sync("has_arrow", isServer());
+			CBitStream params;
+			params.write_bool(hasarrow);
+			if(isServer())
+				this.SendCommand(this.getCommandID("has arrows"), params);
+			else
+				this.SendCommandOnlyServer(this.getCommandID("has arrows"), params);
 		}
 
 	}
@@ -429,7 +435,12 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			if (responsible)
 			{
 				this.set_bool("has_arrow", hasarrow);
-				this.Sync("has_arrow", isServer());
+				CBitStream params;
+				params.write_bool(hasarrow);
+				if(isServer())
+					this.SendCommand(this.getCommandID("has arrows"), params);
+				else
+					this.SendCommandOnlyServer(this.getCommandID("has arrows"), params);
 			}
 
 			charge_time = 0;
@@ -1059,6 +1070,14 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (params.saferead_u8(type) && hasArrows(this, type))
 		{
 			CycleToArrowType(this, archer, type);
+		}
+	}
+	else if (cmd == this.getCommandID("has arrows"))
+	{
+		bool hasarrow;
+		if(params.saferead_bool(hasarrow))
+		{
+			this.set_bool("has_arrow", hasarrow);
 		}
 	}
 	else

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -345,7 +345,7 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			this.set_bool("has_arrow", hasarrow);
 			CBitStream params;
 			params.write_bool(hasarrow);
-			if(isServer())
+			if (isServer())
 				this.SendCommand(this.getCommandID("has arrows"), params);
 			else
 				this.SendCommandOnlyServer(this.getCommandID("has arrows"), params);
@@ -437,7 +437,7 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 				this.set_bool("has_arrow", hasarrow);
 				CBitStream params;
 				params.write_bool(hasarrow);
-				if(isServer())
+				if (isServer())
 					this.SendCommand(this.getCommandID("has arrows"), params);
 				else
 					this.SendCommandOnlyServer(this.getCommandID("has arrows"), params);

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -1075,7 +1075,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	else if (cmd == this.getCommandID("has arrows"))
 	{
 		bool hasarrow;
-		if(params.saferead_bool(hasarrow))
+		if (params.saferead_bool(hasarrow))
 		{
 			this.set_bool("has_arrow", hasarrow);
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When player changes class from archer to archer in tent or any other respawn, there might be a bad sync, that would cause a bad snapshot, or sometimes bad delta spam that would crash the server. Here i replaced Sync with Command to prevent this from happening.

## Steps to Test or Reproduce

Quickly press E and pick archer class couple of times, you will see errors in console.
