### PR TITLE
[fixed] Solid tile repair when obstructed by ladder

### DIFF
--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -86,6 +86,18 @@ bool serverTileCheck(CBlob@ blob, u8 tileIndex, Vec2f cursorPos)
 		return false;
 	}
 
+	if ((blockToPlace.tile == CMap::tile_wood && backtile.type >= CMap::tile_wood_d1 && backtile.type <= CMap::tile_wood_d0) ||
+			(blockToPlace.tile == CMap::tile_castle && backtile.type >= CMap::tile_castle_d1 && backtile.type <= CMap::tile_castle_d0))
+	{
+		//repair like tiles
+		return true;
+	}
+	else if (blockToPlace.tile == CMap::tile_castle && backtile.type >= CMap::tile_wood && backtile.type <= CMap::tile_wood_d0 && !map.isInFire(cursorPos))
+	{
+		// can build stone on wood when not on fire, do nothing
+		return true;
+	}
+
 	// Are we trying to place a solid tile on a door/ladder/platform/bridge (usually due to lag)?
 	if (fakeHasTileSolidBlobs(cursorPos) && map.isTileSolid(blockToPlace.tile))
 	{

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -85,10 +85,12 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 			(buildTile == CMap::tile_castle && backtile.type >= CMap::tile_castle_d1 && backtile.type <= CMap::tile_castle_d0))
 	{
 		//repair like tiles
+		return true;
 	}
 	else if (buildTile == CMap::tile_castle && backtile.type >= CMap::tile_wood && backtile.type <= CMap::tile_wood_d0 && !map.isInFire(p))
 	{
 		// can build stone on wood when not on fire, do nothing
+		return true;
 	}
 	else if (buildTile == CMap::tile_wood_back && backtile.type == CMap::tile_castle_back)
 	{


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

A fix for #1365 issue, allows you to repair solid tiles that overlap with ladder.

## Steps to Test or Reproduce

Build a scene like [this](https://imgur.com/a/wnOMmvX). You will now be able to repair these tiles.
