### PR TITLE
[fixed?] Keg sometimes losing its Fuse spritelayer when popping out of inventories

### DIFF
--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -125,3 +125,13 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 	return damage;
 }
+
+void onThisRemoveFromInventory(CBlob@ this, CBlob@ inventoryBlob)
+{
+	CSpriteLayer@ fuse = this.getSprite().getSpriteLayer("fuse");
+
+	if (fuse !is null)
+	{
+		fuse.SetVisible(true);
+	}
+}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1266.

Added onThisRemoveFromInventory() which will set visibility of fuse to true.
I tested with [clumsy](https://jagt.github.io/clumsy/) set to Lag 50ms on my own server.
Before this change, there are a bunch of Kegs that lost their fuse.
After this change, I have not seen any Kegs with a lost fuse.

## Steps to Test or Reproduce

Put a bunch of Kegs in a bunch of Dinghies.
Explode one Keg on top of the Dinghies.
Some of the Kegs that will pop out of the Dinghies will have lost their fuse. **After this PR, not anymore.**