### PR TITLE
[fixed] Player not taking damage when taking fire hits in quick succession

### DIFF
--- a/Entities/Common/FireScripts/FireCommon.as
+++ b/Entities/Common/FireScripts/FireCommon.as
@@ -44,6 +44,9 @@ void server_setFireOff(CBlob@ this)
 
 	this.set_s16(burn_timer, 0);
 	this.Sync(burn_timer, true);
+	
+	this.set_s16(burn_counter, 0);
+	this.Sync(burn_counter, true);
 
 	if (this.hasTag("had only fire flag"))
 		this.getCurrentScript().runFlags |= Script::tick_infire;

--- a/Entities/Common/FireScripts/FireCommon.as
+++ b/Entities/Common/FireScripts/FireCommon.as
@@ -9,6 +9,8 @@ const string burn_timer = "burn timer";
 const string burning_tag = "burning";
 const string spread_fire_tag = "spread fire";
 
+const string burn_counter = "burn counter";
+
 const int fire_wait_ticks = 4;
 const int burn_thresh = 70;
 

--- a/Entities/Common/FireScripts/IsFlammable.as
+++ b/Entities/Common/FireScripts/IsFlammable.as
@@ -86,6 +86,7 @@ void onTick(CBlob@ this)
 	//burnination
 	else if (burn_time > 0)
 	{
+		s16 burn_count = this.get_s16(burn_counter);
 		burn_count++;
 	
 		//burninating the other tiles

--- a/Entities/Common/FireScripts/IsFlammable.as
+++ b/Entities/Common/FireScripts/IsFlammable.as
@@ -86,14 +86,16 @@ void onTick(CBlob@ this)
 	//burnination
 	else if (burn_time > 0)
 	{
+		burn_count++;
+	
 		//burninating the other tiles
-		if ((burn_time % 8) == 0 && this.hasTag(spread_fire_tag))
+		if ((burn_count % 8) == 0 && this.hasTag(spread_fire_tag))
 		{
 			BurnRandomNear(pos);
 		}
 
 		//burninating the actor
-		if ((burn_time % 7) == 0)
+		if ((burn_count % 7) == 0)
 		{
 			uint16 netid = this.get_netid("burn starter player");
 			CBlob@ blob = null;
@@ -113,8 +115,9 @@ void onTick(CBlob@ this)
 		//burninating the burning time
 		burn_time--;
 
-		//and making sure it's set correctly!
+		//making sure to set values correctly
 		this.set_s16(burn_timer, burn_time);
+		this.set_s16(burn_counter, burn_count);
 	}
 
 	// (flax roof cottages!)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1368.

If applying `blob.server_Hit(blob, blob.getPosition(), blob.getVelocity(), 0.0f, Hitters::fire);` in a too quick succession (such as every 10th tick), the affected player won't take any damage.

In `IsFlammable.as` in `onTick()`, after `else if (burn_time > 0)`, the value `burn_time` is used to determine if damage should be applied. If `burn_time % 7 == 0` is true, then the damage is applied. Since repeatedly applying `blob.server_Hit()` will reset `burn_time`, the condition can never become true.

I implemented a new value `burn_count`.
This value is incremented by one when entering the `else if (burn_time > 0)` section.
The previous condition `burn_time % 7 == 0` has been replaced by `burn_count % 7 == 0`.
Since `burn_count` is independent, the player can take damage even when `blob.server_Hit()` is repeatedly applied.

Tested in offline and online and it works as it should.

## Steps to Test or Reproduce

There is no readily available means to test this in-game.
You can set up your own testing script or you can test this in conjunction with PR #1371 , which adds a fire mechanism component that repeatedly applies the aforementioned `blob.server_Hit()`.