### PR TITLE
Resupply improvements

### DIFF
--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -131,6 +131,12 @@ shared class CTFSpawns : RespawnSystem
 				p_info.team = 0;
 			}
 
+			// spawn as builder in warmup
+			if (getRules().isWarmup())
+			{
+				p_info.blob_name = "builder";
+			}
+
 			CBlob@ spawnBlob = getSpawnBlob(p_info);
 
 			if (spawnBlob !is null)

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -131,7 +131,12 @@ void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b)
 	{
 		if (gametime > getCTFTimer(this, p, "archer")) 
 		{
-			if (SetMaterials(b, "mat_arrows", 30)) 
+			CInventory@ inv = b.getInventory();
+			if (inv.isInInventory("mat_arrows", 30)) 
+			{
+				return; // don't give arrows if they have 30 already
+			}
+			else if (SetMaterials(b, "mat_arrows", 30)) 
 			{
 				SetCTFTimer(this, p, gametime + (this.isWarmup() ? materials_wait_warmup : materials_wait)*getTicksASecond(), "archer");
 			}
@@ -284,9 +289,6 @@ void onTick(CRules@ this)
 				string class_name = overlapped.getName();
 				
 				if (isShop && name.find(class_name) == -1) continue; // NOTE: builder doesn't get wood+stone at archershop, archer doesn't get arrows at buildershop
-
-				CInventory@ inv = overlapped.getInventory();
-				if (inv.isInInventory("mat_arrows", 30) && class_name == "archer") continue; // don't give arrows if they have 30 already
 
 				doGiveSpawnMats(this, p, overlapped);
 			}

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -18,7 +18,7 @@ const string SPAWN_ITEMS_TIMER_ARCHER  = "CTF SpawnItems Archer:";
 
 string base_name() { return "tent"; }
 
-bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
+bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity, bool drop = false)
 {
 	CInventory@ inv = blob.getInventory();
 	
@@ -37,7 +37,7 @@ bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity)
 		
 		mat.server_SetQuantity(quantity);
 		
-		if (not blob.server_PutInInventory(mat))
+		if (drop || not blob.server_PutInInventory(mat))
 		{
 			mat.setPosition(blob.getPosition());
 		}
@@ -114,9 +114,11 @@ void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b)
 				wood_amount = warmup_wood_amount;
 				stone_amount = warmup_stone_amount;
 			}
+
+			bool drop_mats = (name != "builder");
 			
-			bool did_give_wood = SetMaterials(b, "mat_wood", wood_amount);
-			bool did_give_stone = SetMaterials(b, "mat_stone", stone_amount);
+			bool did_give_wood = SetMaterials(b, "mat_wood", wood_amount, drop_mats);
+			bool did_give_stone = SetMaterials(b, "mat_stone", stone_amount, drop_mats);
 			
 			if (did_give_wood || did_give_stone)
 			{
@@ -124,7 +126,8 @@ void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b)
 			}
 		}
 	} 
-	else if (name == "archer") 
+
+	if (name == "archer") 
 	{
 		if (gametime > getCTFTimer(this, p, "archer")) 
 		{
@@ -142,8 +145,6 @@ void displayResupply(CRules@ this, string player_class, string resupply_class, V
 
 	u32 secs = ((next_items - 1 - getGameTime()) / getTicksASecond()) + 1;
 	string units = ((secs != 1) ? " seconds" : " second");
-
-	SColor color = SColor(200, 135, 185, 45);
 
 	string resupply_available;
 	string resupply_unavailable;
@@ -181,25 +182,30 @@ void displayResupply(CRules@ this, string player_class, string resupply_class, V
 			.replace("{WOOD}", "" + wood_amount)
 			.replace("{STONE}", "" + stone_amount);
 	}
-
-	// this is shown on upper center of screen
-	string text = resupply_available;
-
-	float x = getScreenWidth() / 3 + offset.x;
-	float y = getScreenHeight() - offset.y;
 		
-	// this is shown above inventory GUI
+	// Unavailable resupply - shown on upper center of screen
 	if (next_items > getGameTime())
 	{
-		color = SColor(255, 255, 55, 55);
+		SColor color = SColor(255, 255, 55, 55);
 			
-		text = resupply_unavailable;
+		string text = resupply_unavailable;
 
-		x = getScreenWidth() / 2;
-		y = getScreenHeight() / 3 - offset_second.y;
+		float x = getScreenWidth() / 2;
+		float y = getScreenHeight() / 3 - offset_second.y;
+
+		GUI::DrawTextCentered(text, Vec2f(x, y), color);
 	}
-	
-	GUI::DrawTextCentered(text, Vec2f(x, y), color);
+	else if (this.getCurrentState() == GAME) // Available resupply & not warmup - shown above inventory GUI
+	{
+		SColor color = SColor(200, 135, 185, 45);
+
+		string text = resupply_available;
+
+		float x = getScreenWidth() / 3 + offset.x;
+		float y = getScreenHeight() - offset.y;
+
+		GUI::DrawTextCentered(text, Vec2f(x, y), color);
+	}
 }
 
 // normal hooks
@@ -274,9 +280,14 @@ void onTick(CRules@ this)
 				if (!overlapped.hasTag("player")) continue;
 				CPlayer@ p = overlapped.getPlayer();
 				if (p is null) continue;
+
+				string class_name = overlapped.getName();
 				
-				if (isShop && name.find(overlapped.getName()) == -1) continue; // NOTE(hobey): builder doesn't get wood+stone at archershop, archer doesn't get arrows at buildershop
-					
+				if (isShop && name.find(class_name) == -1) continue; // NOTE: builder doesn't get wood+stone at archershop, archer doesn't get arrows at buildershop
+
+				CInventory@ inv = overlapped.getInventory();
+				if (inv.isInInventory("mat_arrows", 30) && class_name == "archer") continue; // don't give arrows if they have 30 already
+
 				doGiveSpawnMats(this, p, overlapped);
 			}
 		}

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -188,8 +188,7 @@ void displayResupply(CRules@ this, string player_class, string resupply_class, V
 			.replace("{STONE}", "" + stone_amount);
 	}
 		
-	// Unavailable resupply - shown on upper center of screen
-	if (next_items > getGameTime())
+	if (next_items > getGameTime()) // Unavailable resupply - shown on upper center of screen
 	{
 		SColor color = SColor(255, 255, 55, 55);
 			


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes the following issues with current base's state of resupplies (Rebuild version):
- knights and archers inbuild time receive mats in their inventories, newbies may not pay enough attention and give a shitton of mats to the enemy when they die (mats drop on ground now if you're not builder)
- archers at build time don't get arrows at all which is generally ok but it means they have to wait for the match start to get arrows at a resupply point (now you get arrows in build time too)
- if you afk as an archer at a resupply point your resupply counter gets reset and you hear the resupply sound even if you already have 30 arrows (no longer happens)

Moreover, everyone is now switched to builder when a new match starts.

Also, the above-inventory text when you're able to get resupplies now no longer shows in build time (since it's automatic regardless of where you are)