### PR TITLE
[Added] Shooting at Foods will stick them to the Arrow's tip

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -177,8 +177,7 @@ void onTick(CBlob@ this)
 				{	
 					AttachmentPoint@ tip = this.getAttachments().getAttachmentPointByName("TIP");
 					
-					if (tip !is null 								// attachment point exists
-						&& tip.getOccupied() is null)				// no blob in the attachment point yet
+					if (tip !is null && tip.getOccupied() is null)				// no blob in the attachment point yet
 					{
 						this.server_AttachTo(overlapping[i], "TIP");
 						overlapping[i].getSprite().SetRelativeZ(500.0f);			

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -388,7 +388,7 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 	if (!check)
 	{
 		CShape@ shape = blob.getShape();
-		check = (shape.isStatic()  && !shape.getConsts().platform);
+		check = (shape.isStatic() && !shape.getConsts().platform);
 	}
 
 	if (check)

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -14,11 +14,12 @@ const f32 arrowFastSpeed = 13.0f;
 //maximum is 15 as of 22/11/12 (see ArcherCommon.as)
 
 const f32 ARROW_PUSH_FORCE = 6.0f;
-const f32 SPECIAL_HIT_SCALE = 1.0f; //special hit on food items to shoot to team-mates
 
 const s32 FIRE_IGNITE_TIME = 5;
 
 const u32 STUCK_ARROW_DECAY_SECS = 30;
+
+const string[] attachableBlobs = {"food", "grain", "bread", "steak", "cooked_steak", "cooked_fish", "heart", "sponge"};
 
 //Arrow logic
 
@@ -161,6 +162,34 @@ void onTick(CBlob@ this)
 		{
 			turnOnFire(this);
 		}
+		
+		// attach certain blobs with the tip of the arrow	
+		if (!this.hasAttached() 												// arrow doesn't have anything attached yet
+			&& (arrowType == ArrowType::normal || arrowType == ArrowType::fire)	// only normal and fire type
+			&& this.getShape().vellen > 10)										// only if enough velocity
+		{
+			CBlob@[] overlapping;
+			getMap().getBlobsInRadius(this.getPosition(), 7.0f, @overlapping);
+		
+			for (uint i = 0; i < overlapping.length; i++)
+			{
+				if (attachableBlobs.find(overlapping[i].getName()) != -1)
+				{	
+					AttachmentPoint@ tip = this.getAttachments().getAttachmentPointByName("TIP");
+					
+					if (tip !is null 								// attachment point exists
+						&& tip.getOccupied() is null 				// no blob in the attachment point yet
+						&& !overlapping[i].hasTag("arrow tipped")) 	// don't attach blob that is already tipped
+					{
+						this.server_AttachTo(overlapping[i], "TIP");
+						overlapping[i].getSprite().SetRelativeZ(500.0f);			
+						overlapping[i].Tag("arrow tipped");
+						this.set_netid("tipped blob", overlapping[i].getNetworkID());
+						break;
+					}		
+				}		
+			}
+		}
 	}
 
 	// sticking
@@ -185,6 +214,27 @@ void onTick(CBlob@ this)
 		this.setVelocity(Vec2f(0, 0));
 		this.setPosition(this.get_Vec2f("lock"));
 		shape.SetStatic(true);
+		
+		// detach blob from tip and make it static, so it isn't inside walls and can be picked up
+		if (this.hasAttached())
+		{
+			AttachmentPoint@ tip = this.getAttachments().getAttachmentPointByName("TIP");
+					
+			if (tip !is null && tip.getOccupied() !is null)
+			{
+				tip.getOccupied().getShape().SetStatic(true);
+				this.server_DetachAll();
+			}
+		}
+		else if (this.exists("tipped blob")) // untag "arrow tipped" if the tipped blob is picked up
+		{
+			CBlob@ tipped = getBlobByNetworkID(this.get_netid("tipped blob"));
+					
+			if (tipped !is null && tipped.isAttachedTo(getLocalPlayerBlob()))
+			{
+				tipped.Untag("arrow tipped");
+			}
+		}
 	}
 
 	// fire arrow
@@ -217,7 +267,9 @@ void onTick(CBlob@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
-	if (blob !is null && doesCollideWithBlob(this, blob) && !this.hasTag("collided"))
+	if (blob is null || this.hasTag("collided")) return;
+
+	if (doesCollideWithBlob(this, blob) && !blob.isAttachedTo(this))
 	{
 		const u8 arrowType = this.get_u8("arrow type");
 
@@ -234,7 +286,6 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 
 		if (
 			!solid && !blob.hasTag("flesh") &&
-			!specialArrowHit(blob) &&
 			(blob.getName() != "mounted_bow" || this.getTeamNum() != blob.getTeamNum())
 		) {
 			return;
@@ -327,19 +378,13 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 		return true;
 	}
 
-	//anything to always hit
-	if (specialArrowHit(blob))
-	{
-		return true;
-	}
-
 	//definitely collide with non-team blobs
 	bool check = this.getTeamNum() != blob.getTeamNum() || blob.getName() == "bridge";
 	//maybe collide with team structures
 	if (!check)
 	{
 		CShape@ shape = blob.getShape();
-		check = (shape.isStatic() && !shape.getConsts().platform);
+		check = (shape.isStatic() && !blob.hasTag("arrow tipped") && !shape.getConsts().platform);
 	}
 
 	if (check)
@@ -362,13 +407,6 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 	}
 
 	return false;
-}
-
-bool specialArrowHit(CBlob@ blob)
-{
-	string bname = blob.getName();
-	return (bname == "fishy" && blob.hasTag("dead") || bname == "food"
-		|| bname == "steak" || bname == "grain"/* || bname == "heart"*/); //no egg because logic
 }
 
 void Pierce(CBlob @this, CBlob@ blob = null)
