### PR TITLE
fix attempt for faster building

### DIFF
--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -281,7 +281,7 @@ void SetTileAimpos(CBlob@ this, BlockCursor@ bc)
 
 u32 getCurrentBuildDelay(CBlob@ this)
 {
-	return (getRules().hasTag("faster building") ? this.get_u32("warmup build delay") : this.get_u32("build delay"));
+	return (getRules().getCurrentState() != GAME ? this.get_u32("warmup build delay") : this.get_u32("build delay"));
 }
 
 f32 getMaxBuildDistance(CBlob@ this)

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -744,24 +744,6 @@ void onInit(CRules@ this)
 	this.set_s32("restart_rules_after_game_time", 30 * 30);
 }
 
-void onStateChange(CRules@ this, const u8 oldState)
-{
-	// we have to do it like this because warmup state is broken and not synced properly clientside
-	if(isServer())
-	{
-		if (this.getCurrentState() == WARMUP)
-		{
-			this.Tag("faster building");
-			this.Sync("faster building", true);
-		}
-		else
-		{
-			this.Untag("faster building");
-			this.Sync("faster building", true);
-		}
-	}
-}
-
 // had to add it here for tutorial cause something didnt work in the tutorial script
 void onBlobDie(CRules@ this, CBlob@ blob)
 {


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Two issues currently exist:
The first is that current code does not work properly for an unknown reason:
CTF.as (serverside only)
```
void onStateChange(CRules@ this, const u8 oldState)
{
	// we have to do it like this because warmup state is broken and not synced properly clientside
	if(isServer())
	{
		if (this.getCurrentState() == WARMUP)
		{
			this.Tag("faster building");
			this.Sync("faster building", true);
		}
		else
		{
			this.Untag("faster building");
			this.Sync("faster building", true);
		}
	}
}
```
PlacementCommon.as (clientside part)
```
u32 getCurrentBuildDelay(CBlob@ this)
{
	return (getRules().hasTag("faster building") ? this.get_u32("warmup build delay") : this.get_u32("build delay"));
}
```
There have been reports (from petgreendino, NoahTheLegend, and it happened to me too) that if you join the server in build time, you will still be able to build fast in game time. This cannot be replicated 100% of the time and is not consistent.
I do not understand what causes this, because that's all the code there is for it. In theory, since onStateChange is ran serverside, the .Sync should make it so that every person's prop is the same as on server, but if that was the case, the fast building in game time bug either would apply to everyone on the server and not to one person only. So is .Sync broken? Or is something else broken, like .Untagging actually causing a .Tag in some weird situation or some shit like that? no clue

The second issue is that RuleState isn't perfect either and I do not know/recall the full extent of the issues regarding it. One thing I can tell for sure is that WARMUP on server can become INTERMISSION on client sometimes (if you next map in build time). But if this is the only issue with the states, and GAME on client will always be applied correctly, then this PR fixes the current bug of faster building in gametime.