### PR TITLE
Gold will decay over time (only in modes other than Challenge, CTF, TTH)

### DIFF
--- a/Entities/Common/Decaying/DecayQuantity.as
+++ b/Entities/Common/Decaying/DecayQuantity.as
@@ -1,7 +1,7 @@
 
 #define SERVER_ONLY;
 
-// Use `.set_u8('decay step', ..)` to
+// Use `.set_u8("decay step", ..)` to
 // define the quantity that should be
 // discarded each step
 
@@ -15,14 +15,14 @@ void onInit(CBlob@ this)
 	script.runFlags |= Script::tick_not_attached;
 	script.runFlags |= Script::tick_not_ininventory;
 
-	this.getCurrentScript().tickFrequency = (getRules().hasTag('quick decay') ? QUICK_FREQUENCY : FREQUENCY);
+	this.getCurrentScript().tickFrequency = (getRules().hasTag("quick decay") ? QUICK_FREQUENCY : FREQUENCY);
 }
 
 void onTick(CBlob@ this)
 {
-	if (this.getTickSinceCreated() < (getRules().hasTag('quick decay') ? QUICK_FREQUENCY : FREQUENCY)) return;
+	if (this.getTickSinceCreated() < (getRules().hasTag("quick decay") ? QUICK_FREQUENCY : FREQUENCY)) return;
 
-	uint8 step = this.get_u8('decay step');
+	uint8 step = this.get_u8("decay step");
 	uint16 quantity = this.getQuantity();
 
 	if (step >= quantity)
@@ -44,10 +44,10 @@ void onTick(CBlob@ this)
 
 void onAttach(CBlob@ this, CBlob@ blob, AttachmentPoint@ point)
 {
-	this.getCurrentScript().tickFrequency = (getRules().hasTag('quick decay') ? QUICK_FREQUENCY : FREQUENCY);
+	this.getCurrentScript().tickFrequency = (getRules().hasTag("quick decay") ? QUICK_FREQUENCY : FREQUENCY);
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ blob)
 {
-	this.getCurrentScript().tickFrequency = (getRules().hasTag('quick decay') ? QUICK_FREQUENCY : FREQUENCY);
+	this.getCurrentScript().tickFrequency = (getRules().hasTag("quick decay") ? QUICK_FREQUENCY : FREQUENCY);
 }

--- a/Entities/Common/Decaying/DecayUnused.as
+++ b/Entities/Common/Decaying/DecayUnused.as
@@ -1,23 +1,23 @@
 
 #define SERVER_ONLY;
 
-// Use `.set_u8('decay time', ..)` to
+// Use `.set_u8("decay time", ..)` to
 // define how long it takes for the
 // material to disappear when unused
 
 void onInit(CBlob@ this)
 {
-  this.server_SetTimeToDie(this.get_u16('decay time'));
+  this.server_SetTimeToDie(this.get_u16("decay time"));
 }
 
 void onDetach(CBlob@ this, CBlob@ blob, AttachmentPoint@ point)
 {
-  this.server_SetTimeToDie(this.get_u16('decay time'));
+  this.server_SetTimeToDie(this.get_u16("decay time"));
 }
 
 void onThisRemoveFromInventory(CBlob@ this, CBlob@ blob)
 {
-  this.server_SetTimeToDie(this.get_u16('decay time'));
+  this.server_SetTimeToDie(this.get_u16("decay time"));
 }
 
 void onAttach(CBlob@ this, CBlob@ blob, AttachmentPoint@ point)

--- a/Entities/Materials/Ammunition/MaterialArrow.as
+++ b/Entities/Materials/Ammunition/MaterialArrow.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u16('decay time', 45);
+    this.set_u16("decay time", 45);
   }
 
   this.maxQuantity = 30;

--- a/Entities/Materials/Ammunition/MaterialBallistaBolt.as
+++ b/Entities/Materials/Ammunition/MaterialBallistaBolt.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u8('decay step', 2);
+    this.set_u8("decay step", 2);
   }
 
   this.maxQuantity = 12;

--- a/Entities/Materials/Ammunition/MaterialBallistaBombBolt.as
+++ b/Entities/Materials/Ammunition/MaterialBallistaBombBolt.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u8('decay step', 2);
+    this.set_u8("decay step", 2);
   }
 
   this.maxQuantity = 6;

--- a/Entities/Materials/Ammunition/MaterialBombArrow.as
+++ b/Entities/Materials/Ammunition/MaterialBombArrow.as
@@ -3,7 +3,7 @@
 
 void onInit(CBlob@ this)
 {
-  this.set_u16('decay time', 300);
+  this.set_u16("decay time", 300);
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Materials/Ammunition/MaterialFireArrow.as
+++ b/Entities/Materials/Ammunition/MaterialFireArrow.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u16('decay time', 180);
+    this.set_u16("decay time", 180);
   }
 
   this.maxQuantity = 2;

--- a/Entities/Materials/Ammunition/MaterialWaterArrow.as
+++ b/Entities/Materials/Ammunition/MaterialWaterArrow.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u16('decay time', 180);
+    this.set_u16("decay time", 180);
   }
 
   this.maxQuantity = 2;

--- a/Entities/Materials/Construction/MaterialGold.as
+++ b/Entities/Materials/Construction/MaterialGold.as
@@ -1,9 +1,9 @@
 
 void onInit(CBlob@ this)
 {
-  if (getNet().isServer())
+  if (isServer())
   {
-	this.set_u8('decay step', 10);
+	this.set_u8("decay step", 10);
   }
   
   this.maxQuantity = 50;

--- a/Entities/Materials/Construction/MaterialGold.as
+++ b/Entities/Materials/Construction/MaterialGold.as
@@ -1,6 +1,11 @@
 
 void onInit(CBlob@ this)
 {
+  if (getNet().isServer())
+  {
+	this.set_u8('decay step', 10);
+  }
+  
   this.maxQuantity = 50;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;

--- a/Entities/Materials/Construction/MaterialStone.as
+++ b/Entities/Materials/Construction/MaterialStone.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u8('decay step', 14);
+    this.set_u8("decay step", 14);
   }
 
   this.maxQuantity = 250;

--- a/Entities/Materials/Construction/MaterialWood.as
+++ b/Entities/Materials/Construction/MaterialWood.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
   if (getNet().isServer())
   {
-    this.set_u8('decay step', 36);
+    this.set_u8("decay step", 36);
   }
 
   this.maxQuantity = 250;

--- a/Entities/Materials/Explosive/MaterialBomb.as
+++ b/Entities/Materials/Explosive/MaterialBomb.as
@@ -3,7 +3,7 @@
 
 void onInit(CBlob@ this)
 {
-  this.set_u16('decay time', 300);
+  this.set_u16("decay time", 300);
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Entities/Materials/Explosive/MaterialWaterBomb.as
+++ b/Entities/Materials/Explosive/MaterialWaterBomb.as
@@ -3,7 +3,7 @@
 
 void onInit(CBlob@ this)
 {
-  this.set_u16('decay time', 240);
+  this.set_u16("decay time", 240);
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -716,6 +716,6 @@ void onBlobCreated(CRules@ this, CBlob@ blob)
 {
 	if (blob.getName() == "mat_gold")
 	{
-		blob.RemoveScript("DecayQuantity");
+		blob.RemoveScript("DecayQuantity.as");
 	}
 }

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -711,3 +711,11 @@ void onBlobDie(CRules@ this, CBlob@ blob)
 		}
 	}
 }
+
+void onBlobCreated(CRules@ this, CBlob@ blob)
+{
+	if (blob.getName() == "mat_gold")
+	{
+		blob.RemoveScript("DecayQuantity");
+	}
+}

--- a/Rules/Challenge/Scripts/Challenge.as
+++ b/Rules/Challenge/Scripts/Challenge.as
@@ -1009,24 +1009,24 @@ void onBlobCreated(CRules@ this, CBlob@ blob)
 	}
 	else if (name == "hall")
 	{
-		blob.RemoveScript("TunnelTravel");
-		blob.RemoveScript("PickupIntoStorage");
-		blob.RemoveScript("Researching");
+		blob.RemoveScript("TunnelTravel.as");
+		blob.RemoveScript("PickupIntoStorage.as");
+		blob.RemoveScript("Researching.as");
 		blob.Untag("change class store inventory");
 		blob.Tag("change class drop inventory");
 		blob.Tag("script added"); // so it wont add Researching.as on change team
 	}
 	else if (name == "catapult")
 	{
-		blob.RemoveScript("DecayInWater");
-		blob.RemoveScript("DecayIfLowHealth");
-		blob.RemoveScript("DecayIfFlipped");
-		blob.RemoveScript("DecayIfLeftAlone");
+		blob.RemoveScript("DecayInWater.as");
+		blob.RemoveScript("DecayIfLowHealth.as");
+		blob.RemoveScript("DecayIfFlipped.as");
+		blob.RemoveScript("DecayIfLeftAlone.as");
 	}
 
 	if (blob.hasTag("material"))
 	{
-		blob.RemoveScript("DecayQuantity");
+		blob.RemoveScript("DecayQuantity.as");
 	}
 }
 

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -202,7 +202,7 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 				server_CreateBlob('chicken', -1, pos);
 			}
 		}
-		else if (text_in == "!allmats") // 500 wood, 500 stone, 100 gold
+		else if (text_in == "!allmats") // 500 wood, 500 stone, 50 gold
 		{
 			//wood
 			CBlob@ wood = server_CreateBlob('mat_wood', -1, pos);
@@ -212,7 +212,6 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 			stone.server_SetQuantity(500);
 			//gold
 			CBlob@ gold = server_CreateBlob('mat_gold', -1, pos);
-			gold.server_SetQuantity(100);
 		}
 		else if (text_in == "!woodstone") // 250 wood, 500 stone
 		{
@@ -242,10 +241,7 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 		}
 		else if (text_in == "!gold") // 200 gold
 		{
-			for (int i = 0; i < 4; i++)
-			{
-				server_CreateBlob('mat_gold', -1, pos);
-			}
+			server_CreateBlob('mat_gold', -1, pos);
 		}
 		// removed/commented out since this can easily be abused...
 		/*else if (text_in == "!sharkpit") // spawns 5 sharks, perfect for making shark pits

--- a/Rules/CommonScripts/ChatCommands.as
+++ b/Rules/CommonScripts/ChatCommands.as
@@ -211,7 +211,7 @@ bool onServerProcessChat(CRules@ this, const string& in text_in, string& out tex
 			CBlob@ stone = server_CreateBlob('mat_stone', -1, pos);
 			stone.server_SetQuantity(500);
 			//gold
-			CBlob@ gold = server_CreateBlob('mat_gold', -1, pos);
+			server_CreateBlob('mat_gold', -1, pos);
 		}
 		else if (text_in == "!woodstone") // 250 wood, 500 stone
 		{

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -1050,6 +1050,10 @@ void onBlobCreated(CRules@ this, CBlob@ blob)
 	{
 		MakeWarTradeMenu(blob);
 	}
+	else if (blob.getName() == "mat_gold")
+	{
+		blob.RemoveScript("DecayQuantity");
+	}
 }
 
 TradeItem@ addGoldForItem(CBlob@ this, const string &in name,

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -1052,7 +1052,7 @@ void onBlobCreated(CRules@ this, CBlob@ blob)
 	}
 	else if (blob.getName() == "mat_gold")
 	{
-		blob.RemoveScript("DecayQuantity");
+		blob.RemoveScript("DecayQuantity.as");
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes issue #598.

Gold which is spawned into Sandbox would never despawn, since Gold doesn't have a 'decay step' set like the other materials do. Therefore, spamming !gold in Sandbox servers would be a griefing method, since nothing could be done to despawn the Gold.

This change adds a 'decay step' to Gold and DecayQuantity.as to its script section, so it will eventually decay over time.

Similar to Challenge.as, CTF.as and WAR.as will remove DecayQuantity for any gold blobs created so it won't decay in those game modes.

Although ChatCommands.as is getting refactored, I did change the existing ChatCommands.as just to be sure.  
`!gold` will spawn 50 gold instead of 200 and `!allmats` will spawn 500 wood, 500 stone, 50 gold instead of 500 wood, 500 stone, 100 gold. This was done to reduce gold spam and to make decaying gold look less weird (it reduces, then merges, then reduces, etc.)

## Steps to Test or Reproduce

1. Go to Sandbox.
2. !gold !gold !gold
3. Notice the Gold will disappear.