### PR TITLE
Warboat crate drops gold when destroyed done properly && fixed crate auto-pickup

### DIFF
--- a/Entities/Industry/CTFShops/BoatShop/BoatShop.as
+++ b/Entities/Industry/CTFShops/BoatShop/BoatShop.as
@@ -57,21 +57,21 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("shop made item"))
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
-		bool isServer = (getNet().isServer());
+
 		u16 caller, item;
-		if (!params.saferead_netid(caller) || !params.saferead_netid(item))
+		string name;
+
+		if (!params.saferead_netid(caller) || !params.saferead_netid(item) || !params.saferead_string(name))
 		{
 			return;
 		}
-		string name = params.read_string();
-		{
-			if (name == "warboat")
-			{
-				CBlob@ crate = getBlobByNetworkID(item);
 
-				crate.set_Vec2f("required space", Vec2f(10, 6));
-				crate.set_s32("gold building amount", CTFCosts::warboat_gold);
-			}
+		if (name == "warboat")
+		{
+			CBlob@ crate = getBlobByNetworkID(item);
+
+			crate.set_Vec2f("required space", Vec2f(10, 6));
+			crate.set_s32("gold building amount", CTFCosts::warboat_gold);
 		}
 	}
 }

--- a/Entities/Industry/CTFShops/BoatShop/BoatShop.as
+++ b/Entities/Industry/CTFShops/BoatShop/BoatShop.as
@@ -57,5 +57,21 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("shop made item"))
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
+		bool isServer = (getNet().isServer());
+		u16 caller, item;
+		if (!params.saferead_netid(caller) || !params.saferead_netid(item))
+		{
+			return;
+		}
+		string name = params.read_string();
+		{
+			if (name == "warboat")
+			{
+				CBlob@ crate = getBlobByNetworkID(item);
+
+				crate.set_Vec2f("required space", Vec2f(10, 6));
+				crate.set_s32("gold building amount", CTFCosts::warboat_gold);
+			}
+		}
 	}
 }

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -118,7 +118,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			return;
 		}
 
-		if (name == "filled_bucket")
+		if (name == "filled_bucket" && isServer())
 		{
 			CBlob@ b = server_CreateBlobNoInit("bucket");
 			b.setPosition(callerBlob.getPosition());

--- a/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
+++ b/Entities/Industry/CTFShops/BuilderShop/BuilderShop.as
@@ -104,30 +104,28 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
 
-		if (!getNet().isServer()) return; /////////////////////// server only past here
-
 		u16 caller, item;
-		if (!params.saferead_netid(caller) || !params.saferead_netid(item))
+		string name;
+
+		if (!params.saferead_netid(caller) || !params.saferead_netid(item) || !params.saferead_string(name))
 		{
 			return;
 		}
-		string name = params.read_string();
-		{
-			CBlob@ callerBlob = getBlobByNetworkID(caller);
-			if (callerBlob is null)
-			{
-				return;
-			}
 
-			if (name == "filled_bucket")
-			{
-				CBlob@ b = server_CreateBlobNoInit("bucket");
-				b.setPosition(callerBlob.getPosition());
-				b.server_setTeamNum(callerBlob.getTeamNum());
-				b.Tag("_start_filled");
-				b.Init();
-				callerBlob.server_Pickup(b);
-			}
+		CBlob@ callerBlob = getBlobByNetworkID(caller);
+		if (callerBlob is null)
+		{
+			return;
+		}
+
+		if (name == "filled_bucket")
+		{
+			CBlob@ b = server_CreateBlobNoInit("bucket");
+			b.setPosition(callerBlob.getPosition());
+			b.server_setTeamNum(callerBlob.getTeamNum());
+			b.Tag("_start_filled");
+			b.Init();
+			callerBlob.server_Pickup(b);
 		}
 	}
 }

--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -185,38 +185,40 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	bool isServer = (getNet().isServer());
+	bool isServer = isServer();
 
 	if (cmd == this.getCommandID("shop made item"))
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
+
 		u16 caller, item;
-		if (!params.saferead_netid(caller) || !params.saferead_netid(item))
+		string name;
+
+		if (!params.saferead_netid(caller) || !params.saferead_netid(item) || !params.saferead_string(name))
 		{
 			return;
 		}
-		string name = params.read_string();
+
+		CBlob@ callerBlob = getBlobByNetworkID(caller);
+		if (callerBlob is null)
 		{
-			CBlob@ callerBlob = getBlobByNetworkID(caller);
-			if (callerBlob is null)
+			return;
+		}
+
+		if (name == "beer")
+		{
+			this.getSprite().PlaySound("/Gulp.ogg");
+			if (isServer)
 			{
-				return;
+				callerBlob.server_Heal(beer_amount);
 			}
-			if (name == "beer")
+		}
+		else if (name == "meal")
+		{
+			this.getSprite().PlaySound("/Eat.ogg");
+			if (isServer)
 			{
-				this.getSprite().PlaySound("/Gulp.ogg");
-				if (isServer)
-				{
-					callerBlob.server_Heal(beer_amount);
-				}
-			}
-			else if (name == "meal")
-			{
-				this.getSprite().PlaySound("/Eat.ogg");
-				if (isServer)
-				{
-					callerBlob.server_SetHealth(callerBlob.getInitialHealth());
-				}
+				callerBlob.server_SetHealth(callerBlob.getInitialHealth());
 			}
 		}
 	}

