### PR TITLE
Keg makes a sound when hit by Builder pickaxe or Knight jab

### DIFF
--- a/Entities/Items/Explosives/Keg.cfg
+++ b/Entities/Items/Explosives/Keg.cfg
@@ -66,7 +66,8 @@ $attachment_factory                               = box2d_attachment
 $inventory_factory                                =
 
 $name                                             = keg
-@$scripts                                         = FakeRolling.as;
+@$scripts                                         = Wooden.as;
+													FakeRolling.as;
 													Activatable.as;
 													KegVoodoo.as;
 													Keg.as;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When builder hits an enemy Crate, Trampoline, Saw, etc. it's making a wooden sound per hit. However, hitting Keg didn't play any sound.

This adds Wooden.as to the scripts section in Keg.cfg, so Keg is making a wooden damage sound when it is hit by an enemy Builder or Knight, instead of getting knocked back and damaged without any noise.