### PR TITLE
[dev] fixed staging script breaking non-staging

### DIFF
--- a/Entities/Common/Scripts/OffscreenThrottle.as
+++ b/Entities/Common/Scripts/OffscreenThrottle.as
@@ -8,6 +8,7 @@
 // NOTE: This optimization will *not* be done on servers, but it will be done in localhost.
 //       This is acceptable for vanilla, but you may want to override this behavior in a mod.
 
+#ifdef STAGING
 uint32 throttleDuration(CBlob@ blob)
 {
 	const bool client = isClient(), server = isServer();
@@ -34,7 +35,6 @@ uint32 throttleDuration(CBlob@ blob)
 	return 0;
 }
 
-#ifdef STAGING
 void onTick(CBlob@ blob)
 {
 	blob.throttleInterval = throttleDuration(blob);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`isPointOnScreen(Vec2f, const float)` doesn't exist in vanilla, so scripts with offscreenthrottle.as were breaking

wrapping everything with #ifdef STAGING seems to fix it