### PR TITLE
[fixed] Minimap on top of map voting window and exception in CTF when match ends via vote pass or chat command

### DIFF
--- a/Rules/CTF/Scripts/CTF_Banners.as
+++ b/Rules/CTF/Scripts/CTF_Banners.as
@@ -69,6 +69,10 @@ void onTick(CRules@ this)
 	if (this.get_bool("Draw Banner"))
 	{
 		u8 banner_type = this.get_u8("Animate Banner");
+		
+		if (banner_type >= banners.length)	
+			return;
+		
 		Banner@ banner = banners[banner_type];
 
 		if (banner_type == BannerType::GAME_START)
@@ -109,6 +113,9 @@ void onRender(CRules@ this)
 
 				bannerPos = Vec2f_lerp(bannerStart, bannerDest, frameTime);
 			}
+
+			if (banner_type >= banners.length)
+				return;
 
 			Banner@ banner = banners[banner_type];
 

--- a/Rules/CommonScripts/PostGameMapVotes.as
+++ b/Rules/CommonScripts/PostGameMapVotes.as
@@ -233,6 +233,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 			case 3:	LoadMap(mvm.button3.filename); break;
 			default: LoadNextMap(); break;
 		}
+		this.minimap = true;
 	}
 }
 
@@ -252,4 +253,6 @@ void RenderRaw(int id)
 	Render::SetBackfaceCull(true);
 	Render::SetZBuffer(false, false);
 	mvm.Render();
+	
+	getRules().minimap = false;
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This PR fixes an exception that could happen when using chat command `!endgame` or when "Next map" vote passes, in a CTF server, with the newly introduced game state banners (See PR #1166 which introduced GameStateBanners.as and CTF_Banners.as).

Variable `banner_type` could become equal to the length of the `banners` array which causes an out of bounds exception.
I made it so it will return from the function if that's the case and when `banners[banner_type]` is about to be used.

Fixes #1343:

Previously, in a nutshell, `GameStateBanners.as` would set `rules.minimap = true` when a new map loads.
When the game finishes due to a team winning, the winning banner is shown and `rules.minimap = false` executes, so the minimap isn't shown until the next map loads.
When a "Next map" vote passes or when using chat command `!endgame`, having applied the above fix, the minimap would still be visible above the map voting window.
Also, gamemodes other than CTF will use post game map voting but will not use `GameStateBanners.as`, so the minimap would be visible on top of the map voting when a TTH match ends.

So I edited `PostGameMapVotes.as`.
When the map voting window is rendered, then `rules.minimap = false` will execute.
When "voteEndTag" is passed in onCommand() in `PostGameMapVotes.as` and therefore a new map is going to load, then `rules.minimap = true` executes. So even though `GameStateBanners.as` is absent or not executed, the minimap will still be set to true when the map voting ends.

## Steps to Test or Reproduce

Have your up to date CTF or TTH server set up with lots of files changed that allow you to instantly start and pass votes and send chat commands that only mods are able to use normally.

Use chat command `!endgame` or have a "Next map" vote pass. Notice an exception in the console and game banners not showing up anymore. **After this PR , this will not happen. Also notice minimap being disabled when the map voting starts and being enabled again when the map voting ends.**
