### PR TITLE
[fixed] Explosives inventories not taking damage

### DIFF
--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -442,7 +442,7 @@ void LinearExplosion(CBlob@ this, Vec2f _direction, f32 length, const f32 width,
 		//widthwise overlap
 		float q = Maths::Abs(v * normal) - rad - tilesize;
 
-		if (p > 0.0f && p < length && q < halfwidth)
+		if (p >= 0.0f && p < length && q < halfwidth)
 		{
 			HitBlob(this, m_pos, hit_blob, length, damage, hitter, false, should_teamkill);
 		}

--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -580,7 +580,8 @@ bool HitBlob(CBlob@ this, Vec2f mapPos, CBlob@ hit_blob, f32 radius, f32 damage,
 	                hitter, hitter == Hitters::water || //hit with water
 	                isOwnerBlob(this, hit_blob) ||	//allow selfkill with bombs
 	                should_teamkill || hit_blob.hasTag("dead") || //hit all corpses ("dead" tag)
-					hit_blob.hasTag("explosion always teamkill") // check for override with tag
+					hit_blob.hasTag("explosion always teamkill") || // check for override with tag
+					this.isInInventory() && this.getInventoryBlob().getNetworkID() == hit_blob.getNetworkID() //is the inventory container
 	               );
 	return true;
 }

--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -581,7 +581,7 @@ bool HitBlob(CBlob@ this, Vec2f mapPos, CBlob@ hit_blob, f32 radius, f32 damage,
 	                isOwnerBlob(this, hit_blob) ||	//allow selfkill with bombs
 	                should_teamkill || hit_blob.hasTag("dead") || //hit all corpses ("dead" tag)
 					hit_blob.hasTag("explosion always teamkill") || // check for override with tag
-					(this.isInInventory() && this.getInventoryBlob().getNetworkID() == hit_blob.getNetworkID()) //is the inventory container
+					(this.isInInventory() && this.getInventoryBlob() is hit_blob) //is the inventory container
 	               );
 	return true;
 }

--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -581,7 +581,7 @@ bool HitBlob(CBlob@ this, Vec2f mapPos, CBlob@ hit_blob, f32 radius, f32 damage,
 	                isOwnerBlob(this, hit_blob) ||	//allow selfkill with bombs
 	                should_teamkill || hit_blob.hasTag("dead") || //hit all corpses ("dead" tag)
 					hit_blob.hasTag("explosion always teamkill") || // check for override with tag
-					this.isInInventory() && this.getInventoryBlob().getNetworkID() == hit_blob.getNetworkID() //is the inventory container
+					(this.isInInventory() && this.getInventoryBlob().getNetworkID() == hit_blob.getNetworkID()) //is the inventory container
 	               );
 	return true;
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1312 

As said in the issue, Bombs & KEGs weren't able to damage or destroy their own inventory container such as: Dinghy, Longboat, Warboat, Airship, Storage & Magazine (Players & Crates works fine though).

However, I had to do an extra step for the KEG. For some reasons, `keg_blob.isInInventory()` returned `false` and `keg_blob.getInventoryBlob()` returned a `null` value too, so I had to edit the lengthwise comparison check, I'm not sure if it will lead to unexpected behaviours. My tests seems fine though.

## Steps to Test or Reproduce

### Steps
+ Start any game
+ Place any container (!dinghy, !longboat, !warboat, !airship, !storage)
+ Place an activated explosive (!keg, !bomb) in the container and waits it for exploding 
+ Repeat until container's destroy (3 bombs for the storage)

### Affected blobs:
+ Dinghy
+ Longboat
+ Warboat
+ Airship
+ Storage 
+ Magazine (could not test)
