### PR TITLE
[fixed] Loading items you aren't holding in catapult

### DIFF
--- a/Entities/Vehicles/Common/Vehicle.as
+++ b/Entities/Vehicles/Common/Vehicle.as
@@ -196,7 +196,9 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		CBlob@ caller = getBlobByNetworkID(params.read_u16());
 		CBlob@ blob = getBlobByNetworkID(params.read_u16());
-		if (caller !is null && blob !is null)
+		if 	(caller !is null 
+			&& blob !is null 
+			&& blob.isAttachedTo(caller))
 		{
 			// put what was in mag into inv
 			CBlob@ magBlob = getMagBlob(this);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1326.

In offline and online, you can hold an item, keep showing buttons, then throw the item away and press the "load item to catapult" button later to place the item in the catapult's mag, even from screen lengths away. This could possibly be exploited in a number of ways and have a lot of unintentional side-effects (see the linked issue for more information).

This change makes it so you can only load a blob to a catapult if it is attached to you (i.e. you are holding it).
I think this should render all of the described side-effects as fixed.
You can still load stone to catapult via button without holding the stone as usual.

## To make this better

Since buttons are removed when picking up an item, 
you could make it so buttons are removed when you throw an item.

