### PR TITLE
[fixed] Saw killing you when changing class or when using tunnel

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -152,8 +152,11 @@ void Blend(CBlob@ this, CBlob@ tobeblended)
 
 bool canSaw(CBlob@ this, CBlob@ blob)
 {
-	if (blob.getRadius() >= this.getRadius() * 0.99f || blob.getShape().isStatic() ||
-	        blob.hasTag("sawed") || blob.hasTag("invincible"))
+	if (blob.getRadius() >= this.getRadius() * 0.99f 
+		|| blob.getShape().isStatic() 
+		|| blob.hasTag("sawed") 
+		|| blob.hasTag("invincible")
+		|| blob.getTickSinceCreated() < 30)
 	{
 		return false;
 	}

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -156,7 +156,7 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 		|| blob.getShape().isStatic() 
 		|| blob.hasTag("sawed") 
 		|| blob.hasTag("invincible")
-		|| blob.getTickSinceCreated() < 30)
+		|| (blob.hasTag("player") && blob.getTickSinceCreated() < 30)) // fix for getting insta-killed after changing class
 	{
 		return false;
 	}

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -156,7 +156,7 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 		|| blob.getShape().isStatic() 
 		|| blob.hasTag("sawed") 
 		|| blob.hasTag("invincible")
-		|| (blob.hasTag("player") && blob.getTickSinceCreated() < 30)) // fix for getting insta-killed after changing class
+		|| (!blob.hasTag("can be sawed immediately") && blob.getTickSinceCreated() < 30)) // fix for getting insta-killed after changing class
 	{
 		return false;
 	}

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -149,11 +149,21 @@ void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 		//dont travel if caller is attached to something (e.g. siege)
 		if (caller.isAttached())
 			return;
+		
+		// assume destination is center bottom
+		Vec2f position = tunnel.getPosition();
+		position = Vec2f(position.x, position.y + tunnel.getHeight() / 2 - caller.getHeight() / 2);
+		
+		// apply offset (if it exists)
+		if (tunnel.exists("travel offset"))
+		{
+			Vec2f offset = tunnel.get_Vec2f("travel offset");
+			position += tunnel.isFacingLeft() ? -offset : offset;
+		}
 
 		// move caller
-		caller.setPosition(Vec2f(tunnel.getPosition().x, tunnel.getPosition().y + getMap().tilesize));
+		caller.setPosition(position);
 		caller.setVelocity(Vec2f_zero);
-		//caller.getShape().PutOnGround();
 
 		if (caller.isMyPlayer())
 		{

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -151,7 +151,7 @@ void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 			return;
 
 		// move caller
-		caller.setPosition(Vec2f(tunnel.getPosition().x, tunnel.getPosition().y+getMap().tilesize));
+		caller.setPosition(Vec2f(tunnel.getPosition().x, tunnel.getPosition().y + getMap().tilesize));
 		caller.setVelocity(Vec2f_zero);
 		//caller.getShape().PutOnGround();
 

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -151,7 +151,7 @@ void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 			return;
 
 		// move caller
-		caller.setPosition(tunnel.getPosition());
+		caller.setPosition(Vec2f(tunnel.getPosition().x, tunnel.getPosition().y+getMap().tilesize));
 		caller.setVelocity(Vec2f_zero);
 		//caller.getShape().PutOnGround();
 

--- a/Entities/Items/Log/Log.as
+++ b/Entities/Items/Log/Log.as
@@ -22,6 +22,7 @@ void onInit(CBlob@ this)
 		this.set('harvest', harvest);
 	}
 
+	this.Tag("can be sawed immediately");
 	this.Tag("pushedByDoor");
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1540 

Christmas Presents spawning at Pine Tree during the Christmas Event will not get sawed immediately.
Only blobs that have tag "can be sawed immediately" will get sawed right away - only Log has this Tag for now.

-- Older description follows: --

Fixes #1252.

When travelling via tunnel, apply 
`caller.setPosition(Vec2f(tunnel.getPosition().x, tunnel.getPosition().y + getMap().tilesize));` 
instead of `caller.setPosition(tunnel.getPosition());`.
This causes you to be placed slightly below Saw level, so a Saw that stands at a tunnel will not kill you.
In [this image](https://imgur.com/jnw8Ink), a Saw in the third picture will not kill you but a Saw like in the fourth and fifth picture, will kill you.
This is done for logical reasons.
A character who travels to a tunnel like in the 3rd picture should not be falling and a Saw that stands at ground level should not kill any traveller.
The traveller has to actually fall in a Saw to get killed.

Saw will only kill blobs that are created not less than 30 ticks ago.
`blob.getTickSinceCreated() < 30` is applied.
Therefore, if you change class while standing inside a Saw or while holding a Saw, you will not get killed by it after having changed class.

I have tried fixing this issue before.
After adding a check to Saw so only blobs that have a certain downward velocity are killed, some success has been achieved but devs were not satisfied by this. See #1257 
I have also tried applying an immunity span after travelling via tunnel or changing class, but this posed another bag of problems.
A player could spam respawning to become invincible in a TDM_Spawn, a tunnel traveller could not be hurt by attacks when he actually should, and it was not garantueed that the character doesn't get killed by a Saw due to high ping.

## Steps to Test or Reproduce

See the image above and test picture 1, 3, 4 and 5.

## Additional 

Please note that the "tunnel travel" change and the "change class" change, that are both included in this PR, are separate from each other.
If people think that placing a Saw at an enemy tunnel as a tactic should be kept in the game, then that change can be left out without a problem.
I just think it has to take a bit more effort to block an enemy tunnel and therefore added this change.
Please let me know if you want me to change it back.