### PR TITLE
[dev] Fixed seclev reloading showing admin menus on client

### DIFF
--- a/Rules/CommonScripts/KAG.as
+++ b/Rules/CommonScripts/KAG.as
@@ -8,7 +8,10 @@ void onInit(CRules@ this)
 	LoadDefaultMapLoaders();
 	LoadDefaultGUI();
 
-	getSecurity().reloadSecurity();
+	if (isServer())
+	{
+		getSecurity().reloadSecurity();
+	}
 
 	sv_gravity = 9.81f;
 	particles_gravity.y = 0.25f;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

#1478 (which was merged but not released) causes the admin tab to be shown even on servers on which you are not an admin. This is likely because reloading seclevs on the client-side overrides the seclevs obtained from the server. Attempting to actually do things from the admin menu of course fails as it fails the security checks on the server-side.

This checks whether we're the server before executing the seclev reloading. The seclevs will also be reloaded on localhost servers which should not be an issue.