### PR TITLE
 Trampoline has 360 rotation + Help.as, DrawHelp.as minor changes

### DIFF
--- a/Entities/Common/Help/DrawHelp.as
+++ b/Entities/Common/Help/DrawHelp.as
@@ -71,11 +71,11 @@ void onTick(CSprite@ this)
 		doSave();
 		return;
 	}
-	if (!u_showtutorial)
+	/*if (!u_showtutorial)
 	{
 		doSave();
 		return;
-	}
+	}*/
 
 	CBlob@ blob = this.getBlob();
 	const u32 gametime = getGameTime();
@@ -487,44 +487,46 @@ void onRender(CSprite@ this)
 	Vec2f offset(52.0f, getDriver().getScreenHeight() - 68.0f);
 
 	CBlob@ blob = this.getBlob();
-	if (u_showtutorial)
+
+	int count = 0;
+
+	// render helps
+
+	const int size = renderHelps.size();
+	for (int i = size - 1; i >= 0; i--)
 	{
-		int count = 0;
-
-		// render helps
-
-		const int size = renderHelps.size();
-		for (int i = size - 1; i >= 0; i--)
+		if (renderHelps[i].showAlways == true || u_showtutorial)
 		{
 			offset = DrawHelp(blob, renderHelps[i], offset);
 		}
+	}
 
-		// draw item captions
+	// draw item captions
 
+	if (u_showtutorial)
+	{
+		if (getHUD().menuState == 0 && !getHUD().hasButtons() && !getHUD().hasMenus() &&
+		        !blob.isKeyPressed(key_left) && !blob.isKeyPressed(key_right) &&
+		        !blob.isKeyPressed(key_up) && !blob.isKeyPressed(key_action1) &&
+		        !blob.isKeyPressed(key_down) && !blob.isKeyPressed(key_action2) &&
+		        !blob.isKeyPressed(key_pickup) && !blob.isKeyPressed(key_inventory)
+		   )
 		{
-			if (getHUD().menuState == 0 && !getHUD().hasButtons() && !getHUD().hasMenus() &&
-			        !blob.isKeyPressed(key_left) && !blob.isKeyPressed(key_right) &&
-			        !blob.isKeyPressed(key_up) && !blob.isKeyPressed(key_action1) &&
-			        !blob.isKeyPressed(key_down) && !blob.isKeyPressed(key_action2) &&
-			        !blob.isKeyPressed(key_pickup) && !blob.isKeyPressed(key_inventory)
-			   )
+			CBlob@ mouseBlob = getMap().getBlobAtPosition(getControls().getMouseWorldPos());
+			if (mouseBlob !is null && (!mouseBlob.hasTag("player") || mouseBlob.hasTag("migrant")))
 			{
-				CBlob@ mouseBlob = getMap().getBlobAtPosition(getControls().getMouseWorldPos());
-				if (mouseBlob !is null && (!mouseBlob.hasTag("player") || mouseBlob.hasTag("migrant")))
-				{
-					string invName = getTranslatedString(mouseBlob.getInventoryName());
-					Vec2f dimensions;
-					GUI::SetFont("menu");
-					GUI::GetTextDimensions(invName, dimensions);
-					GUI::DrawText(invName, getDriver().getScreenPosFromWorldPos(mouseBlob.getPosition() - Vec2f(0, -mouseBlob.getHeight() / 2)) - Vec2f(dimensions.x / 2, -8.0f), color_white);					//	mouseBlob.RenderForHUD( RenderStyle::outline_front );
-				}
+				string invName = getTranslatedString(mouseBlob.getInventoryName());
+				Vec2f dimensions;
+				GUI::SetFont("menu");
+				GUI::GetTextDimensions(invName, dimensions);
+				GUI::DrawText(invName, getDriver().getScreenPosFromWorldPos(mouseBlob.getPosition() - Vec2f(0, -mouseBlob.getHeight() / 2)) - Vec2f(dimensions.x / 2, -8.0f), color_white);					//	mouseBlob.RenderForHUD( RenderStyle::outline_front );
 			}
 		}
 	}
 
 	// draw arrow for noobs
 
