### PR TITLE
[modified] increased build time resupplies

### DIFF
--- a/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
+++ b/Rules/CTF/Scripts/CTF_GiveSpawnItems.as
@@ -6,8 +6,8 @@
 const u32 materials_wait = 20; //seconds between free mats
 const u32 materials_wait_warmup = 40; //seconds between free mats
 
-const int warmup_wood_amount = 200;
-const int warmup_stone_amount = 60;
+const int warmup_wood_amount = 250;
+const int warmup_stone_amount = 80;
 
 const int matchtime_wood_amount = 100;
 const int matchtime_stone_amount = 30;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The decrease to 200 wood and 60 stone per resupply in build time was too harsh