### PR TITLE
[fixed?] Player wouldn't receive spawn materials when a new match starts

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -18,7 +18,7 @@ const string SPAWN_ITEMS_TIMER_ARCHER  = "CTF SpawnItems Archer:";
 
 string base_name() { return "tent"; }
 
-bool SetMaterials(CBlob@ blob,  const string &in name, const int quantity, bool drop = false)
+bool SetMaterials(CBlob@ blob, const string &in name, const int quantity, bool drop = false)
 {
 	CInventory@ inv = blob.getInventory();
 	
@@ -99,6 +99,14 @@ void SetCTFTimer(CRules@ this, CPlayer@ p, s32 time, string classname)
 //prevents dying over and over, and allows getting more mats throughout the game
 void doGiveSpawnMats(CRules@ this, CPlayer@ p, CBlob@ b)
 {
+	// "no mats" fix
+	if (p.hasTag("give spawn material again"))
+	{
+		SetCTFTimer(this, p, 0, "builder");
+		SetCTFTimer(this, p, 0, "archer");
+		p.Untag("give spawn material again");
+	}
+
 	s32 gametime = getGameTime();
 	string name = b.getName();
 	

--- a/Rules/CommonScripts/RulesCore.as
+++ b/Rules/CommonScripts/RulesCore.as
@@ -274,6 +274,26 @@ shared class RulesCore
 		{
 			blob.server_SetPlayer(null);
 
+			// "no mats" fix
+			if (getGameTime() < 30)
+			{				
+				// remove previous items
+				CInventory@ inv = blob.getInventory();
+				if (inv !is null)
+				{
+					while (inv.getItemsCount() > 0)
+					{
+						print(getGameTime() + " inside remove Items loop");
+						CBlob@ item = inv.getItem(0);
+						blob.server_PutOutInventory(item);
+						item.server_Die();
+					}
+				}
+				
+				// make player eligible for spawn items once more
+				player.Tag("give spawn material again");
+			}
+
 			if (blob.getHealth() > 0.0f)
 				blob.server_Die();
 		}

--- a/Rules/CommonScripts/RulesCore.as
+++ b/Rules/CommonScripts/RulesCore.as
@@ -283,7 +283,6 @@ shared class RulesCore
 				{
 					while (inv.getItemsCount() > 0)
 					{
-						print(getGameTime() + " inside remove Items loop");
 						CBlob@ item = inv.getItem(0);
 						blob.server_PutOutInventory(item);
 						item.server_Die();


### PR DESCRIPTION
## Status

- **READY**

## Description

Fixes #1344.

This is a simple work-around fix for the "no mats" bug.
When joining a server fresh for the first time or when a new match starts, there is a rare chance that your blob will despawn and respawn in quick succession, causing your spawn items to drop to the ground and be picked up by teammates.

It is rather complicated but long story short: I traced the cause of this to be `DefaultBalanceTeams.as`. 
`BalanceAll()` would run `core.ChangePlayerTeam(p, tempteam);` which causes 
`BuildRespawnMenu()` in `onPlayerChangedTeam()` in `CTF_PickSpawn.as` to run which causes
`player.client_RequestSpawn(LAST_PICK);` to run which causes
`AddPlayerSpawn()` in `onPlayerRequestSpawn()` in `CoreHooks.as` to run which causes
`RemovePlayerBlob()` in `RulesCore` to run which causes
`blob.server_Die()` to run so the bug happens.
I think sometimes it runs until at least `BuildRespawnMenu()` without the bug happening.  
For more information, see discussion on Discord #development and comments in issue #1344.

I opted for this solution:
1) If the blob is despawned while in the first 30 ticks of gametime, then despawn all inventory items and apply `player.Tag("give spawn material again");`.
2) `doGiveSpawnMats()` in `CTF_GiveSpawnMaterials.as` would continuously run. When it does, it checks for the Tag and resets the material spawn timer so the player will receive materials once more.

I have tested this with `dedicatedserver.bat` and clumsy simulating up to 300 ping and didn't see bad side-effects so far.
I tested with `print()` to see when the bug scenario happens; when it does the materials are correctly removed and the player receives new ones.
There are still some things I'm wary of, so this is left "in development" for now until I can sort them out.
`BalanceAll()` would run in `DefaultBalanceTeams.as` if `(haveRestarted || (getGameTime() % 1800 == 0))`.
Maybe the bug could still happen if a player joins fresh for the first time and hits a game time of a multiple of 1800 ticks. But that would naturally be very rare.

## Steps to Test or Reproduce

1) Run `dedicatedserver.bat` and join server.
2) There is a rare chance that you will have no mats and the mats will have dropped to the floor or if there are player/bot teammates overlapping, they will have picked up the mats.
3) Go to the next map or scramble teams.
4) See 2)