-	if (showHelpHelp)
+	if (showHelpHelp && u_showtutorial)
 	{
 		int bounce = 4 * Maths::Sin((getGameTime() + blob.getNetworkID()) / 4.5f);
 		Vec2f upperleft = offset + Vec2f(-30.0f, -199.0f + bounce);
@@ -560,7 +562,7 @@ Vec2f DrawHelpText(const string &in text, Vec2f offset, f32 donePercent, const b
 	GUI::SetFont("menu");
 	GUI::GetTextDimensions(text, dim);
 	Vec2f ul = Vec2f(pos.x - 50, y - 18.0f);
-	Vec2f lr = Vec2f(pos.x + 180.0f, y + 18.0f);
+	Vec2f lr = Vec2f(pos.x + 240.0f, y + 18.0f);
 	if (drawBackground)
 	{
 		if (!drawGlow)

--- a/Entities/Common/Help/Help.as
+++ b/Entities/Common/Help/Help.as
@@ -11,7 +11,7 @@ shared class HelpText
 	u32 usedCount;
 	f32	fadeOut;
 	Vec2f drawSize;
-
+	bool showAlways;
 
 	HelpText()
 	{
@@ -21,11 +21,8 @@ shared class HelpText
 };
 
 // altText - when not recipient
-HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient, const string &in text, const string &in altText = "")
+HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient, const string &in text, const string &in altText = "", bool showAlways = false)
 {
-	if (!u_showtutorial)
-		return null;
-
 	if (!getNet().isClient())
 		return null;
 
@@ -44,6 +41,7 @@ HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient
 	ht.text = text;
 	ht.altText = altText;
 	ht.reduceAfterTimes = 1;
+	ht.showAlways = showAlways;
 	this.push(HELPS_ARRAY, ht);
 
 	HelpText@ p_ref;
@@ -51,11 +49,8 @@ HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient
 	return p_ref;
 }
 
-HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient, const string &in text, const string &in altText, const u32 reduceAfterTimes)
+HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient, const string &in text, const string &in altText, const u32 reduceAfterTimes, bool showAlways = false)
 {
-	if (!u_showtutorial)
-		return null;
-
 	if (!getNet().isClient())
 		return null;
 
@@ -74,6 +69,7 @@ HelpText@ SetHelp(CBlob@ this, const string &in name, const string &in recipient
 	ht.text = text;
 	ht.altText = altText;
 	ht.reduceAfterTimes = reduceAfterTimes;
+	ht.showAlways = showAlways;
 	this.push(HELPS_ARRAY, ht);
 
 	HelpText@ p_ref;
@@ -146,9 +142,6 @@ bool hasHelp(CBlob@ this, const string &in name)
 
 void RemoveHelps(CBlob@ this, const string &in name)
 {
-	if (!u_showtutorial)
-		return;
-
 	if (!getNet().isClient())
 		return;
 

--- a/Entities/Structures/Trampoline/Trampoline.cfg
+++ b/Entities/Structures/Trampoline/Trampoline.cfg
@@ -2,7 +2,6 @@
 
 $sprite_factory                                   = generic_sprite
 @$sprite_scripts                                  = Wooden.as;
-													TrampolineLogic.as;
 $sprite_texture                                   = Trampoline.png
 s32_sprite_frame_width                            = 32
 s32_sprite_frame_height                           = 16

--- a/Entities/Structures/Trampoline/Trampoline.cfg
+++ b/Entities/Structures/Trampoline/Trampoline.cfg
@@ -2,6 +2,7 @@
 
 $sprite_factory                                   = generic_sprite
 @$sprite_scripts                                  = Wooden.as;
+													TrampolineLogic.as;
 $sprite_texture                                   = Trampoline.png
 s32_sprite_frame_width                            = 32
 s32_sprite_frame_height                           = 16

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -1,3 +1,5 @@
+#include "Help.as";
+
 namespace Trampoline
 {
 	const string TIMER = "trampoline_timer";
@@ -151,9 +153,18 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 // for help text
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
-	if (!attached.hasTag("player")) return;
+	if (!attached.isMyPlayer()) return;
 
-	this.set_s32("attachtime", getGameTime());
+	SetHelp(attached, "trampoline help lmb", "", getTranslatedString("$trampoline$ Lock to 45° steps  $KEY_HOLD$$LMB$"), "", 3, true);
+	SetHelp(attached, "trampoline help rmb", "", getTranslatedString("$trampoline$ Lock current angle  $KEY_HOLD$$RMB$"), "", 3, true);
+}
+
+void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
+{
+	if (!detached.isMyPlayer()) return;
+
+	RemoveHelps(detached, "trampoline help lmb");
+	RemoveHelps(detached, "trampoline help rmb");
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
@@ -164,64 +175,4 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {
 	return !this.hasTag("no pickup");
-}
-
-void onRender(CSprite@ this)
-{
-	if (g_videorecording) return;
-
-	CBlob@ blob = this.getBlob();
-
-	if (!blob.isAttached()) return;
-
-	CAttachment@ attachment = blob.getAttachments();
-
-	AttachmentPoint@ ap = attachment.getAttachmentPointByName("PICKUP");
-
-	CBlob@ playerblob = ap.getOccupied();
-
-	CControls@ controls = playerblob.getControls();
-
-	if (controls is null) return;
-
-	GUI::SetFont("menu");
-
-	string lmb = getTranslatedString(controls.getActionKeyKeyName(AK_ACTION1));
-	string rmb = getTranslatedString(controls.getActionKeyKeyName(AK_ACTION2));
-	string help_text = getTranslatedString(
-		"Hold {KEY1} to lock trampoline rotation to 45 degree steps\n\nHold {KEY2} to lock angle")
-	.replace("{KEY1}", lmb).replace("{KEY2}", rmb);
-
-	Vec2f text_dim;
-	GUI::GetTextDimensions(help_text, text_dim);
-
-	Vec2f offset = Vec2f(20, 80);
-	float x = getScreenWidth() / 3 + offset.x;
-	float y = getScreenHeight() - offset.y;
-
-	Vec2f drawpos = getDriver().getScreenCenterPos() - Vec2f(0, 240);
-
-	drawpos = Vec2f(x, y);
-
-	int ticks_since_pickup = getGameTime() - this.getBlob().get_s32("attachtime");
-
-	int alpha = 255;
-
-	if (ticks_since_pickup >= 5 * getTicksASecond())
-	{
-		alpha = Maths::Max(0, alpha - Maths::Pow((ticks_since_pickup - 5 * getTicksASecond()), 1.75));
-	}
-
-	SColor color_text = SColor(alpha, 255, 255, 255);
-	SColor color_pane = SColor(alpha, 200, 200, 200);
-
-	GUI::DrawPane(
-		Vec2f(drawpos.x - text_dim.x / 2 - 5, drawpos.y - text_dim.y / 2 - 5), 
-		Vec2f(drawpos.x + text_dim.x / 2 + 5, drawpos.y + text_dim.y / 2 + 5),
-		color_pane);
-
-	GUI::DrawTextCentered(help_text,
-			              drawpos,
-			              color_text);
-
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Steps to Test or Reproduce

When held, trampoline freely rotates like drill.
Holding lmb makes it rotate in 45 degree steps, and holding rmb prevents it from rotating completely (allows players to throw tramps at any angles in different directions and place horizontal tramps more easily)
(same as https://github.com/transhumandesign/kag-base/pull/1074)

Help.as, DrawHelp.as changes:
Increased width of help pane by 33%
Now you can add things to the help system that are ALWAYS drawn (don't need f1 mode turned on for it)
Added trampoline controls explanation to it (TrampolineLogic.as onAttach, onDetach)
