### PR TITLE
[fixed] Characters and Migrants not stopping after HOTHOTHOT is done

### DIFF
--- a/Entities/Common/FireScripts/HOTHOTHOT.as
+++ b/Entities/Common/FireScripts/HOTHOTHOT.as
@@ -14,8 +14,11 @@ void onTick(CMovement@ this)
 	CBlob@ blob = this.getBlob();
 	if (blob.getHealth() > 0.0f)
 	{
-		if (blob.hasTag(burning_tag)) //double check
+		if (blob.hasTag(burning_tag)) // double check
 		{
+			blob.Tag("tick after burning is done");
+			this.getCurrentScript().tickIfTag = "tick after burning is done";
+
 			MovementVars@ vars = this.getVars();
 
 			if (blob.isFacingLeft())
@@ -33,6 +36,13 @@ void onTick(CMovement@ this)
 			{
 				blob.getSprite().PlaySound("/MigrantScream");
 			}
+		}
+		else
+		{
+			blob.setKeyPressed(key_left, false);
+			blob.setKeyPressed(key_right, false);
+			blob.Untag("tick after burning is done");
+			this.getCurrentScript().tickIfTag = burning_tag;
 		}
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When a spawned-in Builder, Knight, Archer or Migrant is burning, they will start waving their arms and run forward.
After the burning is done, they keep running forward.
This change makes it so they stop running.
This is done by having HOTHOTHOT.as run one more tick that will set "left" and "right" keys to false.

## Steps to Test or Reproduce

Go to Sandbox.
Stand on some grass.
!knight
Shoot a fire arrow at the grass so the knight burns.
Notice the Knight runs and doesn't stop after the fire is done. **After this change, he would stop running**