### PR TITLE
Set the "fire source" tag as early as onInit for arrows

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -46,15 +46,18 @@ void onInit(CBlob@ this)
 
 	const u8 arrowType = this.get_u8("arrow type");
 
-	if (arrowType == ArrowType::bomb)			 // bomb arrow
+	if (arrowType == ArrowType::bomb)
 	{
 		SetupBomb(this, bomb_fuse, 48.0f, 1.5f, 24.0f, 0.5f, true);
 		this.set_u8("custom_hitter", Hitters::bomb_arrow);
 	}
-
-	if (arrowType == ArrowType::water)
+	else if (arrowType == ArrowType::water)
 	{
 		this.Tag("splash ray cast");
+	}
+	else if (arrowType == ArrowType::fire)
+	{
+		this.Tag("fire source");
 	}
 
 	CSprite@ sprite = this.getSprite();
@@ -195,7 +198,6 @@ void onTick(CBlob@ this)
 		if (gametime % 6 == 0)
 		{
 			this.getSprite().SetAnimation("fire");
-			this.Tag("fire source");
 
 			Vec2f offset = Vec2f(this.getWidth(), 0.0f);
 			offset.RotateBy(-angle);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
 
## Description

This fixes an issue with #1160 where the keg would often not lit up if the fire arrow was shot from a close enough distance. For some reason, the tag assignment was guarded by a `gametime % 6` condition on the arrow ticking, which was used to play some effects. Hence, the late tagging looks unintentional, and I have not found issues with this fix during my testing.

## Steps to Test or Reproduce

1. Go to sandbox (online or offline)
2. Switch to archer
3. Spawn a keg
4. Shoot a fire arrow at the keg. It should work even if you're basically overlapping the keg, and at short distances.

Without this workaround the arrow would miss most of the time which is largely undesirable.