### PR TITLE
[fixed] Damaging an open Bridge doesn't give it a closed sprite

### DIFF
--- a/Entities/Structures/Platform/Bridge.as
+++ b/Entities/Structures/Platform/Bridge.as
@@ -47,11 +47,14 @@ void MakeDamageFrame(CBlob@ this, bool repaired = false)
 	f32 full_hp = this.getInitialHealth();
 	int frame_count = this.getSprite().animation.getFramesCount();
 	int frame = frame_count - frame_count * (hp / full_hp);
-	this.getSprite().animation.frame = frame;
+	string animation_string = isOpen(this) ? "open" : "destruction";
+	CSprite@ sprite = this.getSprite();
+	sprite.SetAnimation(animation_string);
+	sprite.animation.frame = frame;
 
 	if (repaired)
 	{
-		this.getSprite().PlaySound("/build_wood.ogg");
+		sprite.PlaySound("/build_wood.ogg");
 	}
 }
 

--- a/Entities/Structures/Platform/Bridge.as
+++ b/Entities/Structures/Platform/Bridge.as
@@ -43,12 +43,12 @@ void onHealthChange(CBlob@ this, f32 oldHealth)
 
 void MakeDamageFrame(CBlob@ this, bool repaired = false)
 {
+	CSprite@ sprite = this.getSprite();
 	f32 hp = this.getHealth();
 	f32 full_hp = this.getInitialHealth();
-	int frame_count = this.getSprite().animation.getFramesCount();
+	int frame_count = sprite.animation.getFramesCount();
 	int frame = frame_count - frame_count * (hp / full_hp);
 	string animation_string = isOpen(this) ? "open" : "destruction";
-	CSprite@ sprite = this.getSprite();
 	sprite.SetAnimation(animation_string);
 	sprite.animation.frame = frame;
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1496.

When damaging a Bridge that is currently open due to an enemy player being near, it will not assume a closed sprite.
Repairing an open Bridge will still leave the Bridge open, before and after this PR.
Tested in offline and online with no bugs observed.

## Steps to Test or Reproduce

Go to Sandbox.
Place some Bridges.
Have an enemy Player stand inside the Bridges.
Damage an open Bridge.
Notice it will assume a closed sprite, but still play a "closing" sound when pushing the enemy Player away. 
**→ After this PR, the Bridge will keep its open sprite.**