### PR TITLE
Dummy takes damage by other classes, some other minor changes

### DIFF
--- a/Entities/Characters/Builder/BuilderHittable.as
+++ b/Entities/Characters/Builder/BuilderHittable.as
@@ -14,6 +14,7 @@ const string[] builder_alwayshit =
 	"trap_block",
 	"bridge",
 	"flowers",
+	"dummy",
 
 	//buildings
 	"factory",

--- a/Entities/Special/Dummy/Dummy.as
+++ b/Entities/Special/Dummy/Dummy.as
@@ -2,7 +2,6 @@ void onInit(CBlob@ this)
 {
 	this.getSprite().SetZ(-20.0f);
 	this.getSprite().animation.frame = (this.getNetworkID() * 31) % 4;
-
 	this.SetFacingLeft(((this.getNetworkID() + 27) * 31) % 18 > 9);
 }
 
@@ -31,20 +30,32 @@ void onGib(CSprite@ this)
 		int r = (((blob.getNetworkID() + 1) * 31) % 3);
 		CParticle@ Large1   = makeGibParticle(filename, pos, vel + getRandomVelocity(90, hp - 0.2 , 80), 7 - (r % 2), 1 - (r / 2), Vec2f(16, 16), 2.0f, 20, "/material_drop", team);
 	}
+}
 
+bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
+{	
+    if (blob.getName() == "arrow" && this.getTeamNum() != blob.getTeamNum())
+    {
+        return true;
+    }
+    return false;
 }
 
 f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
 {
 	if (damage > 0.0f)
-	{
+	{	
+		CSprite@ sprite = this.getSprite();
+	
 		if (worldPoint.x > this.getPosition().x)
 		{
-			this.setAngleDegrees(this.getAngleDegrees() - 3 - XORRandom(10));
+			//this.setAngleDegrees(Maths::Max(this.getAngleDegrees() - 3 - XORRandom(10), -30));
+			sprite.RotateBy(-2 - XORRandom(7), Vec2f(0.0f, 12.0f));
 		}
 		else
 		{
-			this.setAngleDegrees(this.getAngleDegrees() + 3 + XORRandom(10));
+			//this.setAngleDegrees(Maths::Min(this.getAngleDegrees() + 3 + XORRandom(10), 30));
+			sprite.RotateBy(2 + XORRandom(7), Vec2f(0.0f, 12.0f));
 		}
 	}
 	return damage;

--- a/Entities/Special/Dummy/Dummy.cfg
+++ b/Entities/Special/Dummy/Dummy.cfg
@@ -76,7 +76,6 @@ $name                                      = dummy
 						IsFlammable.as;
 						Wooden.as;
 						GenericHit.as;
-						NoPlayerCollision.as;
 						AlignToTiles.as;
 f32_health                                 = 2.0
 # looks & behaviour inside inventory

--- a/Entities/Special/Dummy/Dummy.cfg
+++ b/Entities/Special/Dummy/Dummy.cfg
@@ -1,4 +1,4 @@
-# Sign config file
+# Dummy config file
 # $ string
 # @ array
 
@@ -7,12 +7,13 @@
 $sprite_factory                            = generic_sprite
 
 @$sprite_scripts                           = Dummy.as;
-                      						 Wooden.as;
+                      				Wooden.as;
+						FireAnim.as;
 $sprite_texture                            = Dummy.png
 s32_sprite_frame_width                     = 24
 s32_sprite_frame_height                    = 24
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = -4
+f32 sprite_offset_y                        = -8
 
 	$sprite_gibs_start                     = *start*
 
@@ -26,11 +27,11 @@ f32 sprite_offset_y                        = -4
 	
 	$gib_type                              = predefined
 	$gib_style                             = stone
-	u8_gib_count                           = 5					#number of gibs
+	u8_gib_count                           = 5
 	@u8_gib_frame                          = 4; 5; 6; 7;
 	f32_velocity                           = 10.0
 	f32_offset_x                           = 0.0
-	f32_offset_y                           = -0.0
+	f32_offset_y                           = 0.0
 	
 	$sprite_gibs_end                       = *end*
 	
@@ -47,17 +48,17 @@ f32 sprite_offset_y                        = -4
   
 $shape_factory                             = box2d_shape
 @$shape_scripts                            = 
-f32 shape_mass                             = 10.0
+f32 shape_mass                             = 50.0
 f32 shape_radius                           = 8.0
 f32 shape_friction                         = 0.5
 f32 shape_elasticity                       = 0.1
 f32 shape_buoyancy                         = 1.0
 f32 shape_drag                             = 0.1
-bool shape_collides                           = no
+bool shape_collides                        = yes
 bool shape_ladder                          = no
 bool shape_platform                        = no
  #block_collider
-@f32 verticesXY                            =
+@f32 verticesXY                            = 	
 u8 block_support                           = 0
 bool block_background                      = no
 bool block_lightpasses                     = no
@@ -72,16 +73,18 @@ $inventory_factory                         =
 
 $name                                      = dummy
 @$scripts                                  = Dummy.as;
-											 Wooden.as;
-											 GenericHit.as;
-											 AlignToTiles.as;
+						IsFlammable.as;
+						Wooden.as;
+						GenericHit.as;
+						NoPlayerCollision.as;
+						AlignToTiles.as;
 f32_health                                 = 2.0
 # looks & behaviour inside inventory
 $inventory_name                            = Dummy
 $inventory_icon                            = -
 u8 inventory_icon_frame                    = 0
-u8 inventory_icon_frame_width          = 0
-u8 inventory_icon_frame_height         = 0
+u8 inventory_icon_frame_width          	   = 0
+u8 inventory_icon_frame_height             = 0
 u8 inventory_used_width                    = 0
 u8 inventory_used_height                   = 0
 u8 inventory_max_stacks                    = 0

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -405,7 +405,7 @@ class PNGLoader
 			case map_colors::mook_archer:     autotile(offset); AddMarker(map, offset, "mook archer"); break;
 			case map_colors::mook_spawner:    autotile(offset); AddMarker(map, offset, "mook spawner"); break;
 			case map_colors::mook_spawner_10: autotile(offset); AddMarker(map, offset, "mook spawner 10"); break;
-			case map_colors::dummy:           autotile(offset); spawnBlob(map, "dummy", offset, 1, true); break;
+			case map_colors::dummy:           autotile(offset); spawnBlob(map, "dummy", offset, -1, true); break;
 			default:
 				HandleCustomTile( map, offset, pixel );
 			};


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This changes the Dummy strawman which appears in the Tutorial (Basics) and in some TDM maps.

* Before this change, Dummy could only get hit by knight attacks (if in a different team), and other classes couldn't interact with it.
* Now, Dummy can now be shot by arrows (if in a different team), can be grappled (any team), can be hit by a builder (any team).
* Changed the way the Dummy rotates when getting hit. It will rotate around the base pole rather than around its own center.
* Changed the y offset from -4 to -8 so the Dummy stands taller.
* Made Dummy able to burn.
* Changed the Map loader, so Dummy is in no team rather than in Red team. I didn't find an easy way to make Dummy in no team while still giving him red color so it will be grey color for now.

Thanks bunnie for helping a noob like me.

I tested this thoroughly, so barring any mistakes, it should be working as described.

## Steps to Test or Reproduce

Go to any map, then in console type /loadmap Ni_TrainingGround_Revised.
Shoot arrow at a Dummy, notice it will get hit.
Hit a Dummy as a builder, notice it will get hit.
Shoot fire arrow at a Dummy, notice it will burn.
Notice the Dummies are placed slightly higher above ground and will rotate around their pole.
