### PR TITLE
[Fixed] Fire Arrows ricocheting off structure blobs

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -539,7 +539,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 		//stick into "map" blobs
 		if (hitBlob.getShape().isStatic())
 		{
-			ArrowHitMap(this, worldPoint, velocity, damage, Hitters::arrow, hitBlob);
+			ArrowHitMap(this, worldPoint, velocity, damage, Hitters::arrow);
 		}
 		//die otherwise
 		else

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -515,7 +515,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 		{
 			damage = 0.0f;
 		}
-
+		
 		if (arrowType == ArrowType::fire)
 		{
 			if (hitBlob.getName() == "keg" && !hitBlob.hasTag("exploding"))
@@ -535,24 +535,22 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 				this.set_Vec2f("override fire pos", hitBlob.getPosition());
 			}
 		}
+		
+		//stick into "map" blobs
+		if (hitBlob.getShape().isStatic())
+		{
+			ArrowHitMap(this, worldPoint, velocity, damage, Hitters::arrow, hitBlob);
+		}
+		//die otherwise
 		else
 		{
-			//stick into "map" blobs
-			if (hitBlob.getShape().isStatic())
+			//add arrow layer
+			CSprite@ sprite = hitBlob.getSprite();
+			if (sprite !is null && !hitShield && arrowType != ArrowType::bomb && isClient() && !v_fastrender)
 			{
-				ArrowHitMap(this, worldPoint, velocity, damage, Hitters::arrow);
+				AddArrowLayer(this, hitBlob, sprite, worldPoint, velocity);
 			}
-			//die otherwise
-			else
-			{
-				//add arrow layer
-				CSprite@ sprite = hitBlob.getSprite();
-				if (sprite !is null && !hitShield && arrowType != ArrowType::bomb && isClient() && !v_fastrender)
-				{
-					AddArrowLayer(this, hitBlob, sprite, worldPoint, velocity);
-				}
-				this.server_Die();
-			}
+			this.server_Die();
 		}
 	}
 

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -515,7 +515,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 		{
 			damage = 0.0f;
 		}
-		
+
 		if (arrowType == ArrowType::fire)
 		{
 			if (hitBlob.getName() == "keg" && !hitBlob.hasTag("exploding"))


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fire Arrow had this behavior:
- If shot against friendly door or any component structure blob: Bounces off but sets it on fire after a while anyway.
- If shot against enemy door, any team bridge, platform: Sets it on fire and disappears immediately.

This PR changes the behavior to this:
- If shot against any structure blob regardless what team: Sets it on fire and sticks.

## Steps to Test or Reproduce

1. Build a friendly door or a wall made of Magazines. Shoot at it with a fire arrow. It will bounce off. **After this change it sticks.**
2. Build an enemy door, any team bridge or a platform. Shoot at it with a fire arrow. It will set it on fire and disappear. **After this change it keeps sticking.**
