### PR TITLE
[changed] Single water arrow in archershop, instead of double

### DIFF
--- a/Entities/Materials/Ammunition/MaterialWaterArrow.cfg
+++ b/Entities/Materials/Ammunition/MaterialWaterArrow.cfg
@@ -65,9 +65,9 @@ $name                                  = mat_waterarrows
 f32_health                             = 1.0
 
 # Inside inventory
-$inventory_name                        = Water Arrows
+$inventory_name                        = Water Arrow
 $inventory_icon                        = Materials.png
-u8 inventory_icon_frame                = 28
+u8 inventory_icon_frame                = 20
 u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] Water arrow shows up as a stack of 1 in archershop, instead of 2
[changed] "Water Arrows" inventory name to "Water Arrow"

Fixed #1435.

## Steps to Test or Reproduce

Go to Sandbox, spawn an Archershop.
Notice Water Arrow shows up as a stack of 2 in the purchase window.
Once bought, you can only carry 1 per slot, though.
Although Bomb Arrow shows up as `"Bomb Arrow"` in inventory, Water Arrow still show up as `"Water Arrows"` (plural).

**After this PR, Water Arrows will show up as a stack of 1 in archershop. The Water Arrow's inventory name will be "Water Arrow" to be consistent with Bomb Arrow that also comes in a stack of 1.**