### PR TITLE
Catapulted boulders fragment into catapult rocks on collision

### DIFF
--- a/Entities/Effects/Scripts/MakeDustParticle.as
+++ b/Entities/Effects/Scripts/MakeDustParticle.as
@@ -8,3 +8,19 @@ void MakeDustParticle(Vec2f pos, string file)
 		temp.height = 8;
 	}
 }
+
+void MakeRockDustParticle(Vec2f pos, string file, Vec2f vel=Vec2f(0.0, 0.0), int animate_speed = 4)
+{
+	Random _r(XORRandom(9999)); // pain
+	CParticle@ temp = ParticleAnimated(CFileMatcher(file).getFirst(), pos, vel, 0.0f, 1.0f, animate_speed, 0.0f, false);
+
+	if (temp !is null)
+	{
+		temp.rotation = Vec2f(-1, 0);
+		temp.rotation.RotateBy(_r.NextFloat() * 360.0f);
+		temp.rotates = true;
+
+		temp.width = 8;
+		temp.height = 8;
+	}
+}

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -253,10 +253,10 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _charge
 
 		if (bullet.getName() == "boulder") // rock n' roll baby
 		{
-			bullet.getShape().getConsts().mapCollisions = false;
-			bullet.getShape().getConsts().collidable = false;
+			bullet.Tag("fragment on collide");
+			bullet.server_setTeamNum(this.getTeamNum());
 		}
-		if (bullet.hasTag("player"))
+		else if (bullet.hasTag("player"))
 		{
 			shot_player = true;
 		}

--- a/Entities/Vehicles/Catapult/Rock.as
+++ b/Entities/Vehicles/Catapult/Rock.as
@@ -37,6 +37,8 @@ void onInit(CBlob@ this)
 		this.getShape().getConsts().net_threshold_multiplier = 4.0f;
 		this.set_u32("last collided tile", -1);
 	}
+
+	this.Tag("can ricochet");
 }
 
 void onTick(CBlob@ this)
@@ -78,21 +80,6 @@ void onTick(CBlob@ this)
 	}
 
 	Pierce(this);
-}
-
-void MakeRockDustParticle(Vec2f pos, string file, Vec2f vel=Vec2f(0.0, 0.0), int animate_speed = 4)
-{
-	CParticle@ temp = ParticleAnimated(CFileMatcher(file).getFirst(), pos, vel, 0.0f, 1.0f, animate_speed, 0.0f, false);
-
-	if (temp !is null)
-	{
-		temp.rotation = Vec2f(-1, 0);
-		temp.rotation.RotateBy(_r.NextFloat() * 360.0f);
-		temp.rotates = true;
-
-		temp.width = 8;
-		temp.height = 8;
-	}
 }
 
 bool canHitBlob(CBlob@ this, CBlob@ blob)
@@ -295,7 +282,7 @@ void Pierce(CBlob @this)
 
 				// though if we're the client... we honestly don't really have a way to tell.
 				// so if we're the client, assume it's a ricochet and let the resync occur if we were wrong
-				ricochet = map.getTile(tilepos).type != 0 || !isServer();
+				ricochet = this.hasTag("can ricochet") && (map.getTile(tilepos).type != 0 || !isServer());
 
 				if (ricochet)
 				{


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

Right now, boulders shot by catapults pierce through towers in a rather weird and glitchy way, which players generally dislike. Plus, it feels even more unbalanced now given the siege rebalance.

The idea behind this PR is to instead make boulders shot by catapults fragment into a bunch of weak cata rocks (which cannot ricochet) with good precision **on impact** (meaning it doesn't break nearby backwalls except on collision). This makes boulders an alternative to catapult rocks with slightly higher precision.

Though, due to the rebalance, the cost of a boulder and a cata shot is roughly the same (29 vs 35). It is difficult to make boulders an interesting option that is not OP but feels different...