--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -118,7 +118,6 @@ void onTick(CBlob@ this)
 {
 	// TODO: Add stage based sleeping, rest(2 * 30) | sleep(heal_amount * (patient.getHealth() - patient.getInitialHealth())) | awaken(1 * 30)
 	// TODO: Add SetScreenFlash(rest_time, 19, 13, 29) to represent the player gradually falling asleep
-	bool isServer = getNet().isServer();
 	AttachmentPoint@ bed = this.getAttachments().getAttachmentPointByName("BED");
 	if (bed !is null)
 	{
@@ -127,7 +126,7 @@ void onTick(CBlob@ this)
 		{
 			if (bed.isKeyJustPressed(key_up) || patient.getHealth() == 0)
 			{
-				if (isServer)
+				if (isServer())
 				{
 					patient.server_DetachFrom(this);
 				}
@@ -140,7 +139,7 @@ void onTick(CBlob@ this)
 					{
 						Sound::Play("Heart.ogg", patient.getPosition(), 0.5);
 					}
-					if (isServer)
+					if (isServer())
 					{
 						f32 oldHealth = patient.getHealth();
 						patient.server_Heal(heal_amount);
@@ -149,7 +148,7 @@ void onTick(CBlob@ this)
 				}
 				else
 				{
-					if (isServer)
+					if (isServer())
 					{
 						patient.server_DetachFrom(this);
 					}
@@ -185,8 +184,6 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	bool isServer = isServer();
-
 	if (cmd == this.getCommandID("shop made item"))
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
@@ -208,7 +205,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (name == "beer")
 		{
 			this.getSprite().PlaySound("/Gulp.ogg");
-			if (isServer)
+			if (isServer())
 			{
 				callerBlob.server_Heal(beer_amount);
 			}
@@ -216,7 +213,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		else if (name == "meal")
 		{
 			this.getSprite().PlaySound("/Eat.ogg");
-			if (isServer)
+			if (isServer())
 			{
 				callerBlob.server_SetHealth(callerBlob.getInitialHealth());
 			}
@@ -235,7 +232,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			if (bed !is null && bedAvailable(this))
 			{
 				CBlob@ carried = caller.getCarriedBlob();
-				if (isServer)
+				if (isServer())
 				{
 					if (carried !is null)
 					{

--- a/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
+++ b/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
@@ -73,26 +73,28 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("shop made item"))
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
-		bool isServer = (getNet().isServer());
+
+		if (!getNet().isServer()) return; /////////////////////// server only past here
+
 		u16 caller, item;
-		if (!params.saferead_netid(caller) || !params.saferead_netid(item))
+		string name;
+
+		if (!params.saferead_netid(caller) || !params.saferead_netid(item) || !params.saferead_string(name))
 		{
 			return;
 		}
-		string name = params.read_string();
+
+		if (name == "upgradebolts")
 		{
-			if (name == "upgradebolts")
-			{
-				GiveFakeTech(getRules(), "bomb ammo", this.getTeamNum());
-			}
-			else if (name == "outpost")
-			{
-				CBlob@ crate = getBlobByNetworkID(item);
+			GiveFakeTech(getRules(), "bomb ammo", this.getTeamNum());
+		}
+		else if (name == "outpost")
+		{
+			CBlob@ crate = getBlobByNetworkID(item);
 				
-				crate.set_Vec2f("required space", Vec2f(5, 5));
-				crate.set_s32("gold building amount", CTFCosts::outpost_gold);
-				crate.Tag("unpack_check_nobuild");
-			}
+			crate.set_Vec2f("required space", Vec2f(5, 5));
+			crate.set_s32("gold building amount", CTFCosts::outpost_gold);
+			crate.Tag("unpack_check_nobuild");
 		}
 	}
 }

--- a/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
+++ b/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
@@ -74,8 +74,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
 
-		if (!getNet().isServer()) return; /////////////////////// server only past here
-
 		u16 caller, item;
 		string name;
 

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -25,20 +25,15 @@ void onInit(CBlob@ this)
 	this.addCommandID("stop unpack");
 	this.addCommandID("boobytrap");
 
-	string packed = this.get_string("packed");
-
 	this.set_u32("boobytrap_cooldown_time", 0);
-	int goldAmount = 0;
-	if (packed == "warboat")
-	{
-		goldAmount = 50;
-	}
-	this.set_s32("gold building amount", goldAmount);
+
+	this.set_s32("gold building amount", 0);
 
 	u8 frame = 0;
 	if (this.exists("frame"))
 	{
 		frame = this.get_u8("frame");
+		string packed = this.get_string("packed");
 
 		// GIANT HACK!!!
 		if (packed == "catapult" || packed == "bomber" || packed == "ballista" || packed == "outpost" || packed == "mounted_bow" || packed == "longboat" || packed == "warboat")


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

As per mugg's comment on the old PR:

https://github.com/transhumandesign/kag-base/pull/1475

The gold drops for Outpost crate and Warboat crate are declared in two different places.

Gold drop for Outpost crate is added via VehicleShop.as onCommand()
whereas epsilon's PR added Gold drop for Warboat crate in Crate.as onInit().

It also caused an issue with crates not being able to auto-pickup items.
Doing `blob.get_string("packed")` means `blob.exists("packed")` will return true every time after that (which is stupid, but I suppose you're supposed to do an .exists check before getting it every time),
so `crateTake()` in CratePickupCommon.as was returning false due to that, breaking the autopickup.