### PR TITLE
[fixed] Withdrawn items making continuous noise

### DIFF
--- a/Entities/Common/Fabric/Stone.as
+++ b/Entities/Common/Fabric/Stone.as
@@ -36,12 +36,7 @@ void onGib(CSprite@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
-	if (!solid)
-	{
-		return;
-	}
-
-	if (!getNet().isServer())
+	if (!solid || this.isInInventory())
 	{
 		return;
 	}
@@ -76,9 +71,8 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	const f32 base = heavy ? 5.0f : 7.0f;
 	const f32 ramp = 1.2f;
 
-	//print("stone vel " + vellen + " base " + base );
 	// damage
-	if (getNet().isServer() && vellen > base && !this.hasTag("ignore fall"))
+	if (isServer() && vellen > base && !this.hasTag("ignore fall"))
 	{
 		if (vellen > base * ramp)
 		{

--- a/Entities/Common/Fabric/Wooden.as
+++ b/Entities/Common/Fabric/Wooden.as
@@ -41,7 +41,7 @@ void onGib(CSprite@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
-	if (!solid)
+	if (!solid || this.isInInventory())
 	{
 		return;
 	}
@@ -73,57 +73,54 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 		}
 	}
 
+	const f32 base = heavy ? 5.0f : 7.0f;
+	const f32 ramp = 1.2f;
+
 	// damage
-	if (!this.hasTag("ignore fall"))
+	if (isServer() && vellen > base && !this.hasTag("ignore fall"))
 	{
-		const f32 base = heavy ? 5.0f : 7.0f;
-		const f32 ramp = 1.2f;
-
-		if (getNet().isServer() && vellen > base) // server only
+		if (vellen > base * ramp)
 		{
-			if (vellen > base * ramp)
+			f32 damage = 0.0f;
+
+			if (vellen < base * Maths::Pow(ramp, 1))
 			{
-				f32 damage = 0.0f;
+				damage = 0.5f;
+			}
+			else if (vellen < base * Maths::Pow(ramp, 2))
+			{
+				damage = 1.0f;
+			}
+			else if (vellen < base * Maths::Pow(ramp, 3))
+			{
+				damage = 2.0f;
+			}
+			else if (vellen < base * Maths::Pow(ramp, 3))
+			{
+				damage = 3.0f;
+			}
+			else //very dead
+			{
+				damage = 100.0f;
+			}
 
-				if (vellen < base * Maths::Pow(ramp, 1))
-				{
-					damage = 0.5f;
-				}
-				else if (vellen < base * Maths::Pow(ramp, 2))
-				{
-					damage = 1.0f;
-				}
-				else if (vellen < base * Maths::Pow(ramp, 3))
-				{
-					damage = 2.0f;
-				}
-				else if (vellen < base * Maths::Pow(ramp, 3))
-				{
-					damage = 3.0f;
-				}
-				else //very dead
-				{
-					damage = 100.0f;
-				}
+			// check if we aren't touching a trampoline
+			CBlob@[] overlapping;
 
-				// check if we aren't touching a trampoline
-				CBlob@[] overlapping;
-
-				if (this.getOverlapping(@overlapping))
+			if (this.getOverlapping(@overlapping))
+			{
+				for (uint i = 0; i < overlapping.length; i++)
 				{
-					for (uint i = 0; i < overlapping.length; i++)
+					CBlob@ b = overlapping[i];
+
+					if (b.hasTag("no falldamage"))
 					{
-						CBlob@ b = overlapping[i];
-
-						if (b.hasTag("no falldamage"))
-						{
-							return;
-						}
+						return;
 					}
 				}
-
-				this.server_Hit(this, point1, normal, damage, Hitters::fall);
 			}
+
+			this.server_Hit(this, point1, normal, damage, Hitters::fall);
 		}
 	}
 }

--- a/Entities/Items/Explosives/Bomb.as
+++ b/Entities/Items/Explosives/Bomb.as
@@ -111,7 +111,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 
 	const f32 vellen = this.getOldVelocity().Length();
 	const u8 hitter = this.get_u8("custom_hitter");
-	if (vellen > 1.7f)
+	if (vellen > 1.7f && !this.isInInventory())
 	{
 		Sound::Play(!isExplosionHitter(hitter) ? "/WaterBubble" :
 		            "/BombBounce.ogg", this.getPosition(), Maths::Min(vellen / 8.0f, 1.1f));


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1234.

After this change, in online withdrawing a wooden item (bucket, log, lantern) from a Storage or Dinghy into your own inventory will not play a continuous wooden sound effect.
In online, placing a bomb or water bomb into your inventory will not play a continuous metallic or watery sound.
In online, a boulder landing on the ground will play a sound effect instead of being silent.

Since `onCollision()` was almost the same between Fabric/Wooden.as and Fabric/Stone.as, I copy-pasted `onCollision()` from the latter into the former. It is possible to place `onCollision()` and `onGib()` of both into a separate common file, but I opted not to in case one is getting its logic and sounds changed later on. Let me know if a common file should still be created anyway.

## Steps to Test or Reproduce

Go to online Sandbox.
Place a bucket in a Dinghy, then withdraw the bucket from the Dinghy into your inventory.
Notice there is a wooden sound effect continuously playing. **After this change, not anymore.**

---

Place a bomb into your inventory.
Notice there is a continuous metallic sound effect playing. **After this change, not anymore.**

---

Throw a Boulder on the ground.
Notice no sound effect playing. **After this change, there will be a sound effect playing.**