### PR TITLE
[dev] 8x8 icons are centered in inventory HUD

### DIFF
--- a/Entities/Common/GUI/ActorHUDStartPos.as
+++ b/Entities/Common/GUI/ActorHUDStartPos.as
@@ -34,8 +34,8 @@ void DrawInventoryOnHUD(CBlob@ this, Vec2f tl)
 			const int quantity = this.getBlobCount(name);
 			drawn.push_back(name);
 
-			GUI::DrawIcon(item.inventoryIconName, item.inventoryIconFrame, item.inventoryFrameDimension, tl + Vec2f(0 + (drawn.length - 1) * 40, -6), 1.0f);
-
+			GUI::DrawIcon(item.inventoryIconName, item.inventoryIconFrame, item.inventoryFrameDimension, tl + Vec2f((drawn.length - 1) * 40 + (16-item.inventoryFrameDimension.x), -6 + (16-item.inventoryFrameDimension.y)), 1.0f);
+			
 			f32 ratio = float(quantity) / float(item.maxQuantity);
 			col = ratio > 0.4f ? SColor(255, 255, 255, 255) :
 			      ratio > 0.2f ? SColor(255, 255, 255, 128) :


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This change renders items with 8x8 pixeled icons (e.g. grain, lantern, egg) in the center of a slot rather than in the top left.

`(16-item.inventoryFrameDimension.x)` and `(16-item.inventoryFrameDimension.y)` are used. There is no item whose icon will show up in the HUD that has a greater width or height than 16.

Before: https://i.imgur.com/zDWK792.png
After: https://i.imgur.com/3hqteBK.png