### PR TITLE
[fixed] Knight can no longer destroy Wires/Components by Slashing/Jabbing

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1241,9 +1241,12 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 
 			if (b !is null)
 			{
-				if (b.hasTag("ignore sword")) continue;
-				if (!canHit(this, b)) continue;
-				if (knight_has_hit_actor(this, b)) continue;
+				if (b.hasTag("ignore sword") 
+				    || !canHit(this, b)
+				    || knight_has_hit_actor(this, b)) 
+				{
+					continue;
+				}
 
 				Vec2f hitvec = hi.hitpos - pos;
 
@@ -1258,8 +1261,7 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 					CBlob@ rayb = rayInfos[j].blob;
 					
 					if (rayb is null) break; // means we ran into a tile, don't need blobs after it if there are any
-					if (b.hasTag("ignore sword")) continue;
-					if (!canHit(this, rayb)) continue;
+					if (rayb.hasTag("ignore sword") || !canHit(this, rayb)) continue;
 
 					bool large = rayb.hasTag("blocks sword") && !rayb.isAttached() && rayb.isCollidable(); // usually doors, but can also be boats/some mechanisms
 					if (knight_has_hit_actor(this, rayb)) 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1544.

Although Wire, Inverter and other component blobs have Tag `"ignore sword"`, Knights could still destroy them via Jabbing/Slashing as long as the same attack also hit something else (a platform or a lever).

The cause of this is the line `this.server_Hit(rayb, rayInfos[j].hitpos, velocity, temp_damage, type, true);` in `DoAttack()` in `KnightLogic.as`. The function does check if `b` has Tag `"ignore sword"` (in fact, it checks for it twice) but it doesn't check if `rayb` has that Tag.

This PR fixes this by making the following changes:
- In `KnightLogic.as` in `DoAttack()`, `if (b.hasTag("ignore sword")) continue;` is only applied once instead of twice.
- Added `if (rayb.hasTag("ignore sword")) continue;`
- Stack conditions together via `||` instead of having a bunch of lines that say `continue;`.

I have tested it in offline.
The bug doesn't happen anymore and I have not witnessed any side-effects.
You can still not hit characters behind doors and you can still hit multiple blobs (lanterns, logs, doors).

## Steps to Test or Reproduce

Go to `Ni_Ashes` and go to the top center of the map and experiment with slashing/jabbing the Wire.
If your attack hits a platform or Lever, it has a chance of destroying the nearby Wire.
After this PR, it won't destroy anything.

Other maps you can test on are `Labyrinth` and `FilthPit`.