### PR TITLE
[fixed] CTF Flag return timer bugs

### DIFF
--- a/Entities/Special/CTF/CTF_Flag.as
+++ b/Entities/Special/CTF/CTF_Flag.as
@@ -283,8 +283,12 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 
 void onAttach( CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint )
 {
-    if (!getNet().isServer())
-        return;
+    this.Untag("return");
+    this.set_u16(return_prop, 0);
+    this.Sync("return", true);
+    this.Sync(return_prop, true);
+	
+    if (isServer())	return;
 
     CRules@ rules = getRules();
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixed #1319.

If you pick up an enemy CTF Flag and throw it on the same tick, its return timer would not reset.
If you pick up an enemy CTF Flag on the last possible moment, it is possible that it could have the "return" flag, so if you throw it, it would instantly return to its base.
This PR aims to fix these bugs by adding these lines to the beginning of `onAttach()`.
```
	this.Untag("return");
	this.set_u16(return_prop, 0);
	this.Sync("return", true);
	this.Sync(return_prop, true);
```
Initially, I wanted to have this code execute on client-side only. But the server could lag and the bugs could still happen, so I now have both client and server enter these lines and run `Sync()`. I have not seen the bugs happen after that.

## Steps to Test or Reproduce

To reproduce "pick up and throw on the same tick", walk into an enemy flag and press the throw key at the same time. It will take a few tries. If done correctly, you will notice the return timer will not have reset.

To reproduce "picking up in the last moment and throwing will return the flag instantly", you can set `return_time` in line 7 to a low number such as 30 and keep trying. You can add a line to `onAttach()` such as this for checking:
`if (this.hasTag("return")) print("If you let go of me now I will return to my base.")`
