### PR TITLE
Prevent fast travel if tunnel/outpost is destroyed or team has changed

### DIFF
--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -146,6 +146,10 @@ void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 		//if (isKnockable(caller) && caller.get_u8("knocked") > 0)
 		//	return;
 
+		//dont travel if tunnel team has changed while tunnel menu was open
+		if (tunnel.getTeamNum() != caller.getTeamNum())
+			return;
+
 		//dont travel if caller is attached to something (e.g. siege)
 		if (caller.isAttached())
 			return;

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -148,7 +148,7 @@ void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 		//	return;
 
 		//dont travel if tunnel team has changed while tunnel menu was open
-		if (tunnel.getTeamNum() != caller.getTeamNum())
+		if (this.getTeamNum() != tunnel.getTeamNum())
 			return;
 
 		//dont travel if caller is attached to something (e.g. siege)

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -139,7 +139,8 @@ bool doesFitAtTunnel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 
 void Travel(CBlob@ this, CBlob@ caller, CBlob@ tunnel)
 {
-	if (caller !is null && tunnel !is null)
+	CBlob@ thisTunnel = getBlobByNetworkID(this.getNetworkID());
+	if (thisTunnel !is null && caller !is null && tunnel !is null)
 	{
 		//(this should prevent travel when stunned, but actually
 		// causes issues on net)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1434 except the issue of the menu not updating immediately which affects more than just tunnels.

## Steps to Test or Reproduce

Outpost team changed:
1. Have three or more outposts
2. Open the travel menu
3. Have an enemy capture one of the outposts
4. Attempt to travel to the captured outpost

Tunnel destroyed:
1. Have three or more tunnels or outposts
2. Open the travel menu
3. Have someone destroy the tunnel/outpost you're travelling from
4. Attempt to travel