### PR TITLE
Fix fake rolling angle calculation

### DIFF
--- a/Entities/Common/Movement/CheapFakeRolling.as
+++ b/Entities/Common/Movement/CheapFakeRolling.as
@@ -23,7 +23,7 @@ void onTick(CBlob@ this)
 		CSprite@ sprite = this.getSprite();
 		if (sprite !is null)
 		{
-			angle += vel.x * this.getRadius();
+			angle += vel.x / this.getRadius() * 180 / Maths::Pi;
 			if (angle > 360.0f)
 				angle -= 360.0f;
 			else if (angle < -360.0f)

--- a/Entities/Common/Movement/CheapFakeRolling.as
+++ b/Entities/Common/Movement/CheapFakeRolling.as
@@ -1,6 +1,8 @@
 //cheaper analogy to FakeRolling.as
 // - use when you just need the sprite to turn and there's only one sprite layer
 
+const float MAX_ROTATION_SPEED = 60.0f;
+
 void onInit(CBlob@ this)
 {
 	f32 angle = (this.getNetworkID() * 977) % 360;
@@ -23,7 +25,7 @@ void onTick(CBlob@ this)
 		CSprite@ sprite = this.getSprite();
 		if (sprite !is null)
 		{
-			angle += vel.x / this.getRadius() * 180 / Maths::Pi;
+			angle += Maths::Clamp(vel.x / this.getRadius() * 180.0f / Maths::Pi, -MAX_ROTATION_SPEED, MAX_ROTATION_SPEED);
 			if (angle > 360.0f)
 				angle -= 360.0f;
 			else if (angle < -360.0f)

--- a/Entities/Common/Movement/FakeRolling.as
+++ b/Entities/Common/Movement/FakeRolling.as
@@ -17,7 +17,7 @@ void onTick(CBlob@ this)
 	Vec2f vel = this.getVelocity();
 	if (getNet().isServer() && Maths::Abs(vel.x) > 0.1)
 	{
-		angle += vel.x * this.getRadius();
+		angle += vel.x / this.getRadius() * 180 / Maths::Pi;
 		if (angle > 360.0f)
 			angle -= 360.0f;
 		else if (angle < -360.0f)

--- a/Entities/Common/Movement/FakeRolling.as
+++ b/Entities/Common/Movement/FakeRolling.as
@@ -1,3 +1,5 @@
+const float MAX_ROTATION_SPEED = 60.0f;
+
 void onInit(CBlob@ this)
 {
 	f32 angle = (this.getNetworkID() * 977) % 360;
@@ -17,7 +19,7 @@ void onTick(CBlob@ this)
 	Vec2f vel = this.getVelocity();
 	if (getNet().isServer() && Maths::Abs(vel.x) > 0.1)
 	{
-		angle += vel.x / this.getRadius() * 180 / Maths::Pi;
+		angle += Maths::Clamp(vel.x / this.getRadius() * 180.0f / Maths::Pi, -MAX_ROTATION_SPEED, MAX_ROTATION_SPEED);
 		if (angle > 360.0f)
 			angle -= 360.0f;
 		else if (angle < -360.0f)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The existing way of calculating the angle to rotate the blob was completely wrong and increases rotation speed the larger the blob's radius is. The new equation corrects this by calculating the angle from the arc length of the circle defined by the blob's radius. Since the blob is rolling, the arc length is equal to the distance travelled.

Since bombs and mines relied on the existing faulty rotation calculation, I had to clamp the rotation speed to avoid blobs spinning way too fast. This can be thought of as the blob losing traction to the ground or it experiencing air resistance.

## Steps to Test or Reproduce

1. Spawn boulders, bombs and mines
2. Toss them around

This same equation was also used in my 3D mod and worked perfectly.

## Videos

https://user-images.githubusercontent.com/30195802/170987852-70820232-0683-46e6-88d0-8ddd87b91e62.mp4

https://user-images.githubusercontent.com/30195802/170987863-1a4688ce-1507-4b80-9c9e-d70ebba16d37.mp4