### PR TITLE
[added] Shake screen when close to a Keg, or when hit by an explosive…

### DIFF
--- a/Entities/Characters/Archer/Archer.cfg
+++ b/Entities/Characters/Archer/Archer.cfg
@@ -164,6 +164,7 @@ $inventory_name                                   = Backpack
 $name                                             = archer
 @$scripts                                         = RunnerDefault.as;
 													StandardControls.as;
+                                                    ScreenShakeOnHit.as;
 													StandardPickup.as;
 													ActivateHeldObject.as;
 													RunnerActivateable.as;

--- a/Entities/Characters/Builder/Builder.cfg
+++ b/Entities/Characters/Builder/Builder.cfg
@@ -219,6 +219,7 @@ $inventory_name                                   = Backpack
 $name                                             = builder
 @$scripts                                         = RunnerDefault.as;
                                                     StandardControls.as;
+                                                    ScreenShakeOnHit.as;
                                                     StandardPickup.as;
                                                     ActivateHeldObject.as;
                                                     RunnerActivateable.as;

--- a/Entities/Characters/Knight/Knight.cfg
+++ b/Entities/Characters/Knight/Knight.cfg
@@ -302,6 +302,7 @@ $inventory_name                                   = Backpack
 $name                                             = knight
 @$scripts                                         = RunnerDefault.as;
                                                     StandardControls.as;
+                                                    ScreenShakeOnHit.as;
                                                     StandardPickup.as;
                                                     ActivateHeldObject.as;
                                                     RunnerActivateable.as;

--- a/Entities/Common/Attacks/ScreenShakeOnHit.as
+++ b/Entities/Common/Attacks/ScreenShakeOnHit.as
@@ -1,0 +1,22 @@
+#define CLIENT_ONLY
+
+
+#include "Hitters.as"
+
+f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
+{
+    if (isExplosionHitter(customData) && this is getLocalPlayerBlob() && getCamera() !is null)
+    {
+        Vec2f pos;
+        if (hitterBlob !is null)
+            pos = hitterBlob.getPosition();
+        else
+            pos = worldPoint;
+        
+        // screen shake intensity depending on damage
+        // bombs do 3 damage
+        ShakeScreen(50, damage * 4, pos);
+    }
+
+    return damage;
+}

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -93,6 +93,38 @@ void Boom(CBlob@ this)
 {
 	this.server_SetHealth(-1.0f);
 	this.server_Die();
+
+	if (getNet().isClient()) {
+		// screenshake when close to a Keg
+
+		CBlob @blob = getLocalPlayerBlob();
+		CPlayer @player = getLocalPlayer();
+		Vec2f pos;
+
+	    CCamera @camera = getCamera();
+		if (camera !is null) {
+			
+			// If the player is a spectating, base their location off of their camera.	
+			if (player !is null && player.getTeamNum() == getRules().getSpectatorTeamNum())
+			{
+				pos = camera.getPosition();
+			}
+			else if (blob !is null)
+			{
+				pos = blob.getPosition();
+			} 
+			else 
+			{
+				return;
+			}
+
+			pos -= this.getPosition();
+			f32 dist = pos.Length();
+			if (dist < 300) {
+				ShakeScreen(200, 60, this.getPosition());
+			}
+		}
+	}
 }
 
 f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)

--- a/GUI/guiSettings.xml
+++ b/GUI/guiSettings.xml
@@ -1037,7 +1037,7 @@
 				<attributes>
 					<int name="Id" value="-1" />
 					<string name="Caption" value="Language (EXPERIMENTAL):" />
-					<rect name="Rect" value="40, 410, 280, 440" />
+					<rect name="Rect" value="40, 460, 280, 490" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1070,7 +1070,7 @@
 				<attributes>
 					<int name="Id" value="13570" />
 					<string name="Caption" value="" />
-					<rect name="Rect" value="40, 440, 280, 480" />
+					<rect name="Rect" value="40, 490, 280, 530" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1118,9 +1118,32 @@
 			<element type="checkBox">
 
 				<attributes>
+					<int name="Id" value="13515" />
+					<string name="Caption" value="Disable screen shake" />
+					<rect name="Rect" value="40, 110, 250, 140" />
+					<position name="MinSize" value="1, 1" />
+					<position name="MaxSize" value="0, 0" />
+					<enum name="LeftAlign" value="upperLeft" />
+					<enum name="RightAlign" value="upperLeft" />
+					<enum name="TopAlign" value="upperLeft" />
+					<enum name="BottomAlign" value="upperLeft" />
+					<bool name="Visible" value="true" />
+					<bool name="Enabled" value="true" />
+					<bool name="TabStop" value="true" />
+					<bool name="TabGroup" value="false" />
+					<int name="TabOrder" value="8" />
+					<bool name="NoClip" value="false" />
+					<bool name="Checked" value="false" />
+				</attributes>
+
+			</element>
+
+			<element type="checkBox">
+
+				<attributes>
 					<int name="Id" value="13520" />
 					<string name="Caption" value="Kids safe" />
-					<rect name="Rect" value="40, 110, 200, 140" />
+					<rect name="Rect" value="40, 160, 200, 190" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1143,7 +1166,7 @@
 				<attributes>
 					<int name="Id" value="13525" />
 					<string name="Caption" value="Chat Filter" />
-					<rect name="Rect" value="40, 160, 250, 190" />
+					<rect name="Rect" value="40, 210, 250, 240" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1167,7 +1190,7 @@
 				<attributes>
 					<int name="Id" value="13540" />
 					<string name="Caption" value="Show Team-Mates Names" />
-					<rect name="Rect" value="40, 210, 250, 240" />
+					<rect name="Rect" value="40, 250, 250, 290" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1190,7 +1213,7 @@
 				<attributes>
 					<int name="Id" value="13530" />
 					<string name="Caption" value="Show Minimap" />
-					<rect name="Rect" value="40, 250, 250, 290" />
+					<rect name="Rect" value="40, 300, 250, 340" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1213,7 +1236,7 @@
 				<attributes>
 					<int name="Id" value="13550" />
 					<string name="Caption" value="Show Chat Bubbles" />
-					<rect name="Rect" value="40, 300, 250, 340" />
+					<rect name="Rect" value="40, 350, 250, 390" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />
@@ -1236,7 +1259,7 @@
 				<attributes>
 					<int name="Id" value="13560" />
 					<string name="Caption" value="Snap Camera To Pixel" />
-					<rect name="Rect" value="40, 350, 250, 390" />
+					<rect name="Rect" value="40, 400, 250, 440" />
 					<position name="MinSize" value="1, 1" />
 					<position name="MaxSize" value="0, 0" />
 					<enum name="LeftAlign" value="upperLeft" />


### PR DESCRIPTION
> ## Status
> 
> - **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
> 
> ## Description
> 
> Add screenshake (existing `ShakeScreen` hook) when close to a Keg, or when hit by an explosive. Includes GUI change to disable screenshake. Ideally should be paired with the Engine screenshake PR #191 so the settings menu has a working disable button.
> 
> For some eye-candy, see: https://discord.com/channels/337250580303052801/337265406001807360/843454986264641536

Stolen from Nananas, moved from Gitea because I am being trolled by the protected master branch for some reason (and this makes it easier to track).