### PR TITLE
[fixed?] Archer bot shooting two arrows in one charge in online

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -305,10 +305,15 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 
 void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 {
+	if (!isClient())
+	{
+		return;	
+	}
+	
 	//are we responsible for this actor?
 	bool ismyplayer = this.isMyPlayer();
 	bool responsible = ismyplayer;
-	if (isServer() && !ismyplayer)
+	if (!ismyplayer)
 	{
 		CPlayer@ p = this.getPlayer();
 		if (p !is null)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This change makes it so Archer bots won't shoot two arrows at once in online servers.

ArcherBrain.as causes the bot character to press keys. 
The actions are managed in ArcherLogic.as.
Apparently both the client and the server go through `ManageBow()` and therefore will execute `ClientFire()` twice.
I added this check at the beginning of `ManageBow()` so only the client executes the code:
```
	if (!isClient())
	{
		return;
	}
```

Archer bots in offline will not be affected and will still shoot one arrow as usual.
I have not seen any side effects.
Not sure why it happens only with bots and not players, though...

## Steps to Test or Reproduce

Go to your own dedicated server.
Spawn an archer bot by using !bot
Change team and wait for the archer bot to shoot at you. 
Notice the bot will shoot two arrows. **After this change, will only shoot one arrow.**

---

Go to Save the Princess in offline.
Play until the first archer bot.
Wait for the archer bot to shoot at you.
Notice the bot will shoot one arrow. **After this change, this behavior is not broken.**
