### PR TITLE
Lantern overlay on Storage will be synced with Lanterns inside Storage

### DIFF
--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -1,5 +1,7 @@
 // Lantern script
 
+#include "LanternCommon.as";
+
 void onInit(CBlob@ this)
 {
 	this.SetLight(true);
@@ -25,21 +27,6 @@ void onTick(CBlob@ this)
 	{
 		Light(this, false);
 	}
-}
-
-void Light(CBlob@ this, bool on)
-{
-	if (!on)
-	{
-		this.SetLight(false);
-		this.getSprite().SetAnimation("nofire");
-	}
-	else
-	{
-		this.SetLight(true);
-		this.getSprite().SetAnimation("fire");
-	}
-	this.getSprite().PlaySound("SparkleShort.ogg");
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)

--- a/Entities/Items/Lantern/LanternCommon.as
+++ b/Entities/Items/Lantern/LanternCommon.as
@@ -1,0 +1,14 @@
+void Light(CBlob@ this, bool on)
+{
+	if (!on)
+	{
+		this.SetLight(false);
+		this.getSprite().SetAnimation("nofire");
+	}
+	else
+	{
+		this.SetLight(true);
+		this.getSprite().SetAnimation("fire");
+	}
+	this.getSprite().PlaySound("SparkleShort.ogg");
+}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This fixes issue #1245.

When a lantern is added to or removed from a Storage and `updateLayers()` is executed, it will check all lanterns in the Storage. If at least one lantern is turned on, the overlay lantern will be turned on, too.
If no lantern is turned on, the overlay lantern will be turned off.

When the overlay lantern is turned off, it can mean one of two things:

Either 1) only turned-off lanterns have been added to the Storage.

Or 2) the overlay lantern has been flooded by water. 

A code in `onTick()` will go through all lanterns inside the Storage and each one that is turned on will be turned off. This is not a problem, since logically all lanterns inside should be turned-off anyway - see 1).
TickFrequency is kept at 60 like before so it is not expensive. (It doesn't lag even if tickFrequency is 1 and running the same code inside a `for (uint a = 0; a < 200000; a++)` loop. So it may be worth considering increasing the tickFrequency.)

## Steps to Test or Reproduce

Go to Sandbox.
Spawn a Lantern. Turn it off and put it in a Storage.
Notice the overlay will not turn on.

Put a turned-on Lantern inside.
Notice the overlay will be turned on and stay that way until the turned-on Lantern is withdrawn.

Put some turned-on Lanterns inside.
Spawn water so the overlay turns off.
When withdrawing all lanterns, notice they will all be turned off.
