### PR TITLE
Hide resupply text above inventory GUI if help is hidden

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -199,7 +199,7 @@ void displayResupply(CRules@ this, string player_class, string resupply_class, V
 
 		GUI::DrawTextCentered(text, Vec2f(x, y), color);
 	}
-	else if (this.getCurrentState() == GAME) // Available resupply & not warmup - shown above inventory GUI
+	else if (this.getCurrentState() == GAME && u_showtutorial) // Available resupply & not warmup - shown above inventory GUI
 	{
 		SColor color = SColor(200, 135, 185, 45);
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

It is very obnoxious and shouldn't need to be shoved in the face of most players.

## Steps to Test or Reproduce

1. Have resupply available
2. Toggle help with F1