### PR TITLE
Prevent map voting before GUI is visible

### DIFF
--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -1,6 +1,7 @@
 //-- Written by Monkey_Feats 22/2/2020 --//
 #include "LoaderColors.as";
 
+const uint voteWaitDuration = 5 * getTicksASecond();
 const uint voteLockDuration = 3 * getTicksASecond();
 const string voteEndTag = "mapvote: ended";
 const string voteSelectMapTag = "mapvote: selectmap";
@@ -37,7 +38,7 @@ bool isMapVoteOver()
 
 bool isMapVoteVisible()
 {
-	return ticksSinceGameOver() >= 5 * getTicksASecond();
+	return ticksSinceGameOver() >= voteWaitDuration;
 }
 
 class MapVotesMenu

--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -35,6 +35,11 @@ bool isMapVoteOver()
 	return ticksRemainingForMapVote() <= 0;
 }
 
+bool isMapVoteVisible()
+{
+	return ticksSinceGameOver() >= 5 * getTicksASecond();
+}
+
 class MapVotesMenu
 {
 	MapVoteButton@ button1;
@@ -140,7 +145,7 @@ class MapVotesMenu
 
 	void Update(CControls@ controls, u8 &out newSelectedNum)
 	{
-		if (isMapVoteOver()) { return; }
+		if (isMapVoteOver() || !isMapVoteVisible()) { return; }
 
 		Vec2f mousepos = controls.getMouseScreenPos();
 		const bool mousePressed = controls.isKeyPressed(KEY_LBUTTON);

--- a/Rules/CommonScripts/PostGameMapVotes.as
+++ b/Rules/CommonScripts/PostGameMapVotes.as
@@ -243,7 +243,7 @@ void RenderRaw(int id)
 	if (!getRules().get("MapVotesMenu", @mvm)) return;
 	if (!getRules().isGameOver() || !mvm.isSetup) return;
 	if (!getNet().isClient()) return;
-	if (ticksSinceGameOver() < 5*getTicksASecond()) return;
+	if (!isMapVoteVisible()) return;
 
 	CRules@ rules = getRules();
 	rules.Untag("animateGameOver");


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Resolves #1518 

## Steps to Test or Reproduce

1. End CTF match
2. Move your cursor over where the map vote GUI will soon appear
3. Verify that no button sounds are played
4. Verify that clicking doesn't make a vote