### PR TITLE
[fixed] that RunnerDeath wasn't run when sawed

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -237,7 +237,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
     {
         Vec2f pos = this.getPosition();
         Vec2f bpos = blob.getPosition();
-	blob.server_SetHealth(-1);
+        blob.server_SetHealth(-1);
         this.server_Hit(blob, bpos, bpos - pos, 0.0f, Hitters::saw);
         this.Tag("sawed");
     }

--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -237,6 +237,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
     {
         Vec2f pos = this.getPosition();
         Vec2f bpos = blob.getPosition();
+	blob.server_SetHealth(-1);
         this.server_Hit(blob, bpos, bpos - pos, 0.0f, Hitters::saw);
         this.Tag("sawed");
     }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[fixed] Player will do their death cry and properly let go of a held food when getting killed by Saw, instead of eating it.

Fixes #1462.

Here is the order of executions before this PR:
1) `Saw.as`: `this.server_Hit(blob, bpos, bpos - pos, 0.0f, Hitters::saw);`
2) `RunnerDeath.as`: Checks if health is 0 or lower; if true runs things like `... PlaySound("WilhelmShort.ogg", ... )` and `StuffFallsOut(this);`
3) `Saw.as`: `onHitBlob(...)`
4) `Saw.as`: `Blend(...)` and `tobeblended.server_SetHealth(-1.0f);`

The health isn't reduced to zero until 4) happens, so at 2) all the code in `RunnerDeath.as` is skipped.

This PR adds a line `blob.server_SetHealth(-1);` right before 1), therefore the code at 2) is getting run.
This means that the sawed player will do a death cry now and their items will properly detach from hand and fall out of their inventory.
This means that if the player held a food, they will not consume it upon getting sawed.

Note:
Changing `this.server_Hit(blob, bpos, bpos - pos, 0.0f, Hitters::saw);` to `this.server_Hit(blob, bpos, bpos - pos, 10.0f, Hitters::saw);` doesn't seem to make a difference, the player's health is still kept the same. So using `blob.server_SetHealth(-1);` made the most sense.

I verified this PR in a brief testing in online and offline.

## Steps to Test or Reproduce

Go to Sandbox, hold a food in your hand and jump into a Saw. Notice you will make a death cry and you will not eat your food upon getting sawed; you will let go of the food instead.
