### PR TITLE
Warboat crate drops gold when destroyed

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -28,7 +28,12 @@ void onInit(CBlob@ this)
 	string packed = this.get_string("packed");
 
 	this.set_u32("boobytrap_cooldown_time", 0);
-	this.set_s32("gold building amount", packed == "warboat" ? 50 : 0);
+	int goldAmount = 0;
+	if (packed == "warboat")
+	{
+		goldAmount = 50;
+	}
+	this.set_s32("gold building amount", goldAmount);
 
 	u8 frame = 0;
 	if (this.exists("frame"))

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -25,14 +25,15 @@ void onInit(CBlob@ this)
 	this.addCommandID("stop unpack");
 	this.addCommandID("boobytrap");
 
+	string packed = this.get_string("packed");
+
 	this.set_u32("boobytrap_cooldown_time", 0);
-	this.set_s32("gold building amount", 0);
+	this.set_s32("gold building amount", packed == "warboat" ? 50 : 0);
 
 	u8 frame = 0;
 	if (this.exists("frame"))
 	{
 		frame = this.get_u8("frame");
-		string packed = this.get_string("packed");
 
 		// GIANT HACK!!!
 		if (packed == "catapult" || packed == "bomber" || packed == "ballista" || packed == "outpost" || packed == "mounted_bow" || packed == "longboat" || packed == "warboat")


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1449

## Steps to Test or Reproduce

1. Buy a warboat crate.
2. Destroy the crate.
3. Verify 50 gold is dropped.
4. Verify no gold is dropped for other crates that don't require gold to buy.