### PR TITLE
Shark doen't show seats or healthbar when in inventory

### DIFF
--- a/Entities/Common/GUI/HealthBar.as
+++ b/Entities/Common/GUI/HealthBar.as
@@ -6,6 +6,10 @@ void onRender(CSprite@ this)
 		return;
 
 	CBlob@ blob = this.getBlob();
+	
+	if (blob.isInInventory())
+		return;
+	
 	Vec2f center = blob.getPosition();
 	Vec2f mouseWorld = getControls().getMouseWorldPos();
 	const f32 renderRadius = (blob.getRadius()) * 0.95f;

--- a/Entities/Vehicles/Common/SeatsGUI.as
+++ b/Entities/Vehicles/Common/SeatsGUI.as
@@ -12,12 +12,12 @@ void onRender(CSprite@ this)
 
 	// draw only for local player
 	CBlob@ localBlob = getLocalPlayerBlob();
-
-	if (localBlob is null || localBlob.isAttached() || localBlob.isInInventory())
+	CBlob@ blob = this.getBlob();
+	
+	if (localBlob is null || localBlob.isAttached() || localBlob.isInInventory() || blob.isInInventory())
 	{
 		return;
 	}
-	CBlob@ blob = this.getBlob();
 
 	f32 arrowVisibleRadius = blob.getRadius() + 15.0f;
 

--- a/Entities/Vehicles/Common/SeatsGUI.as
+++ b/Entities/Vehicles/Common/SeatsGUI.as
@@ -14,7 +14,7 @@ void onRender(CSprite@ this)
 	CBlob@ localBlob = getLocalPlayerBlob();
 	CBlob@ blob = this.getBlob();
 	
-	if (localBlob is null || localBlob.isAttached() || localBlob.isInInventory() || blob.isInInventory())
+	if (localBlob is null || localBlob.isAttached() || localBlob.isInInventory() || blob.isInInventory() || blob.isAttachedToPoint("PICKUP"))
 	{
 		return;
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When putting Shark in an inventory (Storage/Crate/Dinghy/Longboat/Warboat/Bomber/Airship), the shark's seat arrow and healthbar won't be shown. 

## Steps to Test or Reproduce

Go to Sandbox, !shark, carry it, !crate, put shark in crate, notice there is no seat arrow and no healthbar.