### PR TITLE
Prevent buying beer and meal from quarters when at full health

### DIFF
--- a/Entities/Common/Includes/Requirements.as
+++ b/Entities/Common/Includes/Requirements.as
@@ -57,6 +57,10 @@ string getButtonRequirementsText(CBitStream& inout bs, bool missing)
 		{
 			text += getTranslatedString("{COINS_QUANTITY} $COIN$ required\n").replace("{COINS_QUANTITY}", "" + quantity);
 		}
+		else if (requiredType == "hurt")
+		{
+			text += getTranslatedString("$HEART$ Must be hurt\n");
+		}
 		else if (requiredType == "no more" && missing)
 		{
 			text += quantityColor;
@@ -103,11 +107,21 @@ void AddRequirement(CBitStream &inout bs, const string &in req, const string &in
 	bs.write_u16(quantity);
 }
 
+void AddHurtRequirement(CBitStream &inout bs)
+{
+	bs.write_string("hurt");
+}
+
 bool ReadRequirement(CBitStream &inout bs, string &out req, string &out blobName, string &out friendlyName, u16 &out quantity)
 {
 	if (!bs.saferead_string(req))
 	{
 		return false;
+	}
+
+	if (req == "hurt")
+	{
+		return true;
 	}
 
 	if (!bs.saferead_string(blobName))
@@ -169,6 +183,15 @@ bool hasRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &inout bs, C
 			if (sum < quantity)
 			{
 				AddRequirement(missingBs, req, blobName, friendlyName, quantity);
+				has = false;
+			}
+		}
+		else if (req == "hurt")
+		{
+			CBlob@ blob = inv1 !is null ? inv1.getBlob() : null;
+			if (blob is null || blob.getHealth() >= blob.getInitialHealth())
+			{
+				AddHurtRequirement(missingBs);
 				has = false;
 			}
 		}

--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -93,6 +93,7 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Beer - 1 Heart", "$quarters_beer$", "beer", Descriptions::beer, false);
 		s.spawnNothing = true;
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::beer);
+		AddHurtRequirement(s.requirements);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Meal - Full Health", "$quarters_meal$", "meal", Descriptions::meal, false);
@@ -101,6 +102,7 @@ void onInit(CBlob@ this)
 		s.buttonwidth = 2;
 		s.buttonheight = 1;
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::meal);
+		AddHurtRequirement(s.requirements);
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Egg - Full Health", "$quarters_egg$", "egg", Descriptions::egg, false);

--- a/Scripts/Default/DefaultGUI.as
+++ b/Scripts/Default/DefaultGUI.as
@@ -14,6 +14,7 @@ void LoadDefaultGUI()
 		AddIconToken("$NONE$", interaction, Vec2f(32, 32), 9);
 		AddIconToken("$TIME$", interaction, Vec2f(32, 32), 0);
 		AddIconToken("$COIN$", "Sprites/coins.png", Vec2f(16, 16), 1);
+		AddIconToken("$HEART$", "GUI/HeartNBubble.png", Vec2f(12, 12), 1);
 		AddIconToken("$TEAMS$", "GUI/MenuItems.png", Vec2f(32, 32), 1);
 		AddIconToken("$SPECTATOR$", "GUI/MenuItems.png", Vec2f(32, 32), 19);
 		AddIconToken("$FLAG$", CFileMatcher("flag.png").getFirst(), Vec2f(32, 16), 0);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Added a "hurt" requirement that makes shop items purchasable only when the player is hurt. This requirement has been added to the beer and meal in the quarters. The requirement is shown with the other shop item requirements.

Resolves #1306

## Steps to Test or Reproduce

Try buying a beer or meal when at different amounts of health.
