### PR TITLE
Sponge and Lantern inventory icons update based on their sprite

### DIFF
--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -33,11 +33,13 @@ void Light(CBlob@ this, bool on)
 	{
 		this.SetLight(false);
 		this.getSprite().SetAnimation("nofire");
+		SetFrame(this, false);
 	}
 	else
 	{
 		this.SetLight(true);
 		this.getSprite().SetAnimation("fire");
+		SetFrame(this, true);
 	}
 	this.getSprite().PlaySound("SparkleShort.ogg");
 }
@@ -48,10 +50,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		Light(this, !this.isLight());
 	}
-
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
     return blob.getShape().isStatic();
+}
+
+//sprite
+
+void SetFrame(CBlob@ blob, bool light_on)
+{
+	Animation@ animation = blob.getSprite().getAnimation("fire");
+	if (animation !is null)
+	{
+		u8 index = light_on ? 0 : 3;
+		animation.SetFrameIndex(index);
+		blob.inventoryIconFrame = index;
+	}
 }

--- a/Entities/Items/Sponge/SpongeCommon.as
+++ b/Entities/Items/Sponge/SpongeCommon.as
@@ -2,11 +2,14 @@
 const int ABSORB_COUNT = 100;
 const string ABSORBED_PROP = "absorbed";
 
-
 void spongeUpdateSprite(CSprite@ this, u8 absorbed)
 {
-	uint16 old_frame_index = this.getFrameIndex();
-	this.animation.setFrameFromRatio(f32(absorbed) / ABSORB_COUNT);
+	uint8 old_frame_index = this.getFrameIndex();
+	this.animation.setFrameFromRatio(f32(absorbed) / ABSORB_COUNT); // update sprite on hand
+	
+	uint8 inventory_icon_index = Maths::Min((f32(absorbed) / ABSORB_COUNT)*4, 3);
+	this.getBlob().inventoryIconFrame = inventory_icon_index; // update inventory icon
+	
 	if (old_frame_index > this.getFrameIndex())
 	{
 		makeSteamPuff(this.getBlob());


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

Will set to "READY" after addressing these:
- Catapult should show the correct icon when loading a filled Sponge or a turned off Lantern.

## Description

This change makes it so a Lantern with light turned on/off or an empty/filled Sponge will update their inventory icon accordingly. I'm not sure if the code is ok, please let me know if it isn't. For Lantern I copy-pasted SetFrame() from Bucket. For Sponge I changed spongeUpdateSprite() in SpongeCommon.as.

Before: https://i.imgur.com/ZkoKhzx.png
After: https://i.imgur.com/3towa4G.png
