### PR TITLE
Saw doesn't kill players on the same floor when they change class or use tunnel

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -182,7 +182,7 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 
 		f32 dot = off * (Vec2f(0, -1).RotateBy(this.getAngleDegrees(), Vec2f()));
 
-		if (dot > 0.8f && blob.getVelocity().y > 0.5f)
+		if (dot > 0.8f && (blob.getVelocity().y - this.getVelocity().y) > 0.1f)
 		{
 			if (getNet().isClient() && !g_kidssafe) //add blood gfx
 			{

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -182,7 +182,7 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 
 		f32 dot = off * (Vec2f(0, -1).RotateBy(this.getAngleDegrees(), Vec2f()));
 
-		if (dot > 0.8f)
+		if (dot > 0.8f && blob.getVelocity().y > 0.5f)
 		{
 			if (getNet().isClient() && !g_kidssafe) //add blood gfx
 			{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes [issue #1252](https://github.com/transhumandesign/kag-base/issues/1252).

Player will not get killed by an active Saw on the same ground when changing class or using tunnel.
If a player or a friendly mine is touching the Saw blade but has a velocity of 0.5 or less, then they are not getting sawed.

https://i.imgur.com/jnw8Ink.png