### PR TITLE
Increase pickup priority of arrows and bombs

### DIFF
--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -450,7 +450,7 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
 
 		if (name == "mat_bombs" || name == "mat_waterbombs")
 		{
-			return knight ? factor_resource_useful : factor_resource_boring;
+			return knight ? factor_resource_useful : factor_resource_useful;
 		}
 
 		const bool archer = (thisname == "archer");
@@ -463,7 +463,7 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
 
 		if (name == "mat_waterarrows" || name == "mat_firearrows" || name == "mat_bombarrows")
 		{
-			return archer ? factor_resource_useful_rare : factor_resource_boring;
+			return archer ? factor_resource_useful_rare : factor_resource_useful;
 		}
 	}
 

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -450,7 +450,7 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
 
 		if (name == "mat_bombs" || name == "mat_waterbombs")
 		{
-			return knight ? factor_resource_useful : factor_resource_useful;
+			return knight ? factor_resource_useful_rare : factor_resource_useful;
 		}
 
 		const bool archer = (thisname == "archer");


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1375

## Steps to Test or Reproduce

1. Be knight
2. Pickup arrows surrounded by logs
3. Be archer
4. Pickup bombs surrounded by logs