### PR TITLE
Spikes not attached to stone anymore are doing damage

### DIFF
--- a/Entities/Structures/Spikes/Spikes.as
+++ b/Entities/Structures/Spikes/Spikes.as
@@ -256,6 +256,7 @@ void onTick(CBlob@ this)
 	{
 		this.getCurrentScript().tickFrequency = 25;
 		this.getSprite().SetAnimation("default");
+		this.set_u8(state_prop, 0);
 		this.set_u8(timer_prop, 0);
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes [issue #1231](https://github.com/transhumandesign/kag-base/issues/1231).
Spikes will now do damage again when attached to dirt/wood after no longer being attached to stone.

The bug was that the spikes thought they are still in state "hidden", therefore the onCollision() function didn't execute the damage.

I added a line in onTick() so if placedOnStone is false, then set the spikes to state "normal".

I play-tested the change a bit offline and there seems to be no side-effects. The spikes are behaving as usual.
Before this gets into the next patch, please test this change online, too. (Although I don't think there are side-effects online.)

## Steps to Test or Reproduce

- Place spikes next on stone.
- Remove the stone and make sure there is dirt/wood next to the spikes that it can attach itself to.
- Run, jump or fall against the spikes. Notice they are doing damage now.