### PR TITLE
[fixed] Drill activating when player is attached in online server

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -186,7 +186,7 @@ void onTick(CBlob@ this)
 		AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
 		CBlob@ holder = point.getOccupied();
 
-		if (holder is null) return;
+		if (holder is null || holder.isAttached()) return;
 
 		AimAtMouse(this, holder); // aim at our mouse pos
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.


## Description

When the player is attached (sitting on a vehicle or animal) and is pressing Action1, drill would activate, destroying nearby blobs, scenery or walls. This happens only in online servers.
This PR will add an early return, so the drilling doesn't happen if the player is attached.

## Reproduction Steps

Go to online Sandbox EU.
Spawn a catapult and a drill.
Pick up the drill and sit in the catapult.
Hold Action1 while driving around.
Notice the drill will damage nearby platforms, trees, chickens, etc.
**After this change, not anymore.**