### PR TITLE
Alert admins when gold or seeds are thrown into the void

### DIFF
--- a/Entities/Common/Scripts/AlertAdminOnDie.as
+++ b/Entities/Common/Scripts/AlertAdminOnDie.as
@@ -15,11 +15,11 @@ void onDie(CBlob@ this)
 	string message;
 
 	string username = this.get_string("last held by");
-	CPlayer@ player = getPlayerByUsername(username);
-	if (player !is null)
+	CPlayer@ holder = getPlayerByUsername(username);
+	if (holder !is null)
 	{
 		message = getTranslatedString("{PLAYER} caused {COUNT} {MATERIAL} to fall into the void!")
-			.replace("{PLAYER}", formatPlayerName(player))
+			.replace("{PLAYER}", formatPlayerName(holder))
 			.replace("{COUNT}", "" + this.getQuantity())
 			.replace("{MATERIAL}", this.getInventoryName());
 	}
@@ -35,8 +35,8 @@ void onDie(CBlob@ this)
 		print(message, CHAT_COLOR);
 	}
 
-	@player = getLocalPlayer();
-	if (player !is null && player.isMod())
+	CPlayer@ localPlayer = getLocalPlayer();
+	if (localPlayer !is null && localPlayer.isMod())
 	{
 		client_AddToChat(message, CHAT_COLOR);
 	}

--- a/Entities/Common/Scripts/AlertAdminOnDie.as
+++ b/Entities/Common/Scripts/AlertAdminOnDie.as
@@ -1,0 +1,58 @@
+const SColor CHAT_COLOR = SColor(255, 255, 0, 0);
+
+void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint@ attachedPoint)
+{
+	AttributeBlobToPlayer(this, attached.getPlayer());
+}
+
+void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
+{
+	AttributeBlobToPlayer(this, inventoryBlob.getPlayer());
+}
+
+void onDie(CBlob@ this)
+{
+	string message;
+
+	string username = this.get_string("last held by");
+	CPlayer@ player = getPlayerByUsername(username);
+	if (player !is null)
+	{
+		message = getTranslatedString("{PLAYER} caused {COUNT} {MATERIAL} to fall into the void!")
+			.replace("{PLAYER}", formatPlayerName(player))
+			.replace("{COUNT}", "" + this.getQuantity())
+			.replace("{MATERIAL}", this.getInventoryName());
+	}
+	else
+	{
+		message = getTranslatedString("{COUNT} {MATERIAL} fell into the void!")
+			.replace("{COUNT}", "" + this.getQuantity())
+			.replace("{MATERIAL}", this.getInventoryName());
+	}
+
+	if (isServer())
+	{
+		print(message, CHAT_COLOR);
+	}
+
+	@player = getLocalPlayer();
+	if (player !is null && player.isMod())
+	{
+		client_AddToChat(message, CHAT_COLOR);
+	}
+}
+
+void AttributeBlobToPlayer(CBlob@ blob, CPlayer@ player)
+{
+	if (player !is null)
+	{
+		blob.set_string("last held by", player.getUsername());
+	}
+}
+
+string formatPlayerName(CPlayer@ player)
+{
+	string username = player.getUsername();
+	string nickname = player.getCharacterName();
+	return username == nickname ? username : nickname + " (" + username + ")";
+}

--- a/Entities/Materials/Construction/MaterialGold.cfg
+++ b/Entities/Materials/Construction/MaterialGold.cfg
@@ -63,6 +63,7 @@ $name                                  = mat_gold
                                          DecayQuantity.as;
                                          IgnoreDamage.as;
                                          ImportantPickup.as;
+                                         AlertAdminOnDie.as;
 f32_health                             = 1.0
 
 # Inside inventory

--- a/Entities/Natural/Trees/BushyTree.cfg
+++ b/Entities/Natural/Trees/BushyTree.cfg
@@ -83,6 +83,7 @@ $name                                  = tree_bushy
 										 BushyTreeLogic.as;
 										 AlignToTiles.as;
 										 isFlammable.as;
+                                         AlertAdminOnDie.as;
 f32 health                             = 4.0
 # looks & behaviour inside inventory
 $inventory_name                        = Bushy Tree

--- a/Entities/Natural/Trees/PineTree.cfg
+++ b/Entities/Natural/Trees/PineTree.cfg
@@ -83,6 +83,7 @@ $name                                  = tree_pine
 										 PineTreeLogic.as;
 										 AlignToTiles.as;
 										 isFlammable.as;
+                                         AlertAdminOnDie.as;
 f32 health                             = 5.0
 # looks & behaviour inside inventory
 $inventory_name                        = Pine Tree


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1067 

Could be improved by also detecting the player who throws a blob into the void that contains gold or seeds.

## Steps to Test or Reproduce

1. Throw gold or seeds into the void.
2. Jump into the void with gold or seeds.
3. Throw a blob into the void that contains gold or seeds.