### PR TITLE
Better bomb throwing with ping

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1113,7 +1113,21 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 			if (carried !is null)
 			{
-				DoThrow(this, carried, pos, vector, vel);
+				bool holding_bomb = false;
+				// are we actually holding a bomb or something else?
+				for (uint i = 0; i < bombNames.length; i++)
+				{
+					if(carried.getName() == bombNames[i])
+					{
+						holding_bomb = true;
+						DoThrow(this, carried, pos, vector, vel);
+					}
+				}
+
+				if (!holding_bomb)
+				{
+					ActivateBlob(this, carried, pos, vector, vel);
+				}
 			}
 			else
 			{

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -83,6 +83,7 @@ void onInit(CBlob@ this)
 	this.Tag("flesh");
 
 	this.addCommandID("get bomb");
+	this.addCommandID("activate/throw bomb");
 
 	this.push("names to activate", "keg");
 
@@ -309,9 +310,7 @@ void onTick(CBlob@ this)
 						}
 						else
 						{
-							CBitStream params;
-							params.write_u8(bombType);
-							this.SendCommand(this.getCommandID("get bomb"), params);
+							client_SendThrowOrActivateCommandBomb(this, bombType);
 							thrown = true;
 						}
 						break;
@@ -1074,9 +1073,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("get bomb"))
 	{
-		if (this.getCarriedBlob() !is null)
-			return;
-
 		const u8 bombType = params.read_u8();
 		if (bombType >= bombTypeNames.length)
 			return;
@@ -1152,6 +1148,30 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	}
 	else if (cmd == this.getCommandID("activate/throw"))
 	{
+		SetFirstAvailableBomb(this);
+	}
+	else if (cmd == this.getCommandID("activate/throw bomb"))
+	{
+		if (isServer())
+		{
+			Vec2f pos = params.read_Vec2f();
+			Vec2f vector = params.read_Vec2f();
+			Vec2f vel = params.read_Vec2f();
+			u8 bombType = params.read_u8();
+
+			CBlob @carried = this.getCarriedBlob();
+
+			if (carried !is null)
+			{
+				DoThrow(this, carried, pos, vector, vel);
+			}
+			else
+			{
+				CBitStream cparams;
+				cparams.write_u8(bombType);
+				this.SendCommand(this.getCommandID("get bomb"), cparams);
+			}
+		}
 		SetFirstAvailableBomb(this);
 	}
 	else

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -82,7 +82,6 @@ void onInit(CBlob@ this)
 	this.Tag("player");
 	this.Tag("flesh");
 
-	this.addCommandID("get bomb");
 	this.addCommandID("activate/throw bomb");
 
 	this.push("names to activate", "keg");
@@ -1071,56 +1070,7 @@ void SwordCursorUpdate(CBlob@ this, KnightInfo@ knight)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("get bomb"))
-	{
-		const u8 bombType = params.read_u8();
-		if (bombType >= bombTypeNames.length)
-			return;
-
-		const string bombTypeName = bombTypeNames[bombType];
-		this.Tag(bombTypeName + " done activate");
-		if (hasItem(this, bombTypeName))
-		{
-			if (bombType == 0)
-			{
-				if (getNet().isServer())
-				{
-					CBlob @blob = server_CreateBlob("bomb", this.getTeamNum(), this.getPosition());
-					if (blob !is null)
-					{
-						TakeItem(this, bombTypeName);
-						this.server_Pickup(blob);
-					}
-				}
-			}
-			else if (bombType == 1)
-			{
-				if (getNet().isServer())
-				{
-					CBlob @blob = server_CreateBlob("waterbomb", this.getTeamNum(), this.getPosition());
-					if (blob !is null)
-					{
-						TakeItem(this, bombTypeName);
-						this.server_Pickup(blob);
-						blob.set_f32("map_damage_ratio", 0.0f);
-						blob.set_f32("explosive_damage", 0.0f);
-						blob.set_f32("explosive_radius", 92.0f);
-						blob.set_bool("map_damage_raycast", false);
-						blob.set_string("custom_explosion_sound", "/GlassBreak");
-						blob.set_u8("custom_hitter", Hitters::water);
-                        blob.Tag("splash ray cast");
-
-					}
-				}
-			}
-			else
-			{
-			}
-
-			SetFirstAvailableBomb(this);
-		}
-	}
-	else if (cmd == this.getCommandID("cycle"))  //from standardcontrols
+	if (cmd == this.getCommandID("cycle"))  //from standardcontrols
 	{
 		// cycle bombs
 		u8 type = this.get_u8("bomb type");
@@ -1167,9 +1117,39 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 			else
 			{
-				CBitStream cparams;
-				cparams.write_u8(bombType);
-				this.SendCommand(this.getCommandID("get bomb"), cparams);
+				if (bombType >= bombTypeNames.length)
+					return;
+
+				const string bombTypeName = bombTypeNames[bombType];
+				this.Tag(bombTypeName + " done activate");
+				if (hasItem(this, bombTypeName))
+				{
+					if (bombType == 0)
+					{
+						CBlob @blob = server_CreateBlob("bomb", this.getTeamNum(), this.getPosition());
+						if (blob !is null)
+						{
+							TakeItem(this, bombTypeName);
+							this.server_Pickup(blob);
+						}
+					}
+					else if (bombType == 1)
+					{
+						CBlob @blob = server_CreateBlob("waterbomb", this.getTeamNum(), this.getPosition());
+						if (blob !is null)
+						{
+							TakeItem(this, bombTypeName);
+							this.server_Pickup(blob);
+							blob.set_f32("map_damage_ratio", 0.0f);
+							blob.set_f32("explosive_damage", 0.0f);
+							blob.set_f32("explosive_radius", 92.0f);
+							blob.set_bool("map_damage_raycast", false);
+							blob.set_string("custom_explosion_sound", "/GlassBreak");
+							blob.set_u8("custom_hitter", Hitters::water);
+							blob.Tag("splash ray cast");
+						}
+					}
+				}
 			}
 		}
 		SetFirstAvailableBomb(this);

