### PR TITLE
fixed wrong keg icon in knight shop

### DIFF
--- a/Entities/Industry/CTFShops/KnightShop/KnightShop.as
+++ b/Entities/Industry/CTFShops/KnightShop/KnightShop.as
@@ -43,7 +43,7 @@ void onInit(CBlob@ this)
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::mine);
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Keg", getTeamIcon("keg", "Keg.png", team_num, Vec2f(16, 16), 1), "keg", Descriptions::keg, false);
+		ShopItem@ s = addShopItem(this, "Keg", getTeamIcon("keg", "Keg.png", team_num, Vec2f(16, 16), 0), "keg", Descriptions::keg, false);
 		AddRequirement(s.requirements, "coin", "", "Coins", CTFCosts::keg);
 	}
 }


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

it was showing wrong icon (damaged)
