### PR TITLE
Can't change class at enemy Ballista, Can't get resupplies at enemy Tent

### DIFF
--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -232,22 +232,24 @@ void onTick(CBlob@ this)
 			}
 		}
 	}
-
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	if (isOverlapping(this, caller) && !caller.isAttached())
+	if (caller.getTeamNum() == this.getTeamNum())
 	{
-		if (!Vehicle_AddFlipButton(this, caller) && caller.getTeamNum() == this.getTeamNum())
+		if (isOverlapping(this, caller) && !caller.isAttached())
 		{
-			Vehicle_AddLoadAmmoButton(this, caller);
-		}
-		if (/*!isAnotherRespawnClose(this) &&*/ !isFlipped(this))
-		{
-			caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change class"));
+			if (!Vehicle_AddFlipButton(this, caller))
+			{
+				Vehicle_AddLoadAmmoButton(this, caller);
+			}
+			if (/*!isAnotherRespawnClose(this) &&*/ !isFlipped(this))
+			{
+				caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change class"));
+			}
 		}
 	}
 }

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -238,18 +238,17 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	if (caller.getTeamNum() == this.getTeamNum())
+	if (caller.getTeamNum() == this.getTeamNum()) return;
+	
+	if (isOverlapping(this, caller) && !caller.isAttached())
 	{
-		if (isOverlapping(this, caller) && !caller.isAttached())
+		if (!Vehicle_AddFlipButton(this, caller))
 		{
-			if (!Vehicle_AddFlipButton(this, caller))
-			{
-				Vehicle_AddLoadAmmoButton(this, caller);
-			}
-			if (/*!isAnotherRespawnClose(this) &&*/ !isFlipped(this))
-			{
-				caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change class"));
-			}
+			Vehicle_AddLoadAmmoButton(this, caller);
+		}
+		if (/*!isAnotherRespawnClose(this) &&*/ !isFlipped(this))
+		{
+			caller.CreateGenericButton("$change_class$", Vec2f(0, 1), this, buildSpawnMenu, getTranslatedString("Change class"));
 		}
 	}
 }

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -238,7 +238,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	if (caller.getTeamNum() == this.getTeamNum()) return;
+	if (caller.getTeamNum() != this.getTeamNum()) return;
 	
 	if (isOverlapping(this, caller) && !caller.isAttached())
 	{

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -143,17 +143,16 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	if (caller.getTeamNum() == this.getTeamNum())
-	{
-		CBlob@ occupiedBlob = this.getAttachments().getAttachmentPointByName("MAG").getOccupied();
-		if (
-			!Vehicle_AddFlipButton(this, caller) &&
-			isOverlapping(this, caller) &&
-			!caller.isAttached() &&
-			(occupiedBlob is null || !occupiedBlob.hasTag("player"))
-		) {
-			Vehicle_AddLoadAmmoButton(this, caller);
-		}
+	if (caller.getTeamNum() != this.getTeamNum()) return;
+	
+	CBlob@ occupiedBlob = this.getAttachments().getAttachmentPointByName("MAG").getOccupied();
+	if (
+		!Vehicle_AddFlipButton(this, caller) &&
+		isOverlapping(this, caller) &&
+		!caller.isAttached() &&
+		(occupiedBlob is null || !occupiedBlob.hasTag("player"))
+	) {
+		Vehicle_AddLoadAmmoButton(this, caller);
 	}
 }
 

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -143,15 +143,17 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	CBlob@ occupiedBlob = this.getAttachments().getAttachmentPointByName("MAG").getOccupied();
-	if (
-		!Vehicle_AddFlipButton(this, caller) &&
-		this.getTeamNum() == caller.getTeamNum() &&
-		isOverlapping(this, caller) &&
-		!caller.isAttached() &&
-		(occupiedBlob is null || !occupiedBlob.hasTag("player"))
-	) {
-		Vehicle_AddLoadAmmoButton(this, caller);
+	if (caller.getTeamNum() == this.getTeamNum())
+	{
+		CBlob@ occupiedBlob = this.getAttachments().getAttachmentPointByName("MAG").getOccupied();
+		if (
+			!Vehicle_AddFlipButton(this, caller) &&
+			isOverlapping(this, caller) &&
+			!caller.isAttached() &&
+			(occupiedBlob is null || !occupiedBlob.hasTag("player"))
+		) {
+			Vehicle_AddLoadAmmoButton(this, caller);
+		}
 	}
 }
 

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -9,8 +9,6 @@ const u32 materials_wait_warmup = 40; //seconds between free mats
 //property
 const string SPAWN_ITEMS_TIMER = "CTF SpawnItems:";
 
-const string[] BASE_NAME = {"tent", "warboat", "ballista"};
-
 bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
 {
 	CInventory@ inv = blob.getInventory();
@@ -236,26 +234,10 @@ void onTick(CRules@ this)
 			
 			for (uint i = 0; i < overlapping.length; i++)
 			{
-				string overlappingName = overlapping[i].getName();
-				int overlappingTeam = overlapping[i].getTeamNum();
-				
-				bool isSameTeam = playerBlob.getTeamNum() == overlapping[i].getTeamNum();
-				bool isBase = false;
-				
-				for (uint b = 0; b < BASE_NAME.length; ++b)
-				{
-					if (BASE_NAME[b].find(overlapping[i].getName()) != -1) 
-					{ 
-						isBase = true;
-						break;
-					};
-				}
-		
-				bool isClassShop = overlappingName == "buildershop" || overlappingName == "knightshop" || overlappingName == "archershop";
-				bool isMyClass = overlappingName.find(playerBlob.getName()) != -1;
+				bool isMyBase = overlapping[i].hasTag("respawn") && playerBlob.getTeamNum() == overlapping[i].getTeamNum(); // Base of same team
+				bool isClassShop = overlapping[i].get_string("required class") == playerBlob.getName(); // Shop of same class, of any team
 
-				if ( isSameTeam  && isBase 
-					|| isClassShop && isMyClass )
+				if ( isMyBase || isClassShop )
 				{
 					doGiveSpawnMats(this, getLocalPlayer(), playerBlob, core);
 					return;

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -9,7 +9,7 @@ const u32 materials_wait_warmup = 40; //seconds between free mats
 //property
 const string SPAWN_ITEMS_TIMER = "CTF SpawnItems:";
 
-string base_name() { return "tent"; }
+const string[] base_name = {"tent", "warboat", "ballista"};
 
 bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
 {
@@ -229,24 +229,32 @@ void onTick(CRules@ this)
 	{
 
 		CBlob@[] spots;
-		getBlobsByName(base_name(), @spots);
 		getBlobsByName("buildershop", @spots);
 		getBlobsByName("knightshop", @spots);
 		getBlobsByName("archershop", @spots);
+		
+		for (uint a = 0; a < base_name.length; ++a)
+		{
+			getBlobsByName(base_name[a], @spots);
+		}
+		
 		for (uint step = 0; step < spots.length; ++step)
 		{
 			CBlob@ spot = spots[step];
 			CBlob@[] overlapping;
 			if (spot !is null && spot.getOverlapping(overlapping))
 			{
-				string name = spot.getName();
-				bool isShop = (name.find("shop") != -1);
+				string spotName = spot.getName();
+				int spotTeam = spot.getTeamNum();
+				bool isShop = (spotName.find("shop") != -1);
+
 				for (uint o_step = 0; o_step < overlapping.length; ++o_step)
 				{
 					CBlob@ overlapped = overlapping[o_step];
 					if (overlapped !is null && overlapped.hasTag("player"))
 					{
-						if (!isShop || name.find(overlapped.getName()) != -1)
+						if 	((!isShop && (overlapped.getTeamNum() == spotTeam)) // is a friendly base
+							|| spotName.find(overlapped.getName()) != -1) // or is any shop
 						{
 							CPlayer@ p = overlapped.getPlayer();
 							if (p !is null)

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -224,37 +224,42 @@ void onTick(CRules@ this)
 
 	RulesCore@ core;
 	this.get("core", @core);
+	
 	if (core !is null)
 	{
-		CBlob@[] overlapping;
 		CBlob@ playerBlob = getLocalPlayerBlob();
 		
-		playerBlob.getOverlapping(overlapping);
-		
-		for (uint i = 0; i < overlapping.length; i++)
+		if (playerBlob !is null)
 		{
-			string overlappingName = overlapping[i].getName();
+			CBlob@[] overlapping;
+			playerBlob.getOverlapping(overlapping);
 			
-			bool isSameTeam = playerBlob.getTeamNum() == overlapping[i].getTeamNum();
-			bool isBase = false;
-			
-			for (uint b = 0; b < BASE_NAME.length; ++b)
+			for (uint i = 0; i < overlapping.length; i++)
 			{
-				if (BASE_NAME[b].find(overlapping[i].getName()) != -1) 
-				{ 
-					isBase = true;
-					break;
-				};
-			}
-	
-			bool isClassShop = overlappingName == "buildershop" || overlappingName == "knightshop" || overlappingName == "archershop";
-			bool isMyClass = overlappingName.find(playerBlob.getName()) != -1;
+				string overlappingName = overlapping[i].getName();
+				int overlappingTeam = overlapping[i].getTeamNum();
+				
+				bool isSameTeam = playerBlob.getTeamNum() == overlapping[i].getTeamNum();
+				bool isBase = false;
+				
+				for (uint b = 0; b < BASE_NAME.length; ++b)
+				{
+					if (BASE_NAME[b].find(overlapping[i].getName()) != -1) 
+					{ 
+						isBase = true;
+						break;
+					};
+				}
+		
+				bool isClassShop = overlappingName == "buildershop" || overlappingName == "knightshop" || overlappingName == "archershop";
+				bool isMyClass = overlappingName.find(playerBlob.getName()) != -1;
 
-			if ( isSameTeam && isBase 
-			  || isClassShop && isMyClass )
-			{
-				doGiveSpawnMats(this, getLocalPlayer(), playerBlob, core);
-				return;
+				if ( isSameTeam  && isBase 
+					|| isClassShop && isMyClass )
+				{
+					doGiveSpawnMats(this, getLocalPlayer(), playerBlob, core);
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

- You can't change class at an enemy Ballista and in doing so gain resupplies from it, 
as was already the case with enemy Tent and enemy Warboat.
You can still change class at any TDM_Spawn and any shop regardless of Team.

- You can't flip over an enemy Ballista or enemy Catapult.
Doing so would almost always kill you from collision, so it is removed now.

- You can't get resupplies at an enemy Tent.

- You can get resupplies by overlapping with a friendly Warboat or friendly Ballista.
This is because changing class gives materials, so why not just give them automatically when overlapping.

---

Please note, you can still gain resupplies from any shop.
Because if you can buy from and change class at enemy Shops, the shop keeper is probably dumb and will also give you mats.

## Reproduction Steps

1. Be in Blue Team.
2. Go to a Red Ballista and show buttons.
3. Notice there is a "Change Class" button, using it would give you resupplies. **After this change, there is no button.**

---

1. Be in Blue Team.
2. Spawn a Ballista or Catapult and make it fall over.
3. Switch to Red Team and show buttons.
4. Notice there is a "Flip" button, using it would probably kill you. **After this change, there is no button.**

---

1. Be in Blue Team and be a builder.
2. Go to a Red Tent.
3. Notice you can't switch class at the enemy Tent but you will get resupplies. **After this change, you won't get resupplies.**

---

1. Be in Blue Team and be a builder.
2. Go to a Blue Ballista or Blue Warboat.
3. Notice nothing happening. **After this change, you will get automatic resupplies at those entities.**
