### PR TITLE
Prevent knight attack when using shops

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -458,7 +458,7 @@ class NormalState : KnightState
 
 	bool TickState(CBlob@ this, KnightInfo@ knight, RunnerMoveVars@ moveVars)
 	{
-		if (this.isKeyPressed(key_action1) && !moveVars.wallsliding)
+		if (this.isKeyPressed(key_action1) && !moveVars.wallsliding && !InShop(this))
 		{
 			knight.state = KnightStates::sword_drawn;
 			return true;
@@ -501,7 +501,7 @@ class ShieldingState : KnightState
 
 	bool TickState(CBlob@ this, KnightInfo@ knight, RunnerMoveVars@ moveVars)
 	{
-		if (this.isKeyPressed(key_action1))
+		if (this.isKeyPressed(key_action1) && !InShop(this))
 		{
 			knight.state = KnightStates::sword_drawn;
 			return true;
@@ -548,7 +548,7 @@ class ShieldGlideState : KnightState
 
 	bool TickState(CBlob@ this, KnightInfo@ knight, RunnerMoveVars@ moveVars)
 	{
-		if (this.isKeyPressed(key_action1))
+		if (this.isKeyPressed(key_action1) && !InShop(this))
 		{
 			knight.state = KnightStates::sword_drawn;
 			return true;
@@ -624,7 +624,7 @@ class ShieldSlideState : KnightState
 
 	bool TickState(CBlob@ this, KnightInfo@ knight, RunnerMoveVars@ moveVars)
 	{
-		if (this.isKeyPressed(key_action1))
+		if (this.isKeyPressed(key_action1) && !InShop(this))
 		{
 			knight.state = KnightStates::sword_drawn;
 			return true;
@@ -801,7 +801,7 @@ class SwordDrawnState : KnightState
 		AttackMovement(this, knight, moveVars);
 		s32 delta = getSwordTimerDelta(knight);
 
-		if (!this.isKeyPressed(key_action1))
+		if (!this.isKeyPressed(key_action1) || InShop(this))
 		{
 			if (delta < KnightVars::slash_charge)
 			{
@@ -1020,7 +1020,7 @@ class ResheathState : KnightState
 			return false;
 
 		}
-		else if (this.isKeyPressed(key_action1))
+		else if (this.isKeyPressed(key_action1) && !InShop(this))
 		{
 			knight.state = KnightStates::sword_drawn;
 			return true;
@@ -1744,4 +1744,9 @@ void CheckSelectedBombRemovedFromInventory(CBlob@ this, CBlob@ blob)
 	{
 		SetFirstAvailableBomb(this);
 	}
+}
+
+bool InShop(CBlob@ this)
+{
+	return this.get_bool("shop prevent attack");
 }

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -15,6 +15,7 @@ void onInit(CBlob@ this)
 	this.set_u16("hover netid", 0);
 	this.set_bool("release click", false);
 	this.set_bool("can button tap", true);
+	this.set_bool("shop prevent attack", false);
 	this.addCommandID("pickup");
 	this.addCommandID("putin");
 	this.addCommandID("getout");
@@ -149,6 +150,11 @@ void onTick(CBlob@ this)
 		this.ClearMenus();
 		this.ShowInteractButtons();
 		this.set_bool("release click", true);
+		if(this.get_bool("shop prevent attack"))
+		{
+			this.set_bool("shop prevent attack", false);
+			this.Sync("shop prevent attack", false);
+		}
 	}
 	else if (this.isKeyJustReleased(key_use))
 	{
@@ -288,6 +294,8 @@ void onTick(CBlob@ this)
 	   )
 	{
 		this.ClearMenus();
+		this.set_bool("shop prevent attack", false);
+		this.Sync("shop prevent attack", false);
 	}
 
 	//if (this.isKeyPressed(key_action1))


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

Normally, when knight click shop buttons, he does the attack at the same time, this is bad, because you can use shops from different team, and this attack will hit the shop. This pr disables knight attacks when using shops. Code can also be resued for other classes, but it doesnt seems useful for them as much as for knight.

## Steps to Test or Reproduce

- use shop as knigth and click shop buttons, you will see that knight doesnt do his attacks
