### PR TITLE
[fixed] You can click on "change class" buttons from right corners of class shops

### DIFF
--- a/Entities/Common/Respawning/OneClassAvailable.as
+++ b/Entities/Common/Respawning/OneClassAvailable.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 		CShape@ shape = this.getShape();
 		if (shape !is null)
 		{
-			this.set_u8("class button radius", Maths::Max(this.getRadius(), (shape.getWidth() + shape.getHeight()) / 2));
+			this.set_u8("class button radius", Maths::Max(this.getRadius(), Maths::Max(shape.getWidth(), shape.getHeight()) + 8));
 		}
 		else
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1505.

This is a simple fix that makes it so you can click the "change class" button from right corner of a class shop.
This was achieved in `OneClassAvailable.as` by increasing `this.get_u8("class button radius");` in `onInit()` which is applied to the button's `enableRadius` in `getButtonsFor()`.
To determine a higher "class button radius", instead of calculating the average of shape with and shape height, I take whatever is higher and add 8 more to it. So the "class button radius" for class shops is now 48 instead of 32.

There is a more sophisticated solution that will enable or disable the class change button dependent on your distance with the shop, but I decided against it for now.
The solution being:
- Add this to each class shop's `onInit()`:
```
	this.getCurrentScript().runFlags |= Script::tick_blob_in_proximity;
	this.getCurrentScript().runProximityTag = "player";
	this.getCurrentScript().runProximityRadius = 8.0f;
```
- Add this for each class shop:
```
void onTick(CBlob@ this)
{
	CButton@ button = getHUD().getButtonWithCommandID(SpawnCmd::changeClass);
	if (button !is null)
	{
		f32 distance = (this.getPosition() - button.getOwner().getPosition()).Length();
		f32 allowed_distance = this.get_u8("class button radius");
		
		button.SetEnabled((distance < allowed_distance) ? true : false);
	}
}
```
- Remove the line `button.enableRadius = this.get_u8("class button radius");` from `GetButtonsFor()` in `OneClassAvailable.as`.

Although I didn't see lag after placing hundreds of Knightshops, I'm still afraid if a ton of proximity checks could drain performance. The solution should also be applied to all buttons, not just "class change" buttons.

## Steps to Test or Reproduce

Build Archershop, Knightshop or Buildershop and place blocks so that you can stand inside the left and right corners without being able to pass through.
Show buttons, you will notice that you can change class from the left corners but not from the right corners. 
**After this PR, you can change class from both sides.**