### PR TITLE
[fixed] that the "Following Player" text was overlapping with the Timer

### DIFF
--- a/Rules/CommonScripts/TimeToEnd.as
+++ b/Rules/CommonScripts/TimeToEnd.as
@@ -79,6 +79,6 @@ void onRender(CRules@ this)
 		drawRulesFont(getTranslatedString("Time left: {MIN}:{SEC}")
 						.replace("{MIN}", "" + ((MinutesToEnd < 10) ? "0" + MinutesToEnd : "" + MinutesToEnd))
 						.replace("{SEC}", "" + ((secondsToEnd < 10) ? "0" + secondsToEnd : "" + secondsToEnd)),
-		              SColor(255, 255, 255, 255), Vec2f(10, 140), Vec2f(getScreenWidth() - 20, 180), true, false);
+		              SColor(255, 255, 255, 255), Vec2f(10, 128), Vec2f(getScreenWidth() - 20, 180), true, false);
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

I put the Timer slightly higher so the "Following player" text doesn't overlap with it.

https://i.imgur.com/rcC6Grg.png - Before
https://i.imgur.com/ja6laxT.png - After

## Steps to Test or Reproduce

For testing, you can add TDM.as to and remove WAR-related scripts from WAR/gamemode.cfg, then go to offline TTH tutorial. Use !bot, !team 1, !bot, then switch to Spectator.
