### PR TITLE
Fix item spam causing lag in Sandbox [improvement]

### DIFF
--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -8,6 +8,7 @@
 #include "MakeCrate.as"
 #include "CheckSpam.as"
 #include "GenericButtonCommon.as"
+#include "ItemLimits.as";
 
 void onInit(CBlob@ this)
 {
@@ -87,9 +88,9 @@ bool isInRadius(CBlob@ this, CBlob @caller)
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	bool isServer = getNet().isServer();
-
+	
 	if (cmd == this.getCommandID("shop buy"))
-	{
+	{	
 		if (this.hasTag("shop disabled"))
 			return;
 
@@ -106,6 +107,13 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBlob@ caller = getBlobByNetworkID(callerID);
 		if (caller is null) { return; }
 		CInventory@ inv = caller.getInventory();
+		
+		CRules@ rules = getRules();
+		
+		if (rules.hasTag('item limits'))
+		{	
+			if (blobLimitExceeded( blobName, caller )) { return; }
+		}
 
 		if (this.getHealth() <= 0)
 		{
@@ -189,7 +197,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				}
 				else
 				{
-
 					//inv.server_TakeRequirements(s.requirements);
 					Vec2f spawn_offset = Vec2f();
 
@@ -215,9 +222,10 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 						}
 					}
 					else
-					{
+					{	
 						CBlob@ blob = server_CreateBlob(blobName, caller.getTeamNum(), this.getPosition() + spawn_offset);
 						CInventory@ callerInv = caller.getInventory();
+						
 						if (blob !is null)
 						{
 							bool pickable = blob.getAttachments() !is null && blob.getAttachments().getAttachmentPointByName("PICKUP") !is null;
@@ -425,7 +433,6 @@ void BuildShopMenu(CBlob@ this, CBlob @caller, string description, Vec2f offset,
 			menu.AddKeyCommand(numKeys[i], this.getCommandID("shop buy"), params);
 		}
 	}
-
 }
 
 void BuildDefaultShopMenu(CBlob@ this, CBlob @caller)

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -364,8 +364,6 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 	{
 		CBitStream params;
 		params.write_string(errorMessage);
-
-		// List is reverse so we can read it correctly into SColor when reading
 		params.write_u32(errorColor.color);
 
 		this.SendCommand(this.getCommandID("SendChatMessage"), params, player);

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -183,7 +183,7 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 		{	
 			if (!(getRules().hasTag('item limits') && blobLimitExceeded("crate", blob)))
 			{
-				client_AddToChat("usage: !crate BLOBNAME [DESCRIPTION]", SColor(255, 255, 0, 0)); //e.g., !crate shark Your Little Darling
+				client_AddToChat("Usage: !crate BLOBNAME [DESCRIPTION]", SColor(255, 255, 0, 0)); //e.g., !crate shark Your Little Darling
 				server_MakeCrate("", "", 0, team, Vec2f(pos.x, pos.y - 30.0f));
 			}
 		}
@@ -366,10 +366,7 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 		params.write_string(errorMessage);
 
 		// List is reverse so we can read it correctly into SColor when reading
-		params.write_u8(errorColor.getBlue());
-		params.write_u8(errorColor.getGreen());
-		params.write_u8(errorColor.getRed());
-		params.write_u8(errorColor.getAlpha());
+		params.write_u32(errorColor.color);
 
 		this.SendCommand(this.getCommandID("SendChatMessage"), params, player);
 	}
@@ -413,7 +410,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @para)
 	if (cmd == this.getCommandID("SendChatMessage"))
 	{
 		string errorMessage = para.read_string();
-		SColor col = SColor(para.read_u8(), para.read_u8(), para.read_u8(), para.read_u8());
+		SColor col = SColor(para.read_u32());
 		client_AddToChat(errorMessage, col);
 	}
 }

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -40,18 +40,15 @@ void chatWarningItemLimit(int maximum, string item)
 	CBitStream params;
 	CPlayer@ player = getLocalPlayer();
 	CRules@ rules = getRules();
-	string suffix;
 	
-	if (excludedFromTeamCheck.find( item ) == -1) suffix = "per team";
+	string suffix = (excludedFromTeamCheck.find(item) == -1) ? " per team" : "";
+	string plural = (maximum > 1) ? "s" : "";
 		
-	params.write_string("Can't create more than " + maximum + " " + item + "s " + suffix + ".");
+	params.write_string("Can't spawn more than " + maximum + " " + item + " blob" + plural + suffix + ".");
 
 	// List is reverse so we can read it correctly into SColor when reading
 	SColor errorColor = SColor(255,255,100,0);
-	params.write_u8(errorColor.getBlue());
-	params.write_u8(errorColor.getGreen());
-	params.write_u8(errorColor.getRed());
-	params.write_u8(errorColor.getAlpha());
+	params.write_u32(errorColor.color);
 
 	rules.SendCommand(rules.getCommandID("SendChatMessage"), params, player);
 }

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -40,11 +40,11 @@ void chatWarningItemLimit(int maximum, string item)
 	CBitStream params;
 	CPlayer@ player = getLocalPlayer();
 	CRules@ rules = getRules();
