### PR TITLE
[changed] Tunnel, Storage, Quarry and Outpost won't get a window added to them

### DIFF
--- a/Entities/Industry/Building/Building.as
+++ b/Entities/Industry/Building/Building.as
@@ -20,6 +20,8 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 
+	this.Tag("has window");
+
 	//INIT COSTS
 	InitCosts();
 

--- a/Entities/Industry/CTFShops/ArcherShop/ArcherShop.as
+++ b/Entities/Industry/CTFShops/ArcherShop/ArcherShop.as
@@ -14,6 +14,8 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 
+	this.Tag("has window");
+
 	//INIT COSTS
 	InitCosts();
 

--- a/Entities/Industry/CTFShops/BoatShop/BoatShop.as
+++ b/Entities/Industry/CTFShops/BoatShop/BoatShop.as
@@ -14,6 +14,8 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 
+	this.Tag("has window");
+
 	//INIT COSTS
 	InitCosts();
 

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -19,6 +19,8 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 
+	this.Tag("has window");
+
 	// SHOP
 	this.set_Vec2f("shop offset", Vec2f_zero);
 	this.set_Vec2f("shop menu size", Vec2f(4, 4));

--- a/Entities/Industry/CTFShops/KnightShop/KnightShop.as
+++ b/Entities/Industry/CTFShops/KnightShop/KnightShop.as
@@ -15,6 +15,8 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 
+	this.Tag("has window");
+
 	//INIT COSTS
 	InitCosts();
 

--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -73,6 +73,8 @@ void onInit(CBlob@ this)
 	this.addCommandID("rest");
 	this.getCurrentScript().runFlags |= Script::tick_hasattached;
 
+	this.Tag("has window");
+
 	//INIT COSTS
 	InitCosts();
 

--- a/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
+++ b/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
@@ -15,6 +15,8 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 
+	this.Tag("has window");
+
 	//INIT COSTS
 	InitCosts();
 

--- a/Entities/Structures/Common/AddTilesBySector.as
+++ b/Entities/Structures/Common/AddTilesBySector.as
@@ -1,29 +1,6 @@
-void AddTilesBySector(Vec2f ul, Vec2f lr, string sectorName, TileType tile, TileType omitTile = 255)
+void AddTilesBySector(Vec2f ul, Vec2f lr, string sectorName, TileType tile, TileType omitTile = 255, bool hasWindow = false)
 {
-	if (getNet().isServer())
-	{
-		CMap@ map = getMap();
-		const f32 tilesize = map.tilesize;
-		Vec2f tpos = ul;
-		while (tpos.x < lr.x)
-		{
-			while (tpos.y < lr.y)
-			{
-				if (map.getSectorAtPosition(tpos, sectorName) !is null && map.getTile(tpos).type != omitTile)
-				{
-					map.server_SetTile(tpos, tile);
-				}
-				tpos.y += tilesize;
-			}
-			tpos.x += tilesize;
-			tpos.y = ul.y;
-		}
-	}
-}
-
-void AddTilesBySectorWithWindow(Vec2f ul, Vec2f lr, string sectorName, TileType tile, TileType omitTile = 255)
-{
-	if (getNet().isServer())
+	if (isServer())
 	{
 		CMap@ map = getMap();
 		const f32 tilesize = map.tilesize;
@@ -34,7 +11,9 @@ void AddTilesBySectorWithWindow(Vec2f ul, Vec2f lr, string sectorName, TileType 
 		{
 			while (tpos.y < lr.y)
 			{
-				if (map.getSectorAtPosition(tpos, sectorName) !is null && map.getTile(tpos).type != omitTile && tpos != center)
+				if (map.getSectorAtPosition(tpos, sectorName) !is null 
+					&& map.getTile(tpos).type != omitTile
+					&& !(tpos == center && hasWindow))
 				{
 					map.server_SetTile(tpos, tile);
 				}

--- a/Entities/Structures/Common/DefaultNoBuild.as
+++ b/Entities/Structures/Common/DefaultNoBuild.as
@@ -41,7 +41,7 @@ void onTick(CBlob@ this)
 
 		if (this.exists(back))
 		{
-			AddTilesBySectorWithWindow(ul, lr, "no build", this.get_TileType(back), CMap::tile_castle_back);
+			AddTilesBySector(ul, lr, "no build", this.get_TileType(back), CMap::tile_castle_back, this.hasTag("has window"));
 		}
 		else
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] Tunnel, Storage, Quarry and Outpost don't have a window. (Fixes #1314)
[changed] Condense `AddTilesBySector()` and `AddTilesBySectorWithWindow()` into one function.

This makes it so certain buildings where the window cannot be seen are not receiving a window upon building them.

Knightshop, Archershop, Buildershop, Boatshop, Vehicleshop, Quarters and unconstructed Building will get tagged `"has window"` in their `onInit()`.

Then `AddTilesBySector.as` - which places the building's background tiles - will check for that tag. If it does have the tag, it will not place a background tile over the center tile.

Tunnel, Storage, Quarry and Outpost are not tagged with `"has window"`, therefore they will have background placed over the center tile.

I included Quarry because it doesn't hurt to update it while I'm at it.

Because `AddTilesBySector()` and `AddTilesBySectorWithWindow()` are almost duplicate and because of this change, I made it into one function.

Tested in offline, should work in online. No bugs observed.

## Steps to Test or Reproduce

Place a building or use `!knightshop`.
Notice there will be a window.
Construct or spawn a tunnel / quarry / outpost / storage.
Notice there is no window; you cannot place a background tile over the center tile.