### PR TITLE
[Fixed] Catapult flying away if shooting from a Mounted Bow which is in a Catapult's Mag 

### DIFF
--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -257,7 +257,8 @@ void swapAmmo(CBlob@ this, VehicleInfo@ v, u8 ammoIndex)
 
 AttachmentPoint@ getMagAttachmentPoint(CBlob@ this)
 {
-	return this.getAttachments().getAttachmentPointByName("MAG");
+	// returns the "MAG" point only if this blob is the socket
+	return this.getAttachments().getAttachmentPoint("MAG", true);
 }
 
 CBlob@ getMagBlob(CBlob@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1247.

I decided to make this a separate PR and not to include this in #1251.

When a Mounted Bow is in a Catapult's mag and you are firing from that Mounted Bow, the catapult would fly away.
This change fixes that so when shooting from the Mounted Bow, it will shoot arrows and not detach.
The Mounted Bow can be shot forward normally if firing from the catapult's gunner position.

Apparently, the code assumes a Mounted Bow on its own does not have a "MAG" attachment point.
However, when it is attached to the Catapult, it will return a "MAG" attachment point - the one by the catapult.
By changing `this.getAttachments().getAttachmentPointByName("MAG");`
to `this.getAttachments().getAttachmentPoint("MAG", true);`, it will only return the "MAG" attachment point if the blob is the socket - The Mounted Bow will therefore never somehow fetch a wrong mag attachment point now and the bug won't happen.

## Steps to Test or Reproduce

Place changed file in a mod folder.
Start your dev install with the mod.
Go to Save the Princess.
!tradingpost
!999 coins
Buy a Mounted Bow
!catapult
Place the Mounted Bow in the Catapult's mag
Attach to the Mounted Bow and fire.
Notice the catapult will fly away. **After this change, it will shoot arrows and not detach from the catapult.**