### PR TITLE
[changed] Invincibility span code clean-up and changes

### DIFF
--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -146,10 +146,10 @@ void onRespawnCommand(CBlob@ this, u8 cmd, CBitStream @params)
 						newBlob.setPosition(caller.getPosition());
 
 						// no extra immunity after class change
-						if (caller.exists("spawn immunity time"))
+						if (caller.exists("immunity ticks"))
 						{
-							newBlob.set_u32("spawn immunity time", caller.get_u32("spawn immunity time"));
-							newBlob.Sync("spawn immunity time", true);
+							newBlob.set_s32("immunity ticks", caller.get_s32("immunity ticks"));
+							newBlob.Sync("immunity ticks", true);
 						}
 
 						caller.Tag("switch class");

--- a/Rules/CommonScripts/SpawnImmunity.as
+++ b/Rules/CommonScripts/SpawnImmunity.as
@@ -1,17 +1,20 @@
-// no damage until action pressed or 5 secs
-// works with UnSpawnImmunity.as on blobs
+// no damage for 3 sec.
+// Depletes faster if key_action1 is pressed.
+// works with UnSpawnImmunity.as on blobs.
 
-const f32 IMMUNITY_SECS = 3;
+const f32 IMMUNITY_SEC = 3;
 
 void onInit(CRules@ this)
 {
-	this.set_f32("immunity sec", IMMUNITY_SECS);
+	this.set_f32("immunity sec", IMMUNITY_SEC);
 }
 
 f32 onPlayerTakeDamage(CRules@ this, CPlayer@ victim, CPlayer@ attacker, f32 DamageScale)
 {
 	CBlob@ victimblob = victim.getBlob();
-	if (victimblob !is null && victimblob.getTickSinceCreated() < getTicksASecond() * IMMUNITY_SECS && victim !is attacker)
+	if (victimblob !is null 
+		&& victimblob.getTickSinceCreated() < getTicksASecond() * IMMUNITY_SEC 
+		&& victim !is attacker)
 	{
 		if (victimblob.hasTag("invincible"))
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

I tried finding a fix for #1252, but abandoned the idea of using invincibility spans.
I still did some cleaning up and other changes that may be interesting, hence this PR.

As a result of rewriting code, I renamed 
`IMMUNITY_SECS` to `IMMUNITY_SEC`,
`"spawn immunity time"` to `"immunity ticks"`
and `immune` to `isImmune`.

**UnSpawnImmunity.as:**

- Instead of saving game time stamps, I save the immunity ticks directly to the blob and deplete it every tick.

- Instead of using a modifier that determines a maximum invincibility span, I make it deplete by 2 if action1 is pressed.

- These checks below have been removed because it doesn't make sense they are in onInit() and appear to be unused.
A newly created blob can't have any tags or set values.
```
if (this.hasTag("invincibility done"))
	{
		return;
	}
```
```
if (!this.exists("spawn immunity time"))
```
As a consequence, removed Tag "invincibility done".
It still works the same way as before when testing offline and online.

Added a check to onTick() instead:
```
if (!this.hasTag("invincible"))
	{
		return;
	}
```

- Still kept `this.getCurrentScript().runFlags |= Script::remove_after_this;` for now. 
But if needed in the future, you could add invincibility span to the character on the go.
Then this line would have to be removed and the script keeps checking if any invincibility has to be handled.

- Updated commenting that explains the code.

## Steps to Test or Reproduce

Go to Sandbox.
Suicide or respawn at a tent.
Notice everything is as before.
If you hold action1, notice the invincibility getting lost faster. (Not the same way as before. Now every keypress matters.)
