### PR TITLE
Obstructor and Motion Sensor no longer break background

### DIFF
--- a/Entities/Structures/Common/DummyOnStatic.as
+++ b/Entities/Structures/Common/DummyOnStatic.as
@@ -5,7 +5,7 @@
 #include "DummyCommon.as";
 
 void onSetStatic(CBlob@ this, const bool isStatic)
-{
+{	
 	if (this.exists(Dummy::TILE))
 	{
 		const Vec2f POSITION = this.getPosition();
@@ -19,9 +19,12 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 				server_setDummyGridNetworkID(map.getTileOffset(POSITION), this.getNetworkID());
 			}
 			else
-			{
-				map.server_SetTile(POSITION, CMap::tile_empty);
-				server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
+			{	
+				if (this.getHealth()==0) //this check fixes Obstructor and Sensor breaking background
+				{ 
+					map.server_SetTile(POSITION, CMap::tile_empty);
+					server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
+				}
 			}
 		}
 	}

--- a/Entities/Structures/Common/DummyOnStatic.as
+++ b/Entities/Structures/Common/DummyOnStatic.as
@@ -18,13 +18,10 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 				map.server_SetTile(POSITION, this.get_TileType(Dummy::TILE));
 				server_setDummyGridNetworkID(map.getTileOffset(POSITION), this.getNetworkID());
 			}
-			else
+			else if (this.getHealth() == 0) //this check fixes Obstructor and Sensor breaking background
 			{	
-				if (this.getHealth()==0) //this check fixes Obstructor and Sensor breaking background
-				{ 
-					map.server_SetTile(POSITION, CMap::tile_empty);
-					server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
-				}
+				map.server_SetTile(POSITION, CMap::tile_empty);
+				server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
 			}
 		}
 	}

--- a/Entities/Structures/Common/DummyOnStatic.as
+++ b/Entities/Structures/Common/DummyOnStatic.as
@@ -5,7 +5,7 @@
 #include "DummyCommon.as";
 
 void onSetStatic(CBlob@ this, const bool isStatic)
-{	
+{
 	if (this.exists(Dummy::TILE))
 	{
 		const Vec2f POSITION = this.getPosition();
@@ -19,7 +19,7 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 				server_setDummyGridNetworkID(map.getTileOffset(POSITION), this.getNetworkID());
 			}
 			else if (this.getHealth() == 0) //this check fixes Obstructor and Sensor breaking background
-			{	
+			{
 				map.server_SetTile(POSITION, CMap::tile_empty);
 				server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
 			}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes [issue #592](https://github.com/transhumandesign/kag-base/issues/592).
Background and grass will no longer break when selecting obstructor/sensor and then something else in the build menu.

The same code in DummyOnStatic.as is executed when "selecting obstructor/sensor and then something else" and when the tile actually breaks. So I check the tile's health to make sure the code only executes in the latter case, when the health is 0.

I play-tested the change and the two components behave the same as before.