-	string appendix;
+	string suffix;
 	
-	if (excludedFromTeamCheck.find( item ) == -1) appendix = "per team";
+	if (excludedFromTeamCheck.find( item ) == -1) suffix = "per team";
 		
-	params.write_string("Can't create more than " + maximum + " " + item + "s " + appendix + ".");
+	params.write_string("Can't create more than " + maximum + " " + item + "s " + suffix + ".");
 
 	// List is reverse so we can read it correctly into SColor when reading
 	SColor errorColor = SColor(255,255,100,0);

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -46,7 +46,6 @@ void chatWarningItemLimit(int maximum, string item)
 		
 	params.write_string("Can't spawn more than " + maximum + " " + item + " blob" + plural + suffix + ".");
 
-	// List is reverse so we can read it correctly into SColor when reading
 	SColor errorColor = SColor(255,255,100,0);
 	params.write_u32(errorColor.color);
 

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -1,0 +1,58 @@
+const string[] excludedFromTeamCheck = {"seed", "food", "fishy", "chicken", "shark", "bison", "greg", "log", "boulder", "tree_pine", "tree_bushy", "bush"};
+
+bool blobLimitExceeded(string blobName, CBlob@ caller = null) // returns true if exceeding the limit, false otherwise
+{	
+	string itemName = blobName;
+	if (blobName == "filled_bucket") itemName = "bucket";
+
+	CBlob@[] blobsInMap;
+	getBlobsByName(itemName, @blobsInMap);
+	int blobCounts = 0;
+
+	int callerTeam = (caller is null) ? 8 : caller.getTeamNum();  
+	if ( callerTeam < 0 || callerTeam > 8 ) callerTeam = 8;
+	
+	ConfigFile cfg = ConfigFile();
+	cfg.loadFile("Rules/CommonScripts/ItemLimits.cfg");
+	s32 maximum = cfg.read_s32( itemName, 200 );
+
+	if (itemName == "tree_pine" || itemName == "tree_bushy" ) print(blobsInMap.length()+"");
+	if ( maximum > 0 )
+	{
+		for (uint b = 0; b < blobsInMap.length(); ++b)
+		{	
+			int blobTeam = blobsInMap[b].getTeamNum();
+			if ( blobTeam < 0 || blobTeam > 7 ) blobTeam = 8;
+			if ( callerTeam == blobTeam || excludedFromTeamCheck.find(itemName) != -1 ) blobCounts++;
+		}
+
+		if ( blobCounts >= maximum ) 
+		{	
+			chatWarningItemLimit(maximum, itemName);
+			return true;
+		}
+	}
+	return false;
+}
+
+void chatWarningItemLimit(int maximum, string item)
+{
+	// send warning to chat
+	CBitStream params;
+	CPlayer@ player = getLocalPlayer();
+	CRules@ rules = getRules();
+	string appendix;
+	
+	if (excludedFromTeamCheck.find( item ) == -1) appendix = "per team";
+		
+	params.write_string("Can't create more than " + maximum + " " + item + "s " + appendix + ".");
+
+	// List is reverse so we can read it correctly into SColor when reading
+	SColor errorColor = SColor(255,255,100,0);
+	params.write_u8(errorColor.getBlue());
+	params.write_u8(errorColor.getGreen());
+	params.write_u8(errorColor.getRed());
+	params.write_u8(errorColor.getAlpha());
+
+	rules.SendCommand(rules.getCommandID("SendChatMessage"), params, player);
+}

--- a/Rules/CommonScripts/ItemLimits.as
+++ b/Rules/CommonScripts/ItemLimits.as
@@ -16,7 +16,6 @@ bool blobLimitExceeded(string blobName, CBlob@ caller = null) // returns true if
 	cfg.loadFile("Rules/CommonScripts/ItemLimits.cfg");
 	s32 maximum = cfg.read_s32( itemName, 200 );
 
