### PR TITLE
[fixed] corpse making a grunt when falling

### DIFF
--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -57,7 +57,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 		// stun on fall
 		const u8 knockdown_time = 12;
 
-		if (doknockdown && setKnocked(this, knockdown_time))
+		if (!this.hasTag("dead") && doknockdown && setKnocked(this, knockdown_time))
 		{
 			if (damage < this.getHealth()) //not dead
 				Sound::Play("/BreakBone", this.getPosition());

--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -5,6 +5,8 @@
 #include "KnockedCommon.as";
 #include "FallDamageCommon.as";
 
+const u8 knockdown_time = 12;
+
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
 	if (!solid || this.isInInventory())
@@ -54,10 +56,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			}
 		}
 
-		// stun on fall
-		const u8 knockdown_time = 12;
-
-		if (!this.hasTag("dead") && doknockdown && setKnocked(this, knockdown_time))
+		if (getGameTime() == this.get_u32("death sound time stamp") && doknockdown && setKnocked(this, knockdown_time))
 		{
 			if (damage < this.getHealth()) //not dead
 				Sound::Play("/BreakBone", this.getPosition());
@@ -66,5 +65,13 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 				Sound::Play("/FallDeath.ogg", this.getPosition());
 			}
 		}
+	}
+}
+
+void onHealthChange(CBlob@ this, f32 health_old)
+{
+	if (health_old > 0.0f)
+	{
+		this.set_u32("death sound time stamp", getGameTime());
 	}
 }

--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -56,7 +56,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			}
 		}
 
-		if (getGameTime() == this.get_u32("death sound time stamp") && doknockdown && setKnocked(this, knockdown_time))
+		if (this.get_bool("play fall damage sound") && doknockdown && setKnocked(this, knockdown_time))
 		{
 			if (damage < this.getHealth()) //not dead
 				Sound::Play("/BreakBone", this.getPosition());
@@ -72,6 +72,10 @@ void onHealthChange(CBlob@ this, f32 health_old)
 {
 	if (health_old > 0.0f)
 	{
-		this.set_u32("death sound time stamp", getGameTime());
+		this.set_bool("play fall damage sound", true);
+	}
+	else
+	{
+		this.set_bool("play fall damage sound", false);
 	}
 }

--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -7,6 +7,11 @@
 
 const u8 knockdown_time = 12;
 
+void onInit(CBlob@ this)
+{
+	this.getCurrentScript().tickIfTag = "dead";
+}
+
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
 	if (!solid || this.isInInventory())
@@ -56,9 +61,12 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			}
 		}
 
-		if (this.get_bool("play fall damage sound") && doknockdown && setKnocked(this, knockdown_time))
-		{
-			if (damage < this.getHealth()) //not dead
+		if (doknockdown)
+			setKnocked(this, knockdown_time);
+
+		if (!this.hasTag("should be silent"))
+		{				
+			if (this.getHealth() > damage) //not dead
 				Sound::Play("/BreakBone", this.getPosition());
 			else
 			{
@@ -68,14 +76,8 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	}
 }
 
-void onHealthChange(CBlob@ this, f32 health_old)
+void onTick(CBlob@ this)
 {
-	if (health_old > 0.0f)
-	{
-		this.set_bool("play fall damage sound", true);
-	}
-	else
-	{
-		this.set_bool("play fall damage sound", false);
-	}
+	this.Tag("should be silent");
+	this.getCurrentScript().tickFrequency = 0;
 }


### PR DESCRIPTION
## Status

- **Fixed**
- No known issues.

## Description

Fixes #1382.

A dead player could make a grunt when fallen from a high place.
If you keep throwing the same corpse, instead of the grunt it could make a broken bone sfx.

This PR checks if the player is actually dead by checking for `hasTag("dead")` before playing 
`Sound::Play("/BreakBone", this.getPosition());` or `Sound::Play("/FallDeath.ogg", this.getPosition());`.
Tested in offline, should work in online.

## Steps to Test or Reproduce

Go to Sandbox.
Place one ladder on the ground, then have spikes fall on you to kill yourself.
Pick up your own corpse, climb to a high place and throw your corpse to the ground.
If done correctly, should make a grunt sound or a break bone sfx. 
--> **After this PR, it doesn't make any sound.**