### PR TITLE
[changed] Blobs on fire are emitting light

### DIFF
--- a/Entities/Common/FireScripts/FireAnim.as
+++ b/Entities/Common/FireScripts/FireAnim.as
@@ -41,6 +41,7 @@ void onTick(CSprite@ this)
 			this.getCurrentScript().tickFrequency = 12;
 
 			fire.SetVisible(true);
+			if (blob !is null)	{ blob.SetLight(true); }
 
 			//TODO: draw the fire layer with varying sizes based on var - may need sync spam :/
 			//fire.SetAnimation( "bigfire" );
@@ -59,6 +60,7 @@ void onTick(CSprite@ this)
 				this.PlaySound("/ExtinguishFire.ogg");
 			}
 			fire.SetVisible(false);
+			if (blob !is null)	{ blob.SetLight(false); }
 		}
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

I noticed the fire animation sprites aren't emitting light.
So I looked into it.
It is possible to make a blob which is on fire to emit light, but if the fire animation is on a worldspace, it cannot be done.

Before - https://imgur.com/5kvgQJT.png 
After - https://i.imgur.com/tCHG0IU.png
(On the left, the blob that emits light - on the right, the worldspace which cannot be set to emit light)

## How to make this Better

It would be better if the sprite itself emits light, not the blob. Because it looks odd when the whole tree is bright in the dark just from a small flame at its bottom. 

This would also fix that a worldspace/tile cannot emit light. If the sprite can emit light, there is no need for a worldspace/tile to emit it.