### PR TITLE
[Fixed] Pick-Up Wheel not updating & "Picking up Flowers" bug

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -217,9 +217,7 @@ void onTick(CBlob@ this)
 						@closest = @GetBetterAlternativePickupBlobs(blobsInRadius, closest);
 						server_Pickup(this, this, closest);
 					}
-
 				}
-
 			}
 
 			return;
@@ -583,6 +581,8 @@ CBlob@ getClosestBlob(CBlob@ this)
 
 bool canBlobBePickedUp(CBlob@ this, CBlob@ blob)
 {
+	if (!blob.canBePickedUp(this)) return false;
+
 	float maxDist = Maths::Max(this.getRadius() + blob.getRadius() + 20.0f, 36.0f);
 
 	Vec2f pos = this.getPosition() + Vec2f(0.0f, -this.getRadius() * 0.9f);

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -64,8 +64,7 @@ void onInit(CBlob@ this)
 			PickupWheelOption("fishy"),
 			PickupWheelOption("grain"),
 			PickupWheelOption("steak"),
-			PickupWheelOption("egg"),
-			PickupWheelOption("flowers")
+			PickupWheelOption("egg")
 		};
 		menu.add_entry(PickupWheelMenuEntry("Food", "$food$", food_options));
 		menu.add_entry(PickupWheelMenuEntry("Ballista Ammo", "$mat_bolts$", "mat_bolts"));
@@ -94,44 +93,38 @@ void onTick(CBlob@ this)
 		{
 			set_active_wheel_menu(@menu);
 		}
+		
+		GatherPickupBlobs(this);
 
-		if (this.isKeyPressed(key_pickup))
+		CBlob@[]@ pickupBlobs;
+		this.get("pickup blobs", @pickupBlobs);
+
+		CBlob@[] available;
+		FillAvailable(this, available, pickupBlobs);
+
+		for (uint i = 0; i < menu.entries.length; i++)
 		{
-			GatherPickupBlobs(this);
+			PickupWheelMenuEntry@ entry = cast<PickupWheelMenuEntry>(menu.entries[i]);
+			entry.disabled = true;
 
-			CBlob@[]@ pickupBlobs;
-			this.get("pickup blobs", @pickupBlobs);
-
-			CBlob@[] available;
-			FillAvailable(this, available, pickupBlobs);
-
-			for (uint i = 0; i < menu.entries.length; i++)
+			for (uint j = 0; j < available.length; j++)
 			{
-				PickupWheelMenuEntry@ entry = cast<PickupWheelMenuEntry>(menu.entries[i]);
-				entry.disabled = true;
-
-				for (uint j = 0; j < available.length; j++)
+				string bname = available[j].getName();
+				for (uint k = 0; k < entry.options.length; k++)
 				{
-					string bname = available[j].getName();
-					for (uint k = 0; k < entry.options.length; k++)
+					if (entry.options[k].name == bname)
 					{
-						if (entry.options[k].name == bname)
-						{
-							entry.disabled = false;
-							break;
-						}
-					}
-
-					if (!entry.disabled)
-					{
+						entry.disabled = false;
 						break;
 					}
 				}
 
+				if (!entry.disabled)
+				{
+					break;
+				}
 			}
-
 		}
-
 	}
 	else if (this.isKeyJustPressed(key_pickup))
 	{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Listing

[fixed] Pick-up wheel not updating if letting go of "pickup key".
[fixed] that you could pick up Flowers.
[fixed] that you could pick up enemy items when you shouldn't be able to.

## Description

Fixed that the pick-up wheel (which appears when pressing **Pickup** and **Pickup Modifier**) didn't update buttons if you let go of **Pickup** while holding **Pickup Modifier**. The "is **Pickup** pressed" check has been removed.

Removed Flowers from list of blobs that are considered as pickable food items in the pick-up wheel.
In doing so, removed that flowers could be picked up by these methods:
a) if a food item was close while the flowers were the closest blob to the player.
b) by abusing the above mentioned bug with the pick-up wheel not updating. Holding **Pickup** and **Pickup Modifier** while near a food item, then letting go of **Pickup**, then going near flowers, then letting go of **Pickup Modifier**.

Unfortunately, I didn't manage to make a work-around that allows the player to "pick flowers only when they were below their InitialHealth", thereby preventing the "picking up flowers" bug. 
The code seems to check for a "can be picked" state, which Flowers don't have, so creating a work-around is hard.
A work-around that checks if the blob has the name "flowers" would be discouraged anyway, and it may be possible for such a work-around to fail if there is high server ping: If picking Flowers at low health while getting healed at the same time, you may end up with Flowers in hand.

## Steps to Test or Reproduce

1. Go to Sandbox.
2. Spawn a Food, walk a little to the right and spawn Flowers, then go a little to the right.
3. Hold **Pickup** and **Pickup Modifier**, select Food.
4. Notice that the Flowers will be picked up. **After this change, the Food will be picked up.**

---

1. Go to Sandbox.
2. Spawn a Food, go far away and spawn Flowers.
3. Stand at the Food.
4. Hold **Pickup** and **Pickup Modifier**, then let go of **Pickup** and walk around.
5. Notice that the buttons will not change when going near other items. **After this change, the buttons will change according to the blobs near you.**
6. While still holding **Pickup Modifier**, go to the Flowers, hover on the Food button and let go of **Pickup Modifier**.
7. Notice you will pick up the Flowers. **After this change, due to the buttons always updating, this cannot be done.**

## Additional Information

One player has said that bugs such as "picking up flowers" one shouldn't be removed since they are harmless and fun to the players.
I leave it up to the devs what should be done.
I think bugs make a bad impression for a game and to create fun, actual new content and mechanics should be added instead.