### PR TITLE
[fixed] Pre-existing Doors and Ladders will now decay in water

### DIFF
--- a/Rules/CommonScripts/WaterDecaysDoors.as
+++ b/Rules/CommonScripts/WaterDecaysDoors.as
@@ -87,7 +87,6 @@ void FetchExisting()
 {
 	if (getMap() !is null)
 	{
-		print("A");
 		CBlob@[] blobs;
 		
 		for (uint i = 0; i < names_to_decay.length; i++)

--- a/Rules/CommonScripts/WaterDecaysDoors.as
+++ b/Rules/CommonScripts/WaterDecaysDoors.as
@@ -4,6 +4,7 @@
 
 u16[] ids;
 u16 limit = 15; //ticks between hitting
+string[] names_to_decay = {"wooden_door", "ladder"};
 
 void onInit(CRules@ this)
 {
@@ -13,12 +14,13 @@ void onInit(CRules@ this)
 void onRestart(CRules@ this)
 {
 	ids.clear();
+	FetchExisting();
 }
 
 void onBlobCreated(CRules@ this, CBlob@ blob)
 {
     string name = blob.getName();
-	if (name == "wooden_door" || name == "ladder")
+	if (names_to_decay.find(name) != -1)
 	{
 		ids.push_back(blob.getNetworkID());
 	}
@@ -27,7 +29,7 @@ void onBlobCreated(CRules@ this, CBlob@ blob)
 void onBlobDie(CRules@ this, CBlob@ blob)
 {
     string name = blob.getName();
-	if (name == "wooden_door" || name == "ladder")
+	if (names_to_decay.find(name) != -1)
 	{
 		u16 id = blob.getNetworkID();
 		for (uint i = 0; i < ids.length; i++)
@@ -77,6 +79,25 @@ void onTick(CRules@ this)
 		if(water && !b.isAttached())
 		{
 			b.server_Hit(b, pos, Vec2f(), 0.5f, Hitters::water, true);
+		}
+	}
+}
+
+void FetchExisting()
+{
+	if (getMap() !is null)
+	{
+		print("A");
+		CBlob@[] blobs;
+		
+		for (uint i = 0; i < names_to_decay.length; i++)
+		{
+			getBlobsByName(names_to_decay[i], @blobs);
+		}
+		
+		for (uint j = 0; j < blobs.length; j++)
+		{
+			ids.push_back(blobs[j].getNetworkID());;
 		}
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1288.

Doors and ladders that are loaded with the map wouldn't decay in water despite the gamemode having `WaterDecaysDoors.as` added to it. This PR will fix this so doors and ladders will decay in water normally.

The map loads before the scripts are loaded, so `WaterDecaysDoors.as` only accounted for newly added doors/ladders.
To account for pre-existing doors/ladders, a function `FetchExisting()` has been added to `onRestart()` which will fetch pre-existing doors/ladders.
A strings array `names_to_decay` has been added, so names "ladder" and "wooden_door" aren't hard-coded in several places.

## Steps to Test or Reproduce

Go to any gamemode that uses `WaterDecaysDoors.as`, e.g. the CTF Tutorial.
`/loadmap Juggernaut` or `/loadmap BorgRuins`.
`/spawnwater` near the doors or ladders.
Notice they won't decay. **After this PR, they will.**

