### PR TITLE
Fix admin tab not showing on esc menu

### DIFF
--- a/Rules/CommonScripts/KAG.as
+++ b/Rules/CommonScripts/KAG.as
@@ -8,6 +8,8 @@ void onInit(CRules@ this)
 	LoadDefaultMapLoaders();
 	LoadDefaultGUI();
 
+	getSecurity().reloadSecurity();
+
 	sv_gravity = 9.81f;
 	particles_gravity.y = 0.25f;
 	sv_visiblity_scale = 1.25f;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #156 🎉 

Seems too simple of a fix to actually be the true fix to this longstanding issue, but it seems to work fine and is the solution players have manually done to resolve the issue (`/rcon /reloadseclevs`).

## Steps to Test or Reproduce

1. Be admin
2. Start and join a dedicated server
3. Verify the admin menu is visible