### PR TITLE
[fixed] Spikes, Spiker and Saw will properly remember if they are bloody and will instantly update their sprite when g_kidssafe changes

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -15,6 +15,12 @@ void onInit(CBlob@ this)
 	this.addCommandID(sawteammate_id);
 
 	SetSawOn(this, true);
+	
+	CRules@ rules = getRules();
+	if (!rules.hasScript("ToggleBloodyStuff.as"))
+	{
+		rules.AddScript("ToggleBloodyStuff.as");
+	}
 }
 
 //toggling on/off
@@ -64,7 +70,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		bool set = !getSawOn(this);
 		SetSawOn(this, set);
 
-		if (getNet().isClient()) //closed/opened gfx
+		if (isClient()) //closed/opened gfx
 		{
 			CSprite@ sprite = this.getSprite();
 
@@ -105,7 +111,7 @@ void Blend(CBlob@ this, CBlob@ tobeblended)
 	string blobname = tobeblended.getName();
 	if (blobname == "log" || blobname == "crate")
 	{
-		if (getNet().isServer())
+		if (isServer())
 		{
 			CBlob@ blob = server_CreateBlobNoInit('mat_wood');
 
@@ -184,16 +190,8 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 
 		if (dot > 0.8f)
 		{
-			if (getNet().isClient() && !g_kidssafe) //add blood gfx
-			{
-				CSprite@ sprite = this.getSprite();
-				CSpriteLayer@ chop = sprite.getSpriteLayer("chop");
-
-				if (chop !is null)
-				{
-					chop.animation.frame = 1;
-				}
-			}
+			this.Tag("bloody");
+			UpdateFrame(this);	//add bloody spritelayer
 
 			return true;
 		}
@@ -204,6 +202,19 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 	}
 
 	return true;
+}
+
+void UpdateFrame(CBlob@ this)
+{
+	if (!isClient())	return;
+
+	CSprite@ sprite = this.getSprite();
+	CSpriteLayer@ chop = sprite.getSpriteLayer("chop");
+
+	if (chop !is null)
+	{	
+		chop.animation.frame = this.hasTag("bloody") && !g_kidssafe ? 1 : 0;
+	}
 }
 
 void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitBlob, u8 customData)

--- a/Entities/Structures/Components/Load/Spiker/GenericSpike.as
+++ b/Entities/Structures/Components/Load/Spiker/GenericSpike.as
@@ -60,16 +60,20 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 
 void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitBlob, u8 customData)
 {
-	if (this.exists("bloody")) return;
+	if (hitBlob !is null 
+		&& hitBlob !is this 
+		&& damage > 0.0f)
+	{
+		this.Tag("bloody");
+		UpdateFrame(this);
+	}
+}
 
-	this.Tag("bloody");
-
-	if (g_kidssafe) return;
-
-	CSpriteLayer@ layer = this.getSprite().getSpriteLayer("blood");
-	if (layer is null) return;
-
-	layer.SetVisible(true);
+void UpdateFrame(CBlob@ this)
+{
+	if (!isClient()) return;
+	
+	this.getSprite().animation.frame = this.hasTag("bloody") && !g_kidssafe ? 1 : 0;
 }
 
 bool canBePickedUp( CBlob@ this, CBlob@ byBlob )

--- a/Entities/Structures/Components/Load/Spiker/Spike.as
+++ b/Entities/Structures/Components/Load/Spiker/Spike.as
@@ -2,8 +2,9 @@
 
 void onInit(CSprite@ this)
 {
-	CSpriteLayer@ layer = this.addSpriteLayer("blood", "Spike.png", 8, 8);
-	layer.addAnimation("default", 0, false);
-	layer.animation.AddFrame(1);
-	layer.SetVisible(false);
+	CRules@ rules = getRules();
+	if (!rules.hasScript("ToggleBloodyStuff.as"))
+	{
+		rules.AddScript("ToggleBloodyStuff.as");
+	}
 }

--- a/Entities/Structures/Components/Load/Spiker/Spike.cfg
+++ b/Entities/Structures/Components/Load/Spiker/Spike.cfg
@@ -16,7 +16,7 @@ $sprite_animation_start                           = *start*
 	$sprite_animation_default_name                = default
 	u16 sprite_animation_default_time             = 0
 	u8_sprite_animation_default_loop              = 0
-	@u16 sprite_animation_default_frames          = 0;
+	@u16 sprite_animation_default_frames          = 0; 1;
 $sprite_animation_end                             = *end*
 
 $shape_factory                                    = box2d_shape

--- a/Rules/CommonScripts/ToggleBloodyStuff.as
+++ b/Rules/CommonScripts/ToggleBloodyStuff.as
@@ -1,0 +1,48 @@
+
+// Change bloody spritelayers when g_kidssafe is toggled on/off
+
+#define CLIENT_ONLY
+
+void OnCloseMenu(CRules@ this)
+{
+	CBlob@[] blobs;
+	getBlobsByName("saw", @blobs);
+	getBlobsByName("spikes", @blobs);
+	getBlobsByName("spike", @blobs);
+	
+	for (int i = 1; i < blobs.length; i++)
+	{
+		CBlob@ blob = blobs[i];
+		
+		if (blob is null)	continue;
+		
+		string name = blob.getName();
+		CSprite@ sprite = blob.getSprite();
+		
+		if (name == "saw")
+		{
+			CSpriteLayer@ chop = sprite.getSpriteLayer("chop");
+
+			if (chop !is null)
+			{	
+				chop.animation.frame = blob.hasTag("bloody") && !g_kidssafe ? 1 : 0;
+			}
+		}
+		else if (name == "spikes")
+		{
+			f32 hp = blob.getHealth();
+			f32 full_hp = blob.getInitialHealth();
+			int frame = (hp > full_hp * 0.9f) ? 0 : ((hp > full_hp * 0.4f) ? 1 : 2);
+	
+			if (blob.hasTag("bloody") && !g_kidssafe)
+			{
+				frame += 3;
+			}
+			sprite.animation.frame = frame;
+		}
+		else if (name == "spike")
+		{
+			sprite.animation.frame = blob.hasTag("bloody") && !g_kidssafe ? 1 : 0;
+		}
+	}
+}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] Spikes, Spiker and Saw will properly remember if they are bloody or not and will instantly update their spritelayer when changing `g_kidssafe` from the menu.
[changed] Spikes don't continuously update their animation frame in `onTick()` via calling `onHealthChange()`
[changed] Spiker will change its animation frame rather than adding a spritelayer
```

Spikes remembered its bloody status but only updated its sprite frame if a player moved inside a radius of 124.0f.
It also called `onHealthChange()` to do it on each tick even if the frame doesn't need updating.

Spiker would either be bloody or not bloody forever after the first hit lands due to a bad return condition in `onHitBlob()`.

Saw turns bloody when `g_kidssafe` was off and then stayed that way forever.

This PR makes it so all three (Spikes, Spiker, Saw) will properly remember if they are bloody or not and update their animation frame accordingly when `g_kidssafe` is changed via the menu. When one of the three spawns, then their `onInit()` will run this:

```
	CRules@ rules = getRules();
	if (!rules.hasScript("ToggleBloodyStuff.as"))
	{
		rules.AddScript("ToggleBloodyStuff.as");
	}
```

And `ToggleBloodyStuff.as` will update the animation frames of all Saws, Spikes and Spikers on the map according to whether they are tagged with "bloody" and `g_kidssafe`. This is done via the hook `void OnCloseMenu(CRules@ this)`.

I didn't want to add `ToggleBloodyStuff.as` as a script to all gamemode config files in order to prevent clutter and since I feel that this is something that should always reliably run regardless what gamemode is played. Of course I can do it if a dev wants me to.

Tested in online and offline, no bugs observed.

## Steps to Test or Reproduce

Have `g_kidssafe` off and jump into some Spikes, Spikers and Saws.
Turn `g_kidssafe` on via settings menu.
Notice that the things that were bloody before are now not bloody.
Turn `g_kidssafe` off again.
Notice that the things that were not bloody are now bloody again.

## Ideas to make this Better

- Have the bloodiness fade away depending how much time passed. This way, you can see which spikes/Saw killed a player most recently.
- Make blood particles change the environment, like turning blocks bloody depending what side it's hit from. Have it go away after some time.