--- a/Entities/Common/Throwing/ActivateHeldObject.as
+++ b/Entities/Common/Throwing/ActivateHeldObject.as
@@ -32,53 +32,6 @@ void onInit(CBlob@ this)
 	this.set_f32("throw ourvel scale", 1.0f);
 }
 
-bool ActivateBlob(CBlob@ this, CBlob@ blob, Vec2f pos, Vec2f vector, Vec2f vel)
-{
-	bool shouldthrow = true;
-	bool done = false;
-
-	if (!blob.hasTag("activated") || blob.hasTag("dont deactivate"))
-	{
-		string carriedname = blob.getName();
-		string[]@ names;
-
-		if (this.get("names to activate", @names))
-		{
-			for (uint step = 0; step < names.length; ++step)
-			{
-				if (names[step] == carriedname)
-				{
-					//if compatible
-					if (getNet().isServer() && blob.hasTag("activatable"))
-					{
-						blob.SendCommand(blob.getCommandID("activate"));
-					}
-
-					blob.Tag("activated");//just in case
-					shouldthrow = false;
-					this.Tag(blob.getName() + " done activate");
-
-					// move ouit of inventory if its the case
-					if (blob.isInInventory())
-					{
-						this.server_Pickup(blob);
-					}
-					done = true;
-				}
-			}
-		}
-	}
-
-	//throw it if it's already lit or we cant light it
-	if (getNet().isServer() && !blob.hasTag("custom throw") && shouldthrow && this.getCarriedBlob() is blob)
-	{
-		DoThrow(this, blob, pos, vector, vel);
-		done = true;
-	}
-
-	return done;
-}
-
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("activate/throw"))
@@ -111,7 +64,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		if (carried !is null)
 		{
-			if (getNet().isServer() && !carried.hasTag("custom throw"))
+			if (isServer() && !carried.hasTag("custom throw"))
 			{
 				DoThrow(this, carried, pos, vector, vel);
 			}

--- a/Entities/Common/Throwing/ActivateHeldObject.as
+++ b/Entities/Common/Throwing/ActivateHeldObject.as
@@ -15,8 +15,6 @@
 
 #include "ThrowCommon.as";
 
-const f32 DEFAULT_THROW_VEL = 6.0f;
-
 void onInit(CBlob@ this)
 {
 	if (!this.exists("names to activate"))
@@ -120,59 +118,4 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			//this.Tag( carried.getName() + " done throw" );
 		}
 	}
