### PR TITLE
[changed] Healing items won't heal upon pickup or when throwing, only on collision or when pressing "Eat Food"

### DIFF
--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -18,7 +18,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 	{
 		this.getSprite().PlaySound(this.get_string("eat sound"));
 
-		if (getNet().isServer())
+		if (isServer())
 		{
 			u16 blob_id;
 			if (!params.saferead_u16(blob_id)) return;
@@ -74,7 +74,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 		return;
 	}
 
-	if (getNet().isServer() && !blob.hasTag("dead"))
+	if (isServer() && !blob.hasTag("dead"))
 	{
 		Heal(blob, this);
 	}
@@ -83,30 +83,24 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
-	if (this is null || attached is null) {return;}
-
-	if (isServer())
-	{
-		Heal(attached, this);
-	}
-
-	CPlayer@ p = attached.getPlayer();
-	if (p is null){return;}
-
-	this.set_u16("healer", p.getNetworkID());
+	SetHealer(this, attached);
 }
 
 void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint @attachedPoint)
 {
-	if (this is null || detached is null) {return;}
+	SetHealer(this, detached);
+}
 
-	if (isServer())
+void SetHealer(CBlob@ food, CBlob@ blob)
+{
+	if (food is null || blob is null) 
 	{
-		Heal(detached, this);
+		return;
 	}
 
-	CPlayer@ p = detached.getPlayer();
-	if (p is null){return;}
-
-	this.set_u16("healer", p.getNetworkID());
-}
+	CPlayer@ p = blob.getPlayer();
+	if (p !is null)
+	{
+		food.set_u16("healer", p.getNetworkID());
+	}
+} 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1167.

This change makes it so healing items won't heal upon attaching (picking up, selecting from inventory) or detaching (throwing). Healing items will only heal on collision when you are below max health or when you have one in your inventory and key "eat food" is pressed.

This is not a bug fix but a suggested change. Please discuss before implementing.

## Steps to Test or Reproduce

Be low on health. 
Pick up a food from the ground, 
Notice it will heal you. **After this change, you will pick it up from the ground.**

---

Be low on health.
Select a food from inventory. 
Notice it will heal you. **After this change, you will pick it up from your inventory.**

---

Have a food in your hand.
Hurt yourself.
Throw the food.
Notice it will heal you. **After this change, you will throw the food.** 