### PR TITLE
[fixed] Archer can't clip through wall when crouching and getting in a Crate 

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -359,7 +359,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			CInventory@ inv = this.getInventory();
 			u8 itemcount = inv.getItemsCount();
 			// Boobytrap if crate has enemy mine
-			CBlob@ mine = null;
 			for (int i = 0; i < inv.getItemsCount(); i++)
 			{
 				CBlob@ item = inv.getItem(i);
@@ -383,6 +382,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 
 			Vec2f velocity = caller.getVelocity();
+			
+			if (this.isAttachedTo(caller))
+			{
+				this.setPosition(caller.getPosition());
+			}
+			
 			this.server_PutInInventory( caller );
 			this.setVelocity(velocity);
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Listing

[changed/fixed] 
When getting in crate, if you are holding the crate, the crate assumes the caller's position.
Therefore, Archer hold Crate and crouching before a wall when getting in the crate will not clip you through the wall

[dev] 
Removed unused `CBlob@ mine = null;`.

## Description

Archer holding Crate and getting inside while crouching in front of a wall would occasionally clip you through the wall.
This PR makes it so the Crate will assume the player blob's position when getting in, but only if you are holding the crate.

## Steps to Test or Reproduce

Stand in front of a wall as Archer, hold a crate and crouch, tap the "get in" button.
Notice you will occasionally clip through the wall. **After this PR, not anymore.**

Keep showing buttons while throwing a crate away.
Click on the "get in" button while the crate lies on the ground.
Notice you will get in the Crate and the Crate will stay in the same position. **Unchanged after this PR.**

Place a Mine in a Crate.
Change Team.
Get in the Crate.
Notice that you will not get in and Mine flies out (booby trap). **Unchanged after this PR.**