### PR TITLE
Magazine accepts any 1x1 item and shows the correct icon

### DIFF
--- a/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -255,7 +255,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int team_num = 0, const stri
 		}
 		{
 			BuildBlock b(0, "magazine", "$magazine$", "Magazine");
-			AddRequirement(b.reqs, "blob", "mat_stone", "Wood", 20);
+			AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 20);
 			blocks[3].push_back(b);
 		}
 		{

--- a/Entities/Structures/Components/Passive/Magazine/Magazine.as
+++ b/Entities/Structures/Components/Passive/Magazine/Magazine.as
@@ -66,13 +66,13 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	if (this.getDistanceTo(caller) > 16.0f || !this.getShape().isStatic()) return;
 
 	CBlob@ carried = caller.getCarriedBlob();
-	bool LOAD = (carried !is null);
+	bool LOAD = carried !is null;
 
 	CBlob@ item = this.getInventory().getItem(0);
 
 	if (LOAD)
 	{
-		if  (!carried.canBePutInInventory(this) 			// doesn't go in inventories to begin with
+		if 	(!carried.canBePutInInventory(this) 			// doesn't go in inventories to begin with
 			|| !this.getInventory().canPutItem(carried)  	// does go in inventories but doesn't fit
 			|| (item !is null && (item.getName() != carried.getName() || item.getQuantity() == item.maxQuantity)))
 		{
@@ -87,10 +87,11 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	CBitStream params;
 	params.write_u16(LOAD ? carried.getNetworkID() : caller.getNetworkID());
 		
-	string iconName = LOAD ? "$" + carried.getName() + "$" : "$" + item.getName() + "$";
-	if (LOAD ? carried.hasTag("use inventory icon") : item.hasTag("use inventory icon"))
+	CBlob@ target = LOAD ? carried : item;
+	string iconName = "$" + target.getName() + "$";
+	if (target.hasTag("use inventory icon"))
 	{
-		iconName = LOAD ? "$" + carried.getInventoryName() + "$" : "$" + item.getInventoryName() + "$";
+		iconName = "$" + target.getInventoryName() + "$";
 	}
 
 	CButton@ button = caller.CreateGenericButton(
@@ -98,8 +99,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	Vec2f_zero,																									// button offset
 	this, 																										// button attachment
 	this.getCommandID(LOAD ? "load" : "unload"), 																// command id
-	LOAD ? getTranslatedString("Load {ITEM}").replace("{ITEM}", carried.getInventoryName())
-		 : getTranslatedString("Unload {ITEM}").replace("{ITEM}", item.getInventoryName()), 					// description
+	getTranslatedString(LOAD ? "Load {ITEM}" : "Unload {ITEM}").replace("{ITEM}", target.getInventoryName()),	// description
 	params);																									// cbitstream
 		
 	button.radius = 8.0f;

--- a/Entities/Structures/Components/Passive/Magazine/Magazine.as
+++ b/Entities/Structures/Components/Passive/Magazine/Magazine.as
@@ -89,7 +89,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		
 	CBlob@ target = LOAD ? carried : item;
 	string iconName = "$" + target.getName() + "$";
-	if (target.hasTag("use inventory icon"))
+	if (GUI::hasIconName("$" + target.getInventoryName() + "$"))
 	{
 		iconName = "$" + target.getInventoryName() + "$";
 	}

--- a/Entities/Structures/Components/Passive/Magazine/Magazine.as
+++ b/Entities/Structures/Components/Passive/Magazine/Magazine.as
@@ -65,47 +65,45 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	if (this.getDistanceTo(caller) > 16.0f || !this.getShape().isStatic()) return;
 
-	CBlob@ carried = caller.getAttachments().getAttachmentPointByName("PICKUP").getOccupied();
-	if (carried !is null)
+	CBlob@ carried = caller.getCarriedBlob();
+	bool LOAD = (carried !is null);
+
+	CBlob@ item = this.getInventory().getItem(0);
+
+	if (LOAD)
 	{
-		if (carried.getRadius() > 3.5f || !carried.canBePutInInventory(this)) return;
-
-		CBlob@ item = this.getInventory().getItem(0);
-		if (item !is null && (item.getName() != carried.getName() || item.getQuantity() == item.maxQuantity)) return;
-
-		CBitStream params;
-		params.write_u16(carried.getNetworkID());
-
-		CButton@ button = caller.CreateGenericButton(
-		"$"+carried.getName()+"$",              // icon token
-		Vec2f_zero,                             // button offset
-		this,                                   // button attachment
-		this.getCommandID("load"),              // command id
-		getTranslatedString("Load"),            // description
-		params);                                // cbitstream
-
-		button.radius = 8.0f;
-		button.enableRadius = 22.0f;
+		if  (!carried.canBePutInInventory(this) 			// doesn't go in inventories to begin with
+			|| !this.getInventory().canPutItem(carried)  	// does go in inventories but doesn't fit
+			|| (item !is null && (item.getName() != carried.getName() || item.getQuantity() == item.maxQuantity)))
+		{
+			return;
+		}
 	}
-	else
+	else if (item is null)
 	{
-		CBlob@ item = this.getInventory().getItem(0);
-		if (item is null) return;
-
-		CBitStream params;
-		params.write_u16(caller.getNetworkID());
-
-		CButton@ button = caller.CreateGenericButton(
-		"$"+item.getName()+"$",                 // icon token
-		Vec2f_zero,                             // button offset
-		this,                                   // button attachment
-		this.getCommandID("unload"),            // command id
-		getTranslatedString("Unload"),          // description
-		params);                                // cbitstream
-
-		button.radius = 8.0f;
-		button.enableRadius = 22.0f;
+		return;
 	}
+
+	CBitStream params;
+	params.write_u16(LOAD ? carried.getNetworkID() : caller.getNetworkID());
+		
+	string iconName = LOAD ? "$" + carried.getName() + "$" : "$" + item.getName() + "$";
+	if (LOAD ? carried.hasTag("use inventory icon") : item.hasTag("use inventory icon"))
+	{
+		iconName = LOAD ? "$" + carried.getInventoryName() + "$" : "$" + item.getInventoryName() + "$";
+	}
+
+	CButton@ button = caller.CreateGenericButton(
+	iconName, 																									// icon token
+	Vec2f_zero,																									// button offset
+	this, 																										// button attachment
+	this.getCommandID(LOAD ? "load" : "unload"), 																// command id
+	LOAD ? getTranslatedString("Load {ITEM}").replace("{ITEM}", carried.getInventoryName())
+		 : getTranslatedString("Unload {ITEM}").replace("{ITEM}", item.getInventoryName()), 					// description
+	params);																									// cbitstream
+		
+	button.radius = 8.0f;
+	button.enableRadius = 22.0f;
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This is an addition/enhancement to [Pull Request #1215](https://github.com/transhumandesign/kag-base/pull/1215). You need to apply PR #1215 and then this to see all the changes.

Fixes [issue #1253](https://github.com/transhumandesign/kag-base/issues/1253).

- You can put in any 1x1 item instead of making it dependent on item's radius. Can put in Log, Drill, Chicken, Mine, Scroll, lit waterbomb now.
- It will show the correct icon for seeds and foods, if you applied PR 1215.
- It will say "(Un)Load -item-" instead of "(Un)Load".
- Magazine requires 20 wood.
- Optimized code to make it less repetitive.
Use `caller.getCarriedBlob()`
instead of `caller.getAttachments().getAttachmentPointByName("PICKUP").getOccupied();`