### PR TITLE
[fixed] workbench bad delta bug

### DIFF
--- a/Entities/Industry/Workbench/Workbench.as
+++ b/Entities/Industry/Workbench/Workbench.as
@@ -71,23 +71,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 	if (cmd == this.getCommandID("shop buy"))
 	{
-		u16 callerID;
-		if (!params.saferead_u16(callerID))
-			return;
-		bool spawnToInventory = params.read_bool();
-		bool spawnInCrate = params.read_bool();
-		bool producing = params.read_bool();
-		string blobName = params.read_string();
-		u8 s_index = params.read_u8();
-
-		// check spam
-		//if (blobName != "factory" && isSpammed( blobName, this.getPosition(), 12 ))
-		//{
-		//}
-		//else
-		{
-			this.getSprite().PlaySound("/ConstructShort");
-		}
+		this.getSprite().PlaySound("/ConstructShort");
 	}
 }
 

--- a/Entities/Industry/Workbench/Workbench.as
+++ b/Entities/Industry/Workbench/Workbench.as
@@ -67,9 +67,7 @@ void InitWorkshop(CBlob@ this)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	bool isServer = getNet().isServer();
-
-	if (cmd == this.getCommandID("shop buy"))
+	if (cmd == this.getCommandID("shop made item"))
 	{
 		this.getSprite().PlaySound("/ConstructShort");
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1555.

This is a fix for the workbench bad snapshot bug that happens when you craft items at workbench in online servers.

`AddShopItemsToMenu()` in `Shop.as` applies this to command `"shop buy"`:
```
		CBitStream params;
		params.write_u16(caller.getNetworkID());
		params.write_bool(s_item.spawnToInventory);
		params.write_bool(s_item.spawnInCrate);
		params.write_bool(s_item.producing);
		params.write_u8(u8(i));
		params.write_bool(false); //used hotkey?
```
and reads it in `onCommand()` as such:
```
		if (!params.saferead_u16(callerID))
			return;
		bool spawnToInventory = params.read_bool();
		bool spawnInCrate = params.read_bool();
		bool producing = params.read_bool();
		u8 s_index = params.read_u8();
		bool hotkey = params.read_bool();
```
But `Workbench.as` reads it in `onCommand()` as such:
```
		u16 callerID;
		if (!params.saferead_u16(callerID))
			return;
		bool spawnToInventory = params.read_bool();
		bool spawnInCrate = params.read_bool();
		bool producing = params.read_bool();
		string blobName = params.read_string();
		u8 s_index = params.read_u8();
```
So things were not being read in the correct order and way.

To fix this, I made this change:
`Workbench.as` responds to command `"shop made item"` instead of `"shop buy"`. 
Nothing was being done with the values and I saw this code being used in Knightshop
```
	if (cmd == this.getCommandID("shop made item"))
	{
		this.getSprite().PlaySound("/ChaChing.ogg");
	}
```
so I applied it to Workbench in a similar fashion.

I removed the unused `bool isServer = getNet().isServer();`.

Tested in offline and in online server, it plays the "item crafted" sound correctly and no snapshot error occurs.

## Steps to Test or Reproduce

Go to online server.
Craft items in Workbench.
Notice you get snapshot errors.
**After this PR, you don't get errors.**