### PR TITLE
[changed] Reduce the wait time before you can move the camera after dying

### DIFF
--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -104,8 +104,6 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 				SetTargetPlayer(null);
 
 			}
-			deathTime = getGameTime() + 2 * getTicksASecond();
-
 		}
 		else
 		{
@@ -126,12 +124,9 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 				camera.setTarget(null);
 
 			}
-			deathTime = getGameTime() + 2 * getTicksASecond();
-
 		}
-
+		deathTime = getGameTime() + 1 * getTicksASecond();
 	}
-
 }
 
 void onRender(CRules@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1536.

This PR makes it so you can move the camera 1 second after dying instead of 2 seconds.
Tested and verified in offline and online.