### PR TITLE
[changed] You can replace Wood Doors with Stone Doors / You can repair Spikes

### DIFF
--- a/Entities/Structures/Door/SwingDoor.as
+++ b/Entities/Structures/Door/SwingDoor.as
@@ -26,25 +26,31 @@ void onInit(CBlob@ this)
 	{
 		this.set_TileType("background tile", CMap::tile_castle_back);
 
-		if (getNet().isServer())
+		if (isServer())
 		{
 			dictionary harvest;
 			harvest.set('mat_stone', 10);
 			this.set('harvest', harvest);
 		}
+		
+		this.Tag("can replace");
+		string[] names_to_replace = {"wooden_door"};
+		this.set("names to replace", names_to_replace);
 	}
 	else
 	{
 		this.set_TileType("background tile", CMap::tile_wood_back);
 
-		if (getNet().isServer())
+		if (isServer())
 		{
 			dictionary harvest;
 			harvest.set('mat_wood', 10);
 			this.set('harvest', harvest);
 		}
 	}
+	
 	this.Tag("door");
+	this.Tag("repairable");
 	this.Tag("blocks water");
 	this.Tag("explosion always teamkill"); // ignore 'no teamkill' for explosives
 }

--- a/Entities/Structures/Platform/Bridge.as
+++ b/Entities/Structures/Platform/Bridge.as
@@ -5,6 +5,7 @@
 void onInit(CBlob@ this)
 {
 	this.Tag("place norotate");
+	this.Tag("repairable");
 
 	this.Tag("explosion always teamkill"); // ignore 'no teamkill' for explosives
 

--- a/Entities/Structures/Platform/WoodenPlatform.as
+++ b/Entities/Structures/Platform/WoodenPlatform.as
@@ -17,10 +17,11 @@ void onInit(CBlob@ this)
 	this.set_s16(burn_duration , 300);
 	//transfer fire to underlying tiles
 	this.Tag(spread_fire_tag);
+	
+	this.Tag("repairable");
 
 	if (this.getName() == "wooden_platform")
 	{
-
 		if (getNet().isServer())
 		{
 			dictionary harvest;

--- a/Entities/Structures/Spikes/Spikes.as
+++ b/Entities/Structures/Spikes/Spikes.as
@@ -31,6 +31,7 @@ void onInit(CBlob@ this)
 	consts.mapCollisions = false;	 // we have our own map collision
 
 	this.Tag("place norotate");
+	this.Tag("repairable");
 
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	//dont set radius flags here so we orient to the ground first


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**
- Remaining issues:
Repairing Spikes should get rid of blood.
Repairing Spikes will make a "take item" sound instead of "spikes being placed" sound.
- After testing, I found Stone door replacing wood door doesn't work in online.

## Description

[changed] You will be able to replace mossy tile with a normal castle tile - Fixes #1530
[changed] You will be able to place Stone Door on a Wood Door in order to replace it - Fixes #1433
[changed] You will be able to repair Spikes

I made some changes to the Blob Placement logic.
Most notably, instead of having a bunch of `isPlatform`, `isDoor`, `isSpikes`, I add a generic Tag `"repairable"` to `Spikes.as`, `Bridge.as`, `WoodenPlatform.as` and `SwingDoor.as`.

For the stone type of `SwingDoor`, I added Tag `"can replace"` and a strings array `names_to_replace` which is saved to the SwingDoor blob. This array currently only contains `wooden_door`. The same principle could be used in the future for other blobs.

Unfortunately, `PlaceBlob()` in `BlobPlacement.as` seems to be called from the engine-side with parameters such as `repairing`. So I couldn't add my own `replacing` boolean. Instead, I check if overlapping blobs contain a "name to replace" and if yes, save the net id of that blob and check for it in `PlaceBlob()`. If the net id blob exists and the blob placement occurs successfully, then the blob will be replaced (`server_Die()` is applied).

So far, I have tested this only in offline. It needs to be tested in online. Given the complexity of the blob placement logic, it would be good to test this in a larger match setting.

