### PR TITLE
Fix item spam causing lag in Sandbox

### DIFF
--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -138,35 +138,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 					}
 				}
 			}
-			
-			/* Method 2:
-			Use this if we want to not rely on dictionary itemLimits in ItemLimits.as
-			and do item counting from scratch:
-			
-			CBlob@[] blobsInMap;
-			getBlobsByName(itemName, @blobsInMap);
-			int blobCounts = 0;
-			
-			int callerTeam = caller.getTeamNum();
-			if (callerTeam < 0 || callerTeam > 7) callerTeam = 8;
-			
-			ConfigFile cfg = ConfigFile();
-			cfg.loadFile("Rules/CommonScripts/ItemLimits.cfg");
-			s32 maximum = cfg.read_s32(itemName, 200);
-			
-			for (uint b = 0; b < blobsInMap.length(); ++b)
-			{
-				int blobTeam = blobsInMap[b].getTeamNum();
-				if (blobTeam < 0 || blobTeam > 7) blobTeam = 8;
-				if (callerTeam == blobTeam) blobCounts++;
-			}
-
-			if (blobCounts >= maximum && maximum > 0) 
-			{	
-				sendChatWarningLimitedItem(maximum, itemName);
-				return;
-			}
-			*/
 		}
 
 		if (this.getHealth() <= 0)

--- a/Entities/Items/Food/Food.as
+++ b/Entities/Items/Food/Food.as
@@ -15,7 +15,6 @@ void onInit(CBlob@ this)
 
 	this.getSprite().SetFrameIndex(index);
 	this.SetInventoryIcon(this.getSprite().getConsts().filename, index, Vec2f(16, 16));
-	this.server_setTeamNum(0); // blue fishy like in sprite sheet
 
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -16,7 +16,8 @@ const string[] blacklistedItems = {
 	"necromancer",  // annoying/grief
 	"greg",         // annoying/grief
 	"ctf_flag",     // sound spam
-	"flag_base"     // sound spam + bedrock grief
+	"flag_base",     // sound spam + bedrock grief
+	"war_base"	// bedrock grief
 };
 
 void onInit(CRules@ this)

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -21,7 +21,6 @@ void onRestart(CRules@ this)
 void Reset(CRules@ this)
 {
 	resetLimitedItemsList();
-	print("hi");
 	CRules@ rules = getRules();
 	rules.set("item_limits", itemLimits);
 }

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -1,0 +1,110 @@
+// This rules script counts spawned items per team and sets a limit to them after which no more can be spawned in,
+// so as to prevent the game lagging from too many spawned items/blobs.
+
+#include "ItemLimitsCommon.as";
+
+dictionary itemLimits;
+
+void onInit(CRules@ this)
+{
+	resetLimitedItemsList();
+	
+	CRules@ rules = getRules();
+	rules.set("item_limits", itemLimits);
+}
+
+void onRestart(CRules@ this)
+{
+	Reset(this);
+}
+
+void Reset(CRules@ this)
+{
+	resetLimitedItemsList();
+	print("hi");
+	CRules@ rules = getRules();
+	rules.set("item_limits", itemLimits);
+}
+
+void resetLimitedItemsList()
+{
+	itemLimits.deleteAll();
+
+	CBlob@[] all;
+	getBlobs(@all);
+			
+	for (uint b = 0; b < all.length(); ++b)
+	{
+		addLimitedItem(all[b]); // keep re-adding the pre-existing blobs as if they were spawned in consecutively
+	}
+}
+
+void addLimitedItem(CBlob@ blob)
+{
+	string item = blob.getName();
+	int team = blob.getTeamNum();
+	if (team < 0 || team > 7) team = 8;
+	
+	if(itemLimits.exists(item)) // increase current count of item by 1
+	{		
+		int[] itemCounts;
+		itemLimits.get(item, itemCounts);
+		itemCounts[team]++;
+		
+		if (itemCounts[team] > itemCounts[9] && itemCounts[9] > 0) // current amount exceeds the maximum allowed, or there is no maximum
+		{
+			// despawn item and its inventory
+			CInventory@ inv = blob.getInventory();
+			if (inv !is null)
+			{
+				for (u8 i = 0; i < inv.getItemsCount(); i++)
+				{
+					inv.getItem(i).server_Die();
+				}
+			}
+			blob.server_Die();
+
+			sendChatWarningLimitedItem(itemCounts[9], item);
+		}
+
+		itemLimits.set(item, itemCounts);
+	}
+	else // add a new entry for this item
+	{
+		ConfigFile cfg = ConfigFile();
+		cfg.loadFile("ItemLimits.cfg");
+		s32 maximum = cfg.read_s32(item, 200); // set to specified maximum or if not existant default to 200
+	
+		int[] itemCounts = {0, 0, 0, 0, 0, 0, 0, 0, 0, maximum}; //teams 0-7, counter for items that aren't assigned to a team, and the maximum amount allowed
+		itemCounts[team]++;
+		itemLimits.set(item, itemCounts);	
+	}
+}
+
+void onBlobCreated(CRules@ this, CBlob@ blob)
+{
+	addLimitedItem(blob);
+	
+	CRules@ rules = getRules();
+	rules.set("item_limits", itemLimits);
+}
+
+void onBlobDie(CRules@ this, CBlob@ blob)
+{
+	string item = blob.getName();
+	int team = blob.getTeamNum();
+	if (team < 0 || team > 7) team = 8;
+	
+	if(itemLimits.exists(item)) // decrease current count of item by 1
+	{		
+		int[] itemCounts;
+		itemLimits.get(item, itemCounts);
+		itemCounts[team]--;
+		if (itemCounts[team] < 0) itemCounts[team] = 0;
+
+		itemLimits.set(item, itemCounts);
+	}
+	
+	CRules@ rules = getRules();
+	rules.set("item_limits", itemLimits);
+}