@@ -465,22 +503,6 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 	{
 		Pierce(this, hitBlob);
 		if (this.hasTag("collided")) return 0.0f;
-
-		// check if invincible + special -> add force here
-		if (specialArrowHit(hitBlob))
-		{
-			const f32 scale = SPECIAL_HIT_SCALE;
-			f32 force = (ARROW_PUSH_FORCE * 0.125f) * Maths::Sqrt(hitBlob.getMass() + 1) * scale;
-			if (this.hasTag("bow arrow"))
-			{
-				force *= 1.3f;
-			}
-
-			hitBlob.AddForce(velocity * force);
-
-			//die
-			this.server_Hit(this, this.getPosition(), Vec2f(), 1.0f, Hitters::crush);
-		}
 
 		// check if shielded
 		const bool hitShield = (hitBlob.hasTag("shielded") && blockAttack(hitBlob, velocity, 0.0f));
@@ -723,7 +745,7 @@ bool isFlammableAt(Vec2f worldPos)
 Random _gib_r(0xa7c3a);
 void onDie(CBlob@ this)
 {
-	if (getNet().isClient())
+	if (isClient())
 	{
 		Vec2f pos = this.getPosition();
 		if (pos.x >= 1 && pos.y >= 1)
@@ -748,6 +770,18 @@ void onDie(CBlob@ this)
 	if (arrowType == ArrowType::water)
 	{
 		SplashArrow(this);
+	}
+	
+	// revert things done to the tipped blob
+	if (this.exists("tipped blob"))
+	{
+		CBlob@ tipped = getBlobByNetworkID(this.get_netid("tipped blob"));
+				
+		if (tipped !is null)
+		{
+			tipped.Untag("arrow tipped");
+			tipped.getShape().SetStatic(false);
+		}
 	}
 }
 
@@ -818,10 +852,10 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 	{
 		// affect players velocity
 
-		const f32 scale = specialArrowHit(hitBlob) ? SPECIAL_HIT_SCALE : 1.0f;
-
+		const f32 scale = 1.0f;
 		Vec2f vel = velocity;
 		const f32 speed = vel.Normalize();
+		
 		if (speed > ArcherParams::shoot_max_vel * 0.5f)
 		{
 			f32 force = (ARROW_PUSH_FORCE * 0.125f) * Maths::Sqrt(hitBlob.getMass() + 1) * scale;
@@ -845,7 +879,6 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 		}
 	}
 }
-
 
 f32 getArrowDamage(CBlob@ this, f32 vellen = -1.0f)
 {

--- a/Entities/Items/Projectiles/Arrow.cfg
+++ b/Entities/Items/Projectiles/Arrow.cfg
@@ -54,7 +54,12 @@ bool block_snaptogrid          = no
 
 $movement_factory              = 
 $brain_factory                 =
-$attachment_factory            =
+
+$attachment_factory 			= box2d_attachment	 
+@$attachment_scripts			= 
+# name; pixel offset (from center) X; offset Y; socket/plug 0/1; controller; radius
+@$attachment_points				=  TIP; 0; 0; 0; 1; 7;
+
 $inventory_factory             = 
 
 # general


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

As far as my judgement goes, this is good to go and ready, but please do test and verify this yourselves.
Please consider the "Things to Add" section below.

## Description

Added a "TIP" attachment point to Arrow that attachable blobs can get attached to.
Removed the previous "specialArrowHit" logic that added velocity if an attachable blob was shot at.
I hope this makes the "shooting foods to teammates" mechanic more reliable, fun and increase depth.

Attachable blobs are:
- food
- grain
- bread
- steak
- cooked_steak
- cooked_fish
- heart (this was commented out before. I included it here because why not.)
- sponge (small enough and makes sense)

A check is added in onTick() that is performed for flying arrows.
If the flying arrow is normal-type or fire-type, velocity is sufficient, and an attachable blob is near,
then that blob will get attached to the arrow.

After the arrow collides, the tipped blob will get detached and set to `SetStatic(true)`, so it can be picked up while staying sticked to the wall. The tipped blob will get set to `collidable = false` to avoid unwanted collision with other blobs.

When the arrow dies, the tipped blob will get set to `SetStatic(false)` and the collidable state will be reverted to what it was before, so it can fall down and have collisions as usual. When the player picks up the tipped blob, the collidable state will also be reverted.

As far as I tested, medium-charged arrow will have enough velocity to pass the check and attach an attachable blob to itself. Having foods bounce on a trampoline and spamming arrows on that trampoline, the arrows will not gain enough velocity to pass the check.

## Steps to Test or Reproduce

Shoot at burgers, hearts and sponges.
Notice they will get attached to your arrows.

## Things to Add

Foods that are attached to a flying arrow should heal teammates.
The coin reward for throwing a healing item to a teammate should be applied here.
I can add a "detach when overlapping with teamplayer" logic, but maybe there is a better way, to avoid accidentally healing the enemy that is overlapping with the teamplayer.