### PR TITLE
Fix blobs launched from catapult appearing behind shops

### DIFF
--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -1008,7 +1008,6 @@ void Vehicle_onAttach(CBlob@ this, VehicleInfo@ v, CBlob@ attached, AttachmentPo
 	{
 		attachedPoint.offset = v.mag_offset;
 		attachedPoint.offset.y += attached.getHeight() / 2.0f;
-		attachedPoint.offsetZ = -60.0f;
 	}
 
 	// sync current ammo index


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1227 

Unsure if removing this line will have any unintended side effects. Blobs in the bucket of the catapult appear at the right z-index even without this line.

## Steps to Test or Reproduce

1. Build a shop
2. Spawn a catapult
3. Load the catapult with a blob
4. Fire it so it lands on the shop