--- a/Rules/CommonScripts/ItemLimits.cfg
+++ b/Rules/CommonScripts/ItemLimits.cfg
@@ -1,0 +1,74 @@
+#item limits list
+	
+	default					= 200
+
+	#structures
+	
+	tunnel					= 20
+	ballista              	= 20
+	warboat 				= 20
+	longboat				= 20
+	bomber					= 20
+	airship					= 20
+	dinghy					= 20
+	raft					= 20
+	saw						= 50
+	trampoline				= 50
+	
+	#items
+	
+	keg            			= 20
+	mine             		= 20
+	bucket					= 100
+	sponge					= 100
+	lantern					= 100
+	crate					= 100
+	boulder					= 100
+	drill					= 100
+	
+	#unlimited - materials should rely on decay timers to disappear before they become a problem
+	
+	stone_door              = -1
+	wooden_door				= -1
+	bridge					= -1
+	ladder					= -1
+	wooden_platform			= -1
+	building				= -1
+	spikes					= -1
+	wire					= -1
+	elbow					= -1
+	tee						= -1
+	junction				= -1
+	diode					= -1
+	resistor				= -1
+	inverter				= -1
+	oscillator				= -1
+	transistor				= -1
+	toggle					= -1
+	randomizer				= -1
+	lever					= -1
+	push_button				= -1
+	coin_slot				= -1
+	pressure_plate			= -1
+	sensor					= -1
+	lamp					= -1
+	emitter					= -1
+	receiver				= -1
+	magazine				= -1
+	bolter					= -1
+	dispenser				= -1
+	obstructor				= -1
+	spike					= -1
+	mat_wood				= -1
+	mat_stone				= -1
+	mat_gold				= -1
+	mat_arrows				= -1
+	mat_waterarrows			= -1
+	mat_firearrows			= -1
+	mat_bombarrows			= -1
+	mat_bombs				= -1
+	mat_waterbombs			= -1
+	mat_bolts				= -1
+	mat_bomb_bolts			= -1
+	arrow					= -1
+	bomb					= -1

--- a/Rules/CommonScripts/ItemLimitsCommon.as
+++ b/Rules/CommonScripts/ItemLimitsCommon.as
@@ -1,0 +1,18 @@
+void sendChatWarningLimitedItem(int maximum, string item)
+{
+	// send warning to chat
+	CBitStream params;
+	CPlayer@ player = getLocalPlayer();
+	CRules@ rules = getRules();
+			
+	params.write_string("Can't create more than " + maximum + " " + item + "s.");
+
+	// List is reverse so we can read it correctly into SColor when reading
+	SColor errorColor = SColor(255,255,100,0);
+	params.write_u8(errorColor.getBlue());
+	params.write_u8(errorColor.getGreen());
+	params.write_u8(errorColor.getRed());
+	params.write_u8(errorColor.getAlpha());
+
+	rules.SendCommand(rules.getCommandID("SendChatMessage"), params, player);
+}

--- a/Rules/Sandbox/Scripts/Sandbox_Rules.as
+++ b/Rules/Sandbox/Scripts/Sandbox_Rules.as
@@ -7,11 +7,6 @@
 #include "RulesCore.as";
 #include "RespawnSystem.as";
 
-const int maxMines = 20;
-const int maxKegs = 20;
-int mineCount = 0;
-int kegCount = 0;
-
 //simple config function - edit the variables below to change the basics
 
 void Config(SandboxCore@ this)
@@ -38,9 +33,7 @@ void Config(SandboxCore@ this)
 	//spawn after death time
 	this.spawnTime = (getTicksASecond() * cfg.read_s32("spawn_time", 15));
 
-
 	getRules().Tag('quick decay');
-
 }
 
 //Sandbox spawn system
@@ -389,41 +382,4 @@ void Reset(CRules@ this)
 	this.set("core", @core);
 	this.set("start_gametime", getGameTime() + core.warmUpTime);
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as
-
-	kegCount = 0;
-	mineCount = 0;
 }
-
-void onBlobCreated(CRules@ this, CBlob@ blob)
-{
-	if (blob.getName() == "mine")
-	{
-		mineCount += 1;
-		if (mineCount > maxMines)
-		{
-			blob.server_Die(); // wont explode because its just been made
-		}
-	}
-	else if (blob.getName() == "keg")
-	{
-		kegCount += 1;
-		if (kegCount > maxKegs)
-		{
-			blob.server_Die();
-		}
-	}
-}
-
-
-void onBlobDie(CRules@ this, CBlob@ blob)
-{
-	if (blob.getName() == "mine")
-	{
-		mineCount -= 1;
-	}
-	else if (blob.getName() == "keg")
-	{
-		kegCount -= 1;
-	}
-}
-

--- a/Rules/Sandbox/gamemode.cfg
+++ b/Rules/Sandbox/gamemode.cfg
@@ -51,6 +51,7 @@ scripts                                           = KAG.as;
 													BindingsMenu.as;
 													ColoredNameToggle.as;
 													PropagateBans.as;
+													ItemLimits.as;
 
 daycycle_speed                                    = 10
 daycycle_start                                    = 0.3


### PR DESCRIPTION
## Status

**READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Short Description

- Can't keep spamming !fishyschool, !chickenflock or other items to lag the server.
- War_base is now blacklisted so you can't spam it to grief in online Sandbox. 
- Buying an item that is limited will not subtract money from you.

## Long Description

This change adds a new rules script ItemLimits.as which is added to Sandbox/gamemode.cfg (scripts section).
Instead of checking for only two items (keg and mine) and imposing a general limit of 20 in Sandbox_Rules.as, all items are counted per team in ItemLimits.as.
So e.g. Blue Team can have 20 kegs and 20 tunnels, Red Team can have their own 20 kegs and 20 tunnels. Etc.
Basicly, this change takes what Sandbox_Rules.as was already doing to the next level.

The maximum allowed per item per team is fetched from ItemLimits.cfg. The default is 200 but I have set most items to lower values, please refer to ItemLimits.cfg to get an understanding.

Materials are not counted as I would like them to disappear based on their decay timer. Gold is currently the only material not decaying so that still needs addressing, otherwise it works as intended.

Builder blobs are not counted because I don't want to prevent someone from filling the whole map with doors, sensors, etc. They are not causing lag in a way that e.g. chicken do, anyway.

This change also adds war_base to the blacklisted items due to griefing (it can destroy the ground beneath you, like the already blacklisted hall could). Tent and TDM_Spawn will also be limited to 20, so the whole map can't be spammed with it.

If adjustments are made, ItemLimits.as could also be added to other game modes, but I have not seen item spam being a problem in CTF/TTH/TDM. This change is just so that Sandbox servers can't be made unplayable by someone spamming !chickenflock, !fishyschool or !war_base.

Shop.as will fetch ItemLimits.as' item counts to check if an item that is about to be bought is exceeding its limit. If yes, the item will not get created and no money is subtracted either. Otherwise, ItemLimits.as will despawn items if they exceed their limit (e.g. when there are 20 kegs and you try !keg). In both cases, a warning in chat lets the player know what happened. 
https://i.imgur.com/Y49xp74.png
https://i.imgur.com/YGg0a0S.png

Removed `this.server_setTeamNum(0); // blue fishy like in sprite sheet;` from Food.as onInit() so that burgers bought in quarters will be properly assigned to the caller's team, so as to make the item counting work properly. I didn't see any side-effects since Fishy sprite in inventory is still blue when you are in a team other than Blue Team.

When a map is loaded, ItemLimits.as will count items already on the map.
/restartmap or /loadmap will properly reset the item counts.

This PR is in a state where I assume all side-effects and crashes are fixed. If you do encounter any issues, please let me know.

## Additional Information

Thanks to all the people on #modding helping me.