### PR TITLE
[modified] amount of materials in build time (balance change)

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -6,7 +6,7 @@
 const u32 materials_wait = 20; //seconds between free mats
 const u32 materials_wait_warmup = 40; //seconds between free mats
 
-const int warmup_wood_amount = 250;
+const int warmup_wood_amount = 200;
 const int warmup_stone_amount = 60;
 
 const int matchtime_wood_amount = 100;

--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -4,10 +4,10 @@
 #include "CTF_Structs.as";
 
 const u32 materials_wait = 20; //seconds between free mats
-const u32 materials_wait_warmup = 30; //seconds between free mats
+const u32 materials_wait_warmup = 40; //seconds between free mats
 
-const int warmup_wood_amount = 300;
-const int warmup_stone_amount = 100;
+const int warmup_wood_amount = 250;
+const int warmup_stone_amount = 60;
 
 const int matchtime_wood_amount = 100;
 const int matchtime_stone_amount = 30;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The amount of materials added to the game because of the build time changes was underestimated, so it's being modified.

REBUILD (CURRENT):
30s timer (resupply at 180/150/120/90/60/30) - 6 resupplies 
21600 wood total (12 players, 300 per player)
7200 stone total (12 players, 100 per player)

THIS PR:
40s timer (resupply at 180/140/100/60/40) - 5 resupplies 
12000 wood total (12 players, 200 per player)
3600 stone total (12 players, 60 per player)

The 50% reduction in stone may be a bit harsh, but it is still going to be more mats than pre-rebuild. Moreover, most maps also have tons of stone accessible from stone ore at the start of the game (eg. elantris - easy 3k), so it's not gonna be a 50% reduction in practice - probably 1/3 to 1/4 on most maps.

However, if it will be too harsh of a decrease (need to see in-game) then probably it'll be increased to be something in between.