### PR TITLE
Cannot toggle lantern underwater, Lantern checks for water every tick

### DIFF
--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	this.Tag("ignore fall");
 
 	this.getCurrentScript().runFlags |= Script::tick_inwater;
-	this.getCurrentScript().tickFrequency = 24;
+	this.getCurrentScript().tickFrequency = 1;
 }
 
 void onTick(CBlob@ this)
@@ -46,6 +46,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("activate"))
 	{
+		if (this.isInWater()) return;
+		
 		Light(this, !this.isLight());
 	}
 

--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -16,7 +16,6 @@ void onInit(CBlob@ this)
 	this.Tag("ignore fall");
 
 	this.getCurrentScript().runFlags |= Script::tick_inwater;
-	this.getCurrentScript().tickFrequency = 1;
 }
 
 void onTick(CBlob@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This change makes it so that you cannot toggle the lantern on or off (= action 3) when it is in water.
Additionally, I set tickFrequency from 24 to 1, so the game checks if lantern is touching water much more reliably.
Since onTick() only checks for two bools, there should not be a drain on performance.
It is also possible to not set the tickFrequency, since the default seems to be 1.

It should be tested if the "lantern not getting extinguished" bug still happens in online servers with this change.

## Steps to Test or Reproduce

Hold a Lantern and stand in water. It will be extinguished by the water.
Press Action 3. Notice it will not turn light on anymore.

Throw a bunch of lanterns in water and notice they all get extinguished immediately rather than in 0.0 to 0.8 sec.