### PR TITLE
[fixed] picking up items that have already been attached / picking up items after getting in a crate

### DIFF
--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -60,7 +60,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		    && !owner.isInInventory()
 		    && !owner.isAttached()
 		    && pick !is null 
-		    && !pick.isAttached())
+		    && !pick.isAttached()
+		    && !pick.hasAttached())
 		{
 			owner.server_Pickup(pick);
 		}

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -56,7 +56,10 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBlob@ owner = getBlobByNetworkID(params.read_netid());
 		CBlob@ pick = getBlobByNetworkID(params.read_netid());
 
-		if (owner !is null && pick !is null && !owner.isInInventory())
+		if (owner !is null 
+		    && !owner.isInInventory()
+		    && pick !is null 
+		    && !pick.isAttached())
 		{
 			owner.server_Pickup(pick);
 		}

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -58,6 +58,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		if (owner !is null 
 		    && !owner.isInInventory()
+		    && !owner.isAttached()
 		    && pick !is null 
 		    && !pick.isAttached())
 		{

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -61,7 +61,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		    && !owner.isAttached()
 		    && pick !is null 
 		    && !pick.isAttached()
-		    && !pick.hasAttached())
+		    && pick.canBePickedUp(owner))
 		{
 			owner.server_Pickup(pick);
 		}

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -56,7 +56,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBlob@ owner = getBlobByNetworkID(params.read_netid());
 		CBlob@ pick = getBlobByNetworkID(params.read_netid());
 
-		if (owner !is null && pick !is null)
+		if (owner !is null && pick !is null && !owner.isInInventory())
 		{
 			owner.server_Pickup(pick);
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1320:

At high ping in online, you could pick up items after sending the "get in" command but before you got put in the crate.
This PR makes it so `onCommand()` in StandardControls.as checks if the picker is in inventory. If yes, the picking up will not happen.

Fixes #1323:

At high ping in online, it is possible that a player picks up an item that has already been picked up or attached.
This PR makes it so the pickup does not happen if the picked item is attached.

Fixes that you could go to Bed or attach yourself and then pick up an item in quick succession.

Fixes #1519:

It was possible to pick up a Dinghy that someone got into just a few ticks ago.
Commit [c73b3b1](https://github.com/transhumandesign/kag-base/pull/1332/commits/c73b3b1331a7f35bb0e10cc25c675b573992eab4) fixes that so it will not be possible.

## Steps to Test or Reproduce

Go to a high ping server.
Have a crate in hand and keep showing buttons.
While showing buttons, throw the crate aside.
Be near the crate or any item and click on the "get in" button and then press "pick up" in quick succession.
The crate (or other item) will be picked up while you are inside the crate.

**After this change, you will get inside the crate and the pickup will not happen.**

---

To test "picking up item from another player's hand", I used this code in BuilderLogic.as:

```
int z=0;
void onTick(CBlob@ this)
{
	if (isServer())
	{	
		if (this.getTeamNum() == 1)
		{
			z++;
		
			CBlob@[] crates;
			getBlobsByName("crate", crates);
			for (uint i = 0; i < crates.length; i++)
			{
				if (z%80==0)
				{
					if (crates[i].isAttached())
					{
						crates[i].server_DetachFromAll();
						break;
					}
				
					else
					{
						server_Pickup(this, this, crates[i]);
						break;
					}
				}

			}
		}
	}
```

Go to your own dedicated server. Use [clumsy](https://jagt.github.io/clumsy/) to simulate high ping.
Spawn a red builder, then go back to being blue.
Spawn a crate. The code above will cause the crate to repeatedly get picked up by and then detached from the red builder.
If you pick up the crate before the red builder, the "bug scenario" can happen.
**After this PR , not anymore.**

---

In online, go heal in a Bed and pick up an item in quick succession.
Notice you will hold your item while you are sleeping.
**After this PR, not possible anymore.**