### PR TITLE
[dev] fix to shop refresh broken logic

### DIFF
--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -39,11 +39,6 @@ void onInit(CBlob@ this)
 			this.set_u8("shop button radius", 16);
 		}
 	}
-
-	if (isClient() && !this.exists("open menu name"))
-	{
-		this.set_string("open menu name", "");
-	}
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
@@ -91,10 +86,10 @@ bool isInRadius(CBlob@ this, CBlob @caller)
 
 void updateShopGUI(CBlob@ shop)
 {
-	const string caption = shop.get_string("open menu name");
+	const string caption = getRules().get_string("shop open menu name");
 	if (caption == "") { return; }
 
-	const int callerBlobID = shop.get_netid("open menu caller blob");
+	const int callerBlobID = getRules().get_netid("shop open menu caller");
 	CBlob@ callerBlob = getBlobByNetworkID(callerBlobID);
 	if (callerBlob is null) { return; }
 
@@ -122,7 +117,7 @@ void updateShopGUI(CBlob@ shop)
 
 void onTick(CBlob@ shop)
 {
-	if (isClient())
+	if (isClient() && getRules().exists("shop open menu blob") && getRules().get_netid("shop open menu blob") == shop.getNetworkID())
 	{
 		updateShopGUI(@shop);
 	}
@@ -447,8 +442,9 @@ void BuildShopMenu(CBlob@ this, CBlob @caller, string description, Vec2f offset,
 	CControls@ controls = caller.getControls();
 	CGridMenu@ menu = CreateGridMenu(caller.getScreenPos() + offset, this, Vec2f(slotsAdd.x, slotsAdd.y), caption);
 
-	this.set_string("open menu name", caption);
-	this.set_netid("open menu caller blob", caller.getNetworkID());
+	getRules().set_netid("shop open menu blob", this.getNetworkID());
+	getRules().set_string("shop open menu name", caption);
+	getRules().set_netid("shop open menu caller", caller.getNetworkID());
 
 	if (menu !is null)
 	{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This is a rather braindead way to do things (as `onTick` could be moved to a rules script there), but it is generally not a big deal. We move the refresh-related properties from shop blob properties to rule properties.

I'd rather not do this, but ATM, the only way to get an open `CGridMenu` appears to be to get it by its caption. Of course, different shops are highly likely to have the same caption.

One could hold onto a `CGridMenu` reference through a generic `get`/`set` but we have seemingly no way of figuring out whether a grid menu is still alive at that point or not.

Considering there is no situation where we can have multiple shops open, this seems to be a functional way to achieve this.