### PR TITLE
Buildings no longer remove center backwall when built on hand-placed backwall 

### DIFF
--- a/Entities/Industry/Building/DefaultBuilding.as
+++ b/Entities/Industry/Building/DefaultBuilding.as
@@ -18,10 +18,6 @@ void onTick(CBlob@ this)
 {
 	if (this.getTickSinceCreated() == 10)
 	{
-		// make window
-		Vec2f tilepos = this.getPosition() - Vec2f(0, 4);
-		getMap().server_SetTile(tilepos, CMap::tile_empty);
-
 		//check for overlapping buildings
 		CBlob@[] buildings;
 		if (getBlobsByTag("building", buildings))

--- a/Entities/Structures/Common/AddTilesBySector.as
+++ b/Entities/Structures/Common/AddTilesBySector.as
@@ -20,3 +20,28 @@ void AddTilesBySector(Vec2f ul, Vec2f lr, string sectorName, TileType tile, Tile
 		}
 	}
 }
+
+void AddTilesBySectorWithWindow(Vec2f ul, Vec2f lr, string sectorName, TileType tile, TileType omitTile = 255)
+{
+	if (getNet().isServer())
+	{
+		CMap@ map = getMap();
+		const f32 tilesize = map.tilesize;
+		Vec2f tpos = ul;
+		Vec2f tsize(map.tilesize, map.tilesize);
+		Vec2f center = ul + (lr - ul - tsize) * 0.5f;
+		while (tpos.x < lr.x)
+		{
+			while (tpos.y < lr.y)
+			{
+				if (map.getSectorAtPosition(tpos, sectorName) !is null && map.getTile(tpos).type != omitTile && tpos != center)
+				{
+					map.server_SetTile(tpos, tile);
+				}
+				tpos.y += tilesize;
+			}
+			tpos.x += tilesize;
+			tpos.y = ul.y;
+		}
+	}
+}

--- a/Entities/Structures/Common/DefaultNoBuild.as
+++ b/Entities/Structures/Common/DefaultNoBuild.as
@@ -41,7 +41,7 @@ void onTick(CBlob@ this)
 
 		if (this.exists(back))
 		{
-			AddTilesBySector(ul, lr, "no build", this.get_TileType(back), CMap::tile_castle_back);
+			AddTilesBySectorWithWindow(ul, lr, "no build", this.get_TileType(back), CMap::tile_castle_back);
 		}
 		else
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Currently, the backwall of a building is generated and then 10 ticks later the center tile is set to air to make a window. This PR changes this so it generates the backwall with the window on the same tick, and the window doesn't remove any existing hand-placed backwall.

Resolves the first proposed change in #1314

## Steps to Test or Reproduce

1. Build a building in the open
2. The window is generated as normal
3. Build a wall of backwall
4. Build a building in front of that backwall
5. Notice that the window is not generated because the backwall exists