### PR TITLE
[fixed] Greg not detaching players before attaching them

### DIFF
--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -527,8 +527,7 @@ void onCollision( CBlob@ this, CBlob@ blob, bool solid )
         this.set_s32("statue time", 0);
         this.set_u16("struggle count", 0);
 
-		if (blob.isAttached())
-			blob.server_DetachFromAll();
+        if (blob.isAttached()) { blob.server_DetachFromAll(); }
 		
         this.server_AttachTo(blob, this.getAttachmentPoint(0));
         this.setVelocity(Vec2f_zero);

--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -526,6 +526,10 @@ void onCollision( CBlob@ this, CBlob@ blob, bool solid )
 
         this.set_s32("statue time", 0);
         this.set_u16("struggle count", 0);
+
+		if (blob.isAttached()
+			blob.server_DetachFromAll();
+		
         this.server_AttachTo(blob, this.getAttachmentPoint(0));
         this.setVelocity(Vec2f_zero);
         this.AddForce(Vec2f(0, -30.0f)); //get a little hop up into the air going.

--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -527,7 +527,7 @@ void onCollision( CBlob@ this, CBlob@ blob, bool solid )
         this.set_s32("statue time", 0);
         this.set_u16("struggle count", 0);
 
-		if (blob.isAttached()
+		if (blob.isAttached())
 			blob.server_DetachFromAll();
 		
         this.server_AttachTo(blob, this.getAttachmentPoint(0));


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1459.

When Greg grabs a player who is already attached, then that player would be attached to that thing and Greg at the same time, causing glitchy behavior.

This PR makes it so the player detaches from catapult/bed/dinghy etc. before getting attached to Greg.
The player still holds onto their item in their hand when getting grabbed.
Tested in offline and online.

## Steps to Test or Reproduce

Go to Sandbox, spawn a Greg, get grabbed when sleeping in bed or sitting in a Catapult.
Notice you are still inside the bed or in the catapult but also fly away with Greg at the same time as indicated by the orange arrow pointer and camera movement. 
**After this PR, no such glitchy behavior happens, as the player properly detaches before getting attached to Greg.**