### PR TITLE
[fixed] Plants growing off incorrect tile

### DIFF
--- a/Entities/Natural/Scripts/PlantGrowth.as
+++ b/Entities/Natural/Scripts/PlantGrowth.as
@@ -17,10 +17,8 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
-	if (getNet().isServer())
+	if (isServer())
 	{
-		Vec2f pos = this.getPosition();
-
 		u8 amount = this.get_u8(grown_amount);
 
 		u8 time = this.get_u8(growth_time);
@@ -32,7 +30,7 @@ void onTick(CBlob@ this)
 			this.Sync(grown_tag, true);
 			this.getCurrentScript().runFlags |= Script::remove_after_this;
 		}
-		else if (canGrowAt(this, (pos + Vec2f(0.0f, 6.0f))))
+		else if (canGrowAt(this, this.getPosition()))
 		{
 			if (XORRandom(this.get_u8(growth_chance)) == 0)
 			{

--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -29,7 +29,7 @@ bool canGrowAt(CBlob@ this, Vec2f pos)
 		}
 	}
 
-	CMap@ map = this.getMap();
+	CMap@ map = getMap();
 
 	/*if ( map.isTileGrass( map.getTile( pos ) )) {
 	return false;
@@ -54,5 +54,6 @@ bool canGrowAt(CBlob@ this, Vec2f pos)
 
 	}*/
 
-	return (map.isTileGround(map.getTile(Vec2f(pos.x, pos.y + 4)).type));
+	Vec2f underneath = Vec2f(pos.x, pos.y + this.getHeight() / 2 + 4);
+	return (map.isTileGround(map.getTile(underneath).type));
 }

--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -54,6 +54,6 @@ bool canGrowAt(CBlob@ this, Vec2f pos)
 
 	}*/
 
-	Vec2f underneath = Vec2f(pos.x, pos.y + this.getHeight() / 2 + 4);
+	Vec2f underneath = Vec2f(pos.x, pos.y + (this.getHeight() + map.tilesize) * 0.5f);
 	return (map.isTileGround(map.getTile(underneath).type));
 }

--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -54,5 +54,5 @@ bool canGrowAt(CBlob@ this, Vec2f pos)
 
 	}*/
 
-	return (map.isTileGround(map.getTile(Vec2f(pos.x, pos.y + 8)).type));
+	return (map.isTileGround(map.getTile(Vec2f(pos.x, pos.y + 4)).type));
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is ready.

## Description

For plants to grow, they use a tile one block deeper than expected rather than the surface tile. This change simply changes it so the surface tile is always used instead.
![Untitled](https://user-images.githubusercontent.com/68350259/202825798-8a12b5ff-aa2f-47b6-8519-055ac166aec1.png)

## Steps to Test or Reproduce

Place a plant of any kind onto the ground. The plant will always grow as long as there is a dirt block underneath the plant.
