### PR TITLE
[fixed] Fix that"gold will decay over time" wasn't working

### DIFF
--- a/Entities/Materials/Construction/MaterialGold.cfg
+++ b/Entities/Materials/Construction/MaterialGold.cfg
@@ -60,6 +60,7 @@ $name                                  = mat_gold
 @$scripts                              = MaterialGold.as;
                                          MaterialStandard.as;
                                          MaterialMerge.as;
+                                         DecayQuantity.as;
                                          IgnoreDamage.as;
                                          ImportantPickup.as;
 f32_health                             = 1.0


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Gold should decay in Sandbox as per PR #1276.
However, it wasn't working because it seems I didn't copy over the file `MaterialGold.cfg` by mistake.
So I'm fixing that here.

I tested in Sandbox offline, Gold is now decaying.
Then I tested with `runlocalhost.bat` (CTF offline) and Gold stays as it should.
