### PR TITLE
Vehicles open doors

### DIFF
--- a/Entities/Structures/Door/DoorCommon.as
+++ b/Entities/Structures/Door/DoorCommon.as
@@ -20,7 +20,7 @@ bool canOpenDoor(CBlob@ this, CBlob@ blob)
 				for (u8 i = 0; i < aps.length; i++)
 				{
 					AttachmentPoint@ ap = aps[i];
-					if (ap.name != "ROWER" && ap.name != "DRIVER") continue;
+					if (ap.name != "ROWER" && ap.name != "DRIVER" && ap.name != "SAIL") continue;
 					if (ap.getOccupied() is null) continue;
 					
 					if (ap.isKeyPressed(key_left)) return true;

--- a/Entities/Structures/Door/DoorCommon.as
+++ b/Entities/Structures/Door/DoorCommon.as
@@ -7,16 +7,35 @@ bool canOpenDoor(CBlob@ this, CBlob@ blob)
 	        (this.getTeamNum() == 255 || this.getTeamNum() == blob.getTeamNum()) &&
 	        (blob.hasTag("player") || blob.hasTag("vehicle") || blob.hasTag("migrant"))) //tags that can open doors
 	{
-		Vec2f direction = Vec2f(0, -1);
-		direction.RotateBy(this.getAngleDegrees());
-
 		Vec2f doorpos = this.getPosition();
-		Vec2f playerpos = blob.getPosition();
-
-		if (blob.isKeyPressed(key_left) && playerpos.x > doorpos.x && Maths::Abs(playerpos.y - doorpos.y) < 11) return true;
-		if (blob.isKeyPressed(key_right) && playerpos.x < doorpos.x && Maths::Abs(playerpos.y - doorpos.y) < 11) return true;
-		if (blob.isKeyPressed(key_up) && playerpos.y > doorpos.y && Maths::Abs(playerpos.x - doorpos.x) < 11) return true;
-		if (blob.isKeyPressed(key_down) && playerpos.y < doorpos.y && Maths::Abs(playerpos.x - doorpos.x) < 11) return true;
+		Vec2f blobpos = blob.getPosition();
+	
+		if (blob.hasTag("vehicle"))
+		{
+			if (doorpos.y > blobpos.y + blob.getHeight()/2 + 2) return false;
+			
+			AttachmentPoint@[] aps;
+			if (blob.getAttachmentPoints(@aps))
+			{
+				for (u8 i = 0; i < aps.length; i++)
+				{
+					AttachmentPoint@ ap = aps[i];
+					if (ap.name != "ROWER" && ap.name != "DRIVER") continue;
+					if (ap.getOccupied() is null) continue;
+					
+					if (ap.isKeyPressed(key_left)) return true;
+					if (ap.isKeyPressed(key_right)) return true;
+				}
+			}
+			
+			return false;
+		}
+		
+		if (blob.isKeyPressed(key_left)  && blobpos.x > doorpos.x && Maths::Abs(blobpos.y - doorpos.y) < 11) return true;
+		if (blob.isKeyPressed(key_right) && blobpos.x < doorpos.x && Maths::Abs(blobpos.y - doorpos.y) < 11) return true;
+		if (blob.isKeyPressed(key_up)    && blobpos.y > doorpos.y && Maths::Abs(blobpos.x - doorpos.x) < 11) return true;
+		if (blob.isKeyPressed(key_down)  && blobpos.y < doorpos.y && Maths::Abs(blobpos.x - doorpos.x) < 11) return true;
 	}
+	
 	return false;
 }

--- a/Entities/Vehicles/Boats/Dinghy.as
+++ b/Entities/Vehicles/Boats/Dinghy.as
@@ -24,7 +24,6 @@ void onInit(CBlob@ this)
 	                        0.0f, // movement sound volume modifier   0.0f = no manipulation
 	                        0.0f // movement sound pitch modifier     0.0f = no manipulation
 	                       );
-	this.getShape().SetOffset(Vec2f(0, 9));
 	this.getShape().SetCenterOfMassOffset(Vec2f(-1.5f, 4.5f));
 	this.getShape().getConsts().transports = true;
 	this.Tag("medium weight");

--- a/Entities/Vehicles/Boats/Dinghy.cfg
+++ b/Entities/Vehicles/Boats/Dinghy.cfg
@@ -14,7 +14,7 @@ $sprite_texture                            = Dinghy.png
 s32_sprite_frame_width                     = 64
 s32_sprite_frame_height                    = 32
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = 0
+f32 sprite_offset_y                        = -9
 
 	$sprite_gibs_start                     = *start*
 
@@ -90,9 +90,9 @@ $brain_factory                             =
 $attachment_factory                        = box2d_attachment
 @$attachment_scripts                       =
 # name; pixel offset (from center) X; offset Y; socket/plug 0/1; controller; radius
-@$attachment_points                        =  ROWER; -15; -1;  0; 1; 7;
-											  ROWER; -1;  -1;  0; 1; 7;
-											  PICKUP; -3;   8; 1; 0; 0;
+@$attachment_points                        =  ROWER; -15; -10;  0; 1; 7;
+											  ROWER; -1;  -10;  0; 1; 7;
+											  PICKUP; -3; -1; 1; 0; 0;
 
 $inventory_factory                         = generic_inventory
 @$inventory_scripts                        =
@@ -115,7 +115,7 @@ $name                                      = dinghy
 										 VehicleConvert.as;
 										 SinkOnLowHealth.as;
 										# RunOverPeople.as;
-										FakeBoatCollision.as;
+										 FakeBoatCollision.as;
 										 BoatCommon.as;   # put last for rowing sounds
 										 IsFlammable.as;
 										 RandomExitVelocity.as;

--- a/Entities/Vehicles/Common/BoatCommon.as
+++ b/Entities/Vehicles/Common/BoatCommon.as
@@ -103,7 +103,6 @@ void onTick(CBlob@ this)
 							Vec2f vel = this.getVelocity();
 							for (int particle_step = 0; particle_step < 3; ++particle_step)
 							{
-
 								Splash(pos, vel, particle_step);
 							}
 						}
@@ -146,10 +145,9 @@ void onTick(CBlob@ this)
 		f32 side = this.isFacingLeft() ? this.getWidth() : -this.getWidth();
 		side *= 0.45f;
 		pos.x += side;
-		pos.y += 14.0f;
+		pos.y += this.getHeight() * 0.5f + 4.0f;
 		Splash(pos, this.getVelocity(), XORRandom(3));
 	}
-
 }
 
 // show oars when someone hopped in as rower


### PR DESCRIPTION
## Status

- **READY**

## Description

Vehicles open doors. This was already a feature in KAG some time ago but it was likely removed unintentionally.

https://user-images.githubusercontent.com/68350259/210167289-f17a1706-2b65-47f4-adb7-b14aceb86bc1.mp4


## Steps to Test or Reproduce

Drive a vehicle towards doors and watch as they open magically. This should work with both boats and ground vehicles. Vehicles should not open doors under them, only above or directly to the sides.