-	if (itemName == "tree_pine" || itemName == "tree_bushy" ) print(blobsInMap.length()+"");
 	if ( maximum > 0 )
 	{
 		for (uint b = 0; b < blobsInMap.length(); ++b)

--- a/Rules/CommonScripts/ItemLimits.cfg
+++ b/Rules/CommonScripts/ItemLimits.cfg
@@ -1,0 +1,101 @@
+#item limits list
+	
+	default					= 200
+
+	#structures
+	
+	tunnel					= 20
+	ballista              	= 20
+	warboat 				= 20
+	longboat				= 20
+	bomber					= 20
+	airship					= 20
+	dinghy					= 20
+	raft					= 20
+	catapult				= 30
+	saw						= 50
+	trampoline				= 50
+	tent					= 20
+	tdm_spawn				= 20
+	hall					= 20 # is disabled in online Sandbox
+	ctf_flag				= 20 # is disabled in online Sandbox
+	flag_base				= 20 # is disabled in online Sandbox
+	war_base				= 20 # is disabled in online Sandbox
+	
+	#animals
+	
+	fishy					= 50
+	chicken					= 50
+	bison					= 50 # is disabled in online Sandbox
+	shark					= 50 # is disabled in online Sandbox
+	
+	#others
+	
+	greg					= 20 # is disabled in online Sandbox
+	necromancer				= 20 # is disabled in online Sandbox
+	seed					= 50
+	tree_pine				= 50
+	tree_bushy				= 50
+	bush					= 50
+	flowers					= 50
+	grain_plant				= 50
+	
+	#items
+	
+	keg            			= 20
+	mine             		= 20
+	bucket					= 100
+	sponge					= 100
+	lantern					= 100
+	crate					= 100
+	boulder					= 100
+	drill					= 100
+	food					= 100
+	egg						= 100
+	
+	#unlimited - materials should rely on decay timers to disappear before they become a problem
+	
+	stone_door              = -1
+	wooden_door				= -1
+	bridge					= -1
+	ladder					= -1
+	wooden_platform			= -1
+	building				= -1
+	spikes					= -1
+	wire					= -1
+	elbow					= -1
+	tee						= -1
+	junction				= -1
+	diode					= -1
+	resistor				= -1
+	inverter				= -1
+	oscillator				= -1
+	transistor				= -1
+	toggle					= -1
+	randomizer				= -1
+	lever					= -1
+	push_button				= -1
+	coin_slot				= -1
+	pressure_plate			= -1
+	sensor					= -1
+	lamp					= -1
+	emitter					= -1
+	receiver				= -1
+	magazine				= -1
+	bolter					= -1
+	dispenser				= -1
+	obstructor				= -1
+	spike					= -1
+	mat_wood				= -1
+	mat_stone				= -1
+	mat_gold				= -1
+	mat_arrows				= -1
+	mat_waterarrows			= -1
+	mat_firearrows			= -1
+	mat_bombarrows			= -1
+	mat_bombs				= -1
+	mat_waterbombs			= -1
+	mat_bolts				= -1
+	mat_bomb_bolts			= -1
+	arrow					= -1
+	bomb					= -1

--- a/Rules/Sandbox/Scripts/Sandbox_Rules.as
+++ b/Rules/Sandbox/Scripts/Sandbox_Rules.as
@@ -7,11 +7,6 @@
 #include "RulesCore.as";
 #include "RespawnSystem.as";
 
-const int maxMines = 20;
-const int maxKegs = 20;
-int mineCount = 0;
-int kegCount = 0;
-
 //simple config function - edit the variables below to change the basics
 
 void Config(SandboxCore@ this)
@@ -38,9 +33,7 @@ void Config(SandboxCore@ this)
 	//spawn after death time
 	this.spawnTime = (getTicksASecond() * cfg.read_s32("spawn_time", 15));
 
-
 	getRules().Tag('quick decay');
-
 }
 
 //Sandbox spawn system
@@ -368,6 +361,7 @@ shared class SandboxCore : RulesCore
 
 void onInit(CRules@ this)
 {
+	this.Tag("item limits");
 	Reset(this);
 }
 
@@ -389,41 +383,4 @@ void Reset(CRules@ this)
 	this.set("core", @core);
 	this.set("start_gametime", getGameTime() + core.warmUpTime);
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as
-
-	kegCount = 0;
-	mineCount = 0;
 }
-
-void onBlobCreated(CRules@ this, CBlob@ blob)
-{
-	if (blob.getName() == "mine")
-	{
-		mineCount += 1;
-		if (mineCount > maxMines)
-		{
-			blob.server_Die(); // wont explode because its just been made
-		}
-	}
-	else if (blob.getName() == "keg")
-	{
-		kegCount += 1;
-		if (kegCount > maxKegs)
-		{
-			blob.server_Die();
-		}
-	}
-}
-
-
-void onBlobDie(CRules@ this, CBlob@ blob)
-{
-	if (blob.getName() == "mine")
-	{
-		mineCount -= 1;
-	}
-	else if (blob.getName() == "keg")
-	{
-		kegCount -= 1;
-	}
-}
-


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This is an improved version of PR #1269 . Please refer to that PR's description to get an overview of the changes. 

Instead of painstakingly keeping count of all blobs created and doing checking based on a list, 
this change will instead do counting and checking on the go, whenever a blob is about to be created 
(either from shopping or from spawning via chat command).

This reduces risk of possible errors in code, since this time around there is a lot less code and data type dictionary isn't relied on. This also has the nice side-effect that converted items are now accounted for.

New item limits added:
- greg = 20
- necromancer = 20
- ctf_flag = 20
- seed = 50
- food = 100
- egg = 100
- catapult = 30
- tree_pine = 50
- tree_bushy = 50
- grain_plant = 50
- bush = 50

This version accounts for seeds, chicken, bison, shark, fishy, greg, log, boulder, tree_pine, tree_bushy, bush getting assigned to team 255 and food to team 0 (else cooked fish looks grey). 
These will still be counted, but not per team.