### PR TITLE
Text changes to Ballista Ammunition and German translation

### DIFF
--- a/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
+++ b/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
@@ -40,7 +40,7 @@ void onInit(CBlob@ this)
 		AddRequirement(s.requirements, "blob", "mat_gold", "Gold", CTFCosts::ballista_gold);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Ballista Ammo", "$mat_bolts$", "mat_bolts", "$mat_bolts$\n\n\n" + Descriptions::ballista_ammo, false, false);
+		ShopItem@ s = addShopItem(this, "Ballista Bolts", "$mat_bolts$", "mat_bolts", "$mat_bolts$\n\n\n" + Descriptions::ballista_ammo, false, false);
 		s.crate_icon = 5;
 		s.customButton = true;
 		s.buttonwidth = 2;

--- a/Entities/Materials/Ammunition/MaterialBallistaBombBolt.cfg
+++ b/Entities/Materials/Ammunition/MaterialBallistaBombBolt.cfg
@@ -65,7 +65,7 @@ $name                                  = mat_bomb_bolts
 f32_health                             = 1.0
 
 # Inside inventory
-$inventory_name                        = Ballista Bolts
+$inventory_name                        = Ballista Shells
 $inventory_icon                        = Materials.png
 u8 inventory_icon_frame                = 31
 u8 inventory_icon_frame_width          = 16

--- a/Locales/German_de.json
+++ b/Locales/German_de.json
@@ -623,6 +623,7 @@
 	"Arrows":"Pfeile",
 	"Ballista Bolt":"Ballistenbolzen",
 	"Ballista Bolts":"Ballistenbolzen",
+	"Ballista Shells":"Ballistenbomben",
 	"Scroll":"Schriftrolle",
 	"Scroll of Drought":"Schriftrolle der Dürre",
 	"Scroll of Carnage":"Schriftrolle des Gemetzels",

--- a/Locales/German_de.json
+++ b/Locales/German_de.json
@@ -507,13 +507,13 @@
 	"A red name indicates a server admin - ask them for help if you need it.": "Rote Namen indizieren Serveradmins. Bitte sie um Hilfe wenn du welche brauchst.",
 	"A bush plus a mine equals happy fun time.": "Ein Busch und eine Mine ergeben eine explosive Mischung Spaß.",
 	"Enemies can walk through your doors if open them. Don't let them in!":"Feinde können durch deine Türen gehen wenn du sie aufhältst.",
-	"If you see an object/body holding a door open - move it away!":"Siehst du ein etwas, das deine Tür blockiert, räume es weg!",
+	"If you see an object/body holding a door open - move it away!":"Siehst du etwas, das deine Tür blockiert, räume es weg!",
 	"Visit the KAG forums for more friendly help and advice!": "Besuch das KAG Forum für noch mehr freundliche Hilfe und Ratschläge.",
 	"A bomb's timer lasts four seconds before exploding": "Eine Bombe explodiert nach vier Sekunden.",
 	"When you light a bomb, let the fuse burn down before throwing it so your enemy can't react!": "Zündest du eine Bombe, warte kurz bevor du sie wirfst, damit deine Feinde nicht entkommen!",
 	"If you're throwing a bomb, jump in the direction that you're aiming to throw further!": "Wirfst du eine Bombe, spring dabei in die Richtung in die du wirfst, um sie noch weiter zu werfen.",
 	"Try bomb jumping: drop a bomb on the ground, then jump and shield downwards as it explodes!": "Versuch mal Bombjumping. Zünde dazu eine Bombe, lass sie fallen und stell dich mit dem Schild zur Bombe gerichtet drauf.",
-	"If your enemy throws a bomb too early, you can pick it up with [C] and throw it back!": "Wirft dein Feind eine Bombe zu früh, heb sie auf und schleuder sie zurück.",
+	"If your enemy throws a bomb too early, you can pick it up with [C] and throw it back!": "Wirft dein Feind eine Bombe zu früh, heb sie auf und wirf sie zurück.",
 	"You risk walking into mines or traps in dark tunnels - be careful or take a lantern!": "Im Dunkeln siehst du Fallen nicht so gut. Nimm dir also eine Laterne mit.",
 	"Retracting spikes deal less damage and have a delay, but are less likely to hurt your own team.": "Stacheln auf Stein machen zwar weniger Schaden, aber dafür verletzen sie seltener dein eigenes Team.",
 	"Supporting solid walls with backwalling is important but often overlooked.": "Du solltest Mauern durch Wände stützen. Viele machen es nicht, aber es ist ungemein wichtig.",
@@ -715,9 +715,9 @@
 	"Loading blobs...": "Lade Blobs...",
 	"Loading configs...": "Lade Configs...",
 	"Receiving scripts...": "Empfange Skripts...",
-	"Determining changed scripts...": "Determiniere veränderte Skripts...",
-	"Building downloaded scripts...": "Generiere heruntergeladenen Skripts...",
-	"Be nice to each other, read books and do your homework.": "Seit nett zueinander, lest Bücher und macht eure Hausaufgaben!",
+	"Determining changed scripts...": "Finde veränderte Skripts...",
+	"Building downloaded scripts...": "Generiere heruntergeladene Skripts...",
+	"Be nice to each other, read books and do your homework.": "Seid nett zueinander, lest Bücher und macht eure Hausaufgaben!",
 	"Authenticating to server...": "Authentifiziere mit Server...",
 
 //Login
@@ -854,7 +854,7 @@
 	"Language (EXPERIMENTAL):": "Sprache (EXPERIMENTELL):",
 	"Language:": "Sprache:",
 	"Experimental feature warning": "Experimentelle Features Warnung",
-	"Language support is still EXPERIMENTAL!\nThe translations might be incomplete or inaccurate.\nSome translations will need a restart to apply.": "Sprachunterstützung ist noch EXPERIMENTELL!\nDie Übersetzungen sind möglicheerweise nicht vollständig oder fehlerhaft.\nEinige Übersetzungen benötigen einen Neustart um angewendet zu werden.",
+	"Language support is still EXPERIMENTAL!\nThe translations might be incomplete or inaccurate.\nSome translations will need a restart to apply.": "Sprachunterstützung ist noch EXPERIMENTELL!\nDie Übersetzungen sind möglicherweise nicht vollständig oder fehlerhaft.\nEinige Übersetzungen benötigen einen Neustart um angewendet zu werden.",
 
 //LANGUAGE NAMES
 	"French": "Französisch",

--- a/Locales/German_de.json
+++ b/Locales/German_de.json
@@ -310,6 +310,7 @@
 	"A stone throwing, ridable siege engine, requiring a crew of two.":"Ein Steine werfendes, fahrbares Belagerungsgerät, welches zwei Mann Besatzung benötigt.",
 	"A bolt-firing pinpoint accurate siege engine, requiring a crew of two. Allows respawn and class change.":"Ein Bolzen schießendes und pfeilgenaues Belagerungsgerät. Man kann dort auch wiederbelebt werden.",
 	"Piercing bolts for ballista.":"Bolzen für die Balliste.",
+	"Explosive bolts for ballista.":"Explodierende Bolzen für die Balliste.",
 	"For Ballista\nTurns its piercing bolts into a shaped explosive charge.":"Für die Balliste\nÄndert die Bolzen in Explosivbolzen um.",
 
 	"A small boat with two rowing positions and a large space for cargo.":"Ein kleines Boot mit zwei Ruderplätzen und viel Platz für Güter.",


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes [issue #1235](https://github.com/transhumandesign/kag-base/issues/1235).
"Ballista Bolts" and "Ballista Shells" will be named that way in shop and inventories.
I adapted for this change in the German translation and made a few more fixes to the German translation while I was at it.

## Steps to Test or Reproduce

- Build a vehicle shop, notice that the Ballista ammo items will be named "Ballista Bolts" and "Ballista Shells" (Previously: "Ballista Ammo" and "Ballista Shells").
- Add those items into your inventory, notice that they will be named "Ballista Bolts" and "Ballista Shells" (Previously: "Ballista Bolts" and "Ballista Bolts").
- Play the game in the German language and notice "Ballista Shells" be translated to "Ballistenbomben" and "Explosive Bolts for ballista." be translated to "Explodierende Bolzen für die Balliste." Also notice less typos in the German translation.