### PR TITLE
Spawn Sign with your own text in Sandbox

### DIFF
--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -6,6 +6,7 @@
 #include "MakeSeed.as";
 #include "MakeCrate.as";
 #include "MakeScroll.as";
+#include "MakeSign.as";
 
 const bool chatCommandCooldown = false; // enable if you want cooldown on your server
 const uint chatCommandDelay = 3 * 30; // Cooldown in seconds
@@ -302,10 +303,15 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 					}
 					server_MakePredefinedScroll(pos, s);
 				}
-				else if(tokens[0] == "!coins")
+				else if (tokens[0] == "!coins")
 				{
 					int money = parseInt(tokens[1]);
 					player.server_setCoins(money);
+				}
+				else if (tokens[0] == "!sign")
+				{
+					CMap@ map = getMap();
+					createSign(pos, text_in.substr(tokens[0].length+1, -1));
 				}
 			}
 			else


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

Will set to "READY" after addressing these:
- Make the game look for bad words in the Sign's text, don't spawn it or censor it.
- Support line breaks with /n like in "TutorialCTF01.as".
- Make sign hittable by builder.
- Default to the shaggy chocolate text when no text is found after "!sign".
- Fix that text can be out of bounds if a word is too long.
- Fix that an icon can be out of bounds. 

## Description

Before this change, in Sandbox, you could type "!sign" and it spawned a sign saying "The big brown fox jumped over the shaggy chocolate". That's all text you could have. "!sign blah" didn't do anything.

This change makes it so !sign lets you put your own text when spawning a sign in Sandbox.
Type in "!sign your text blah blah $icon$".

https://i.imgur.com/0TFCMoa.png

Let me know what you think.