### PR TITLE
[fixed] Drill not cooling down over time after getting hit by an enemy Fire Arrow

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -190,7 +190,7 @@ void onTick(CBlob@ this)
 		this.Sync(heat_prop, true);
 	}
 	sprite.SetEmitSoundPaused(true);
-	if (this.isAttached())
+	if (this.isAttachedToPoint("PICKUP"))
 	{
 		AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
 		CBlob@ holder = point.getOccupied();
@@ -427,6 +427,10 @@ void onTick(CBlob@ this)
 		if (heat <= 0)
 		{
 			this.getCurrentScript().runFlags |= Script::tick_not_sleeping;
+		}
+		else
+		{
+			this.getCurrentScript().runFlags &= ~Script::tick_not_sleeping;
 		}
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[fixed] Drill will now correctly cool down over time after getting hit by an enemy fire arrow. (Fixes #1400)
[dev] Only go into the huge drill logic code in `onTick()` if Drill is actually in an "PICKUP" attachment point.

Drill didn't cool down over time after getting hit by an enemy fire arrow (if it remained in standstill position).

When Drill stops moving and loses all its heat, the `tick_not_sleeping` flag would get set and Drill stops ticking.
The flag is only cleared when the Drill is picked up.
Because of this behavior, if a Drill that stopped ticking is getting heated again by an enemy fire arrow, it would not cool down since the "tick_not_sleeping" flag hadn't been cleared.
This PR adds an `else` section that clears the "tick_not_sleeping" flag if the Drill has any heat.

Note: I assume that the collision from an enemy fire arrow will always make Drill _move_ and cause `onTick()` to run in the first place. Otherwise, you could add an `onTick()` call in `onHit()`. I don't think this is necessary though.

Additionally, this PR changes `if (this.isAttached())` to `if (this.isAttachedToPoint("PICKUP"))` so the huge drill logic section is only entered if the Drill is actually in someone's hand.

Tested in offline and online, works as expected.

## Steps to Test or Reproduce

Go to Sandbox.
Spawn a Drill.
Change Team and go Archer.
Shoot a fire arrow at the drill and make sure the Drill isn't getting pushed but stands still.
Notice the heat never cools down. **After this PR, it will correctly cool down over time.**

Place Drill in a Catapult's Mag.
Notice `onTick()` running forever unnecessarily, even when the Drill has cooled down completely.
**After this PR, it will tick in a catapult's mag until it cools down or it ticks forever if in someone's hand.**