### PR TITLE
Damaged bridge correctly shows damage after closing

### DIFF
--- a/Entities/Structures/Platform/Bridge.as
+++ b/Entities/Structures/Platform/Bridge.as
@@ -96,7 +96,7 @@ void setOpen(CBlob@ this, bool open)
 	else
 	{
 		sprite.SetZ(100.0f);
-		sprite.SetAnimation("default");
+		sprite.SetAnimation("destruction");
 		shape.getConsts().collidable = true;
 		sprite.PlaySound("bridge_close.ogg");
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1489

## Steps to Test or Reproduce

1. Place bridge
2. Damage bridge
3. Change team
4. Fall through bridge
5. Verify bridge shows correct damage frame after it closes