### PR TITLE
[fixed] War Base crash bug

### DIFF
--- a/Entities/Special/WAR/WAR_base/WAR_base.as
+++ b/Entities/Special/WAR/WAR_base/WAR_base.as
@@ -158,7 +158,7 @@ void onTick(CBlob@ this)
 		int myteam = this.getTeamNum();
 		Vec2f pos = this.getPosition();
 		CBlob@[] blobs;
-		this.getMap().getBlobs(@blobs);
+		getBlobs(@blobs);
 
 		for (uint blob_step = 0; blob_step < blobs.length; ++blob_step)
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1543.

I spent many hours finding the cause of the War Base crash and found that `getMap().getBlobs()` is the culprit.
It doesn't fetch blobs properly.
But using just `getBlobs()` will work fine.

So I made this PR which changes the code so the crash will not happen anymore.

## Steps to Test or Reproduce

Use this code inside `WAR_base.as`:
```
void onTick(CBlob@ this)
{
	if (isServer())
	{
		CBlob@[] b;
		this.getMap().getBlobs(@b);

		for (uint s = 0; s < b.length; ++s)
		{
			CBlob@ blob = b[s];
			
			if (blob is null) 
				continue;
			
			Vec2f blobpos = blob.getPosition();
			print(" "+blobpos);
		}
	}
}
```
When you spawn a `war_base`, it will print either a lot of `(0, 0)` or `(nan, nan)` or even things like `(-2.26674e+23, -nan)`.
Sometimes it will just crash.
After applying the PR, it will print proper positions that make sense since they can be logically assigned to things that are actually on the map.