### PR TITLE
Placing a block will destroy scenery in the whole block instead of only in the top left of the block

### DIFF
--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -31,9 +31,10 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 
 	if (validTile && hasReqs && passesChecks)
 	{
-		DestroyScenary(cursorPos, Vec2f(cursorPos.x+8, cursorPos.y+8));
+		CMap@ map = getMap();
+		DestroyScenary(cursorPos, Vec2f(cursorPos.x+map.tilesize, cursorPos.y+map.tilesize));
 		server_TakeRequirements(inv, bc.reqs);
-		getMap().server_SetTile(cursorPos, bc.tile);
+		map.server_SetTile(cursorPos, bc.tile);
 
 		u32 delay = this.get_u32("build delay");
 		SetBuildDelay(this, delay / 2); // Set a smaller delay to compensate for lag/late packets etc

--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -31,7 +31,7 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 
 	if (validTile && hasReqs && passesChecks)
 	{
-		DestroyScenary(cursorPos, cursorPos);
+		DestroyScenary(cursorPos, Vec2f(cursorPos.x+8, cursorPos.y+8));
 		server_TakeRequirements(inv, bc.reqs);
 		getMap().server_SetTile(cursorPos, bc.tile);
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
A B C
D E F
G H I
```

Assume there is a Bush placed in the tile at E.
I noticed the bush only gets destroyed if a block is placed in E, F, H, I.
So it gets destroyed when placing a block to its right, but it stays alive when placing a block to its left.
I looked into it.

If a building is built, `DestroyScenary(tl, br);` in BuilderCommon.as is executed. 
tl is actually the top-left of the building.
br is actually the bottom-right of the building.
Everything is fine here.

If a block is placed, `DestroyScenary(cursorPos, cursorPos)` in BlockPlacement.as is executed.
cursorPos is equivalent to the tl of the block. 
So scenery will only be destroyed in that section.
This is not consistent with the behavior in BuilderCommon.as.

This PR fixes that so that the whole block is considered, to make it consistent with the behavior in BuilderCommon.as.

A [bug](https://github.com/transhumandesign/kag-base/issues/1284) in `getBlobsInBox()` (which is used in `DestroyScenary()`) makes it so a Bush will still be destroyed if the tl of a placed block is within the sprite_frame of the bush, regardless of its radius.

After this PR, assuming `getBlobsInBox()` stays the way it is, a bush will be destroyed when placing a block in any of the 9 tiles A, B, C, D, E, F, G, H, I, making it consistent.
There is no such thing as "it is destroyed when placing it to its right, but not destroyed when placing it to its left".

## Steps to Test or Reproduce

Go to Sandbox and place a wood block or stone block inside it or in the 8 tiles surrounding it. 
