### PR TITLE
Hide blood on spikes when kidssafe is enabled

### DIFF
--- a/Entities/Structures/Components/Load/Spiker/GenericSpike.as
+++ b/Entities/Structures/Components/Load/Spiker/GenericSpike.as
@@ -64,6 +64,8 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 
 	this.Tag("bloody");
 
+	if (g_kidssafe) return;
+
 	CSpriteLayer@ layer = this.getSprite().getSpriteLayer("blood");
 	if (layer is null) return;
 

--- a/Entities/Structures/Spikes/Spikes.as
+++ b/Entities/Structures/Spikes/Spikes.as
@@ -378,7 +378,11 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 
 		if (!this.hasTag("bloody"))
 		{
-			sprite.animation.frame += 3;
+			if (!g_kidssafe)
+			{
+				sprite.animation.frame += 3;
+			}
+
 			this.Tag("bloody");
 		}
 	}
@@ -390,7 +394,7 @@ void onHealthChange(CBlob@ this, f32 oldHealth)
 	f32 full_hp = this.getInitialHealth();
 	int frame = (hp > full_hp * 0.9f) ? 0 : ((hp > full_hp * 0.4f) ? 1 : 2);
 
-	if (this.hasTag("bloody"))
+	if (this.hasTag("bloody") && !g_kidssafe)
 	{
 		frame += 3;
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1352

Spikes still keep track of whether they are bloody but don't show that to players with `g_kidssafe` enabled. This means spikes will immediately turn bloody when the setting is disabled if someone has jumped into the spikes.

## Steps to Test or Reproduce

1. Enable `g_kidssafe`
2. Jump into spikes
3. Verify blood isn't visible on spikes
4. Disable `g_kidssafe`
5. Notice that blood becomes visible