-}
-
-
-// THROW
-
-void DoThrow(CBlob@ this, CBlob@ carried, Vec2f pos, Vec2f vector, Vec2f selfVelocity)
-{
-	f32 ourvelscale = 0.0f;
-
-	if (this.get_bool("throw uses ourvel"))
-	{
-		ourvelscale = this.get_f32("throw ourvel scale");
-	}
-
-	Vec2f vel = getThrowVelocity(this, vector, selfVelocity, ourvelscale);
-
-	if (carried !is null)
-	{
-		if (carried.hasTag("medium weight"))
-		{
-			vel *= 0.6f;
-		}
-		else if (carried.hasTag("heavy weight"))
-		{
-			vel *= 0.3f;
-		}
-
-		if (carried.server_DetachFrom(this))
-		{
-			carried.setVelocity(vel);
-
-			CShape@ carriedShape = carried.getShape();
-			if (carriedShape !is null)
-			{
-				carriedShape.checkCollisionsAgain = true;
-				carriedShape.ResolveInsideMapCollision();
-			}
-		}
-	}
-}
-
-Vec2f getThrowVelocity(CBlob@ this, Vec2f vector, Vec2f selfVelocity, f32 this_vel_affect = 0.1f)
-{
-	Vec2f vel = vector;
-	f32 len = vel.Normalize();
-	vel *= DEFAULT_THROW_VEL;
-	vel *= this.get_f32("throw scale");
-	vel += selfVelocity * this_vel_affect; // blob velocity
-
-	f32 closeDist = this.getRadius() + 64.0f;
-	if (selfVelocity.getLengthSquared() < 0.1f && len < closeDist)
-	{
-		vel *= len / closeDist;
-	}
-	return vel;
 }

--- a/Entities/Common/Throwing/ThrowCommon.as
+++ b/Entities/Common/Throwing/ThrowCommon.as
@@ -13,6 +13,19 @@ void client_SendThrowOrActivateCommand(CBlob@ this)
 	}
 }
 
+void client_SendThrowOrActivateCommandBomb(CBlob@ this, u8 bombtype)
+{
+    if (this.isMyPlayer())
+    {
+        CBitStream params;
+        params.write_Vec2f(this.getPosition());
+        params.write_Vec2f(this.getAimPos() - this.getPosition());
+        params.write_Vec2f(this.getVelocity());
+        params.write_u8(bombtype);
+        this.SendCommand(this.getCommandID("activate/throw bomb"), params);
+    }
+}
+
 void client_SendThrowCommand(CBlob@ this)
 {
 	CBlob @carried = this.getCarriedBlob();
@@ -33,4 +46,58 @@ void server_ActivateCommand(CBlob@ this, CBlob@ blob)
 		blob.SendCommand(blob.getCommandID("activate"));
 		blob.Tag("activated");
 	}
+}
+
+const f32 DEFAULT_THROW_VEL = 6.0f;
+
+void DoThrow(CBlob@ this, CBlob@ carried, Vec2f pos, Vec2f vector, Vec2f selfVelocity)
+{
+	f32 ourvelscale = 0.0f;
+
+	if (this.get_bool("throw uses ourvel"))
+	{
+		ourvelscale = this.get_f32("throw ourvel scale");
+	}
+
+	Vec2f vel = getThrowVelocity(this, vector, selfVelocity, ourvelscale);
+
+	if (carried !is null)
+	{
+		if (carried.hasTag("medium weight"))
+		{
+			vel *= 0.6f;
+		}
+		else if (carried.hasTag("heavy weight"))
+		{
+			vel *= 0.3f;
+		}
+
+		if (carried.server_DetachFrom(this))
+		{
+			carried.setVelocity(vel);
+
+			CShape@ carriedShape = carried.getShape();
+			if (carriedShape !is null)
+			{
+				carriedShape.checkCollisionsAgain = true;
+				carriedShape.ResolveInsideMapCollision();
+			}
+		}
+	}
+}
+
+Vec2f getThrowVelocity(CBlob@ this, Vec2f vector, Vec2f selfVelocity, f32 this_vel_affect = 0.1f)
+{
+	Vec2f vel = vector;
+	f32 len = vel.Normalize();
+	vel *= DEFAULT_THROW_VEL;
+	vel *= this.get_f32("throw scale");
+	vel += selfVelocity * this_vel_affect; // blob velocity
+
+	f32 closeDist = this.getRadius() + 64.0f;
+	if (selfVelocity.getLengthSquared() < 0.1f && len < closeDist)
+	{
+		vel *= len / closeDist;
+	}
+	return vel;
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Alternative to #1038 , which made it impossible to spam bombs if you had high ping (which caused many complaints)
Implements this comment:
"Instead of the client checking if it's holding something or needs to light a new bomb, the server should do that. Pretty much move all the checks the client is doing onto the server instead. The client just needs to blindly tell the server that they want to light/throw a bomb and the server acts on in."
Moved some code from ActivateHeldObject.as to ThrowCommon.as as well
Video - comparison between PR version and pre-Epsilon's PR bomb throwing.

https://www.youtube.com/watch?v=-4n0ouJ2m80
