### PR TITLE
Fixed grain not appearing on player join

### DIFF
--- a/Entities/Natural/Farming/GrainPlantLogic.as
+++ b/Entities/Natural/Farming/GrainPlantLogic.as
@@ -12,7 +12,7 @@ void onInit(CBlob@ this)
 	this.Tag("builder always hit");
 
 	// this script gets removed so onTick won't be run on client on server join, just onInit
-	if (this.hasTag("instant_grow"))
+	if (this.hasTag("instant_grow") || this.hasTag("has grain"))
 	{
 		GrowGrain(this);
 	}


### PR DESCRIPTION
## Status

- **READY**

## Description

When joining a server, fully grown grain plants will not update to the client fully and the grains will not appear. This is fixed in this PR, so that the plant will update to the client when a player joins.

![Capture](https://user-images.githubusercontent.com/68350259/210285307-bfc485c0-daa4-4410-9000-9cbccbb001c0.PNG)

Pic of a bugged grain plant with no grains

## Steps to Test or Reproduce

Spawn a grain plant and let it grow on a dedicated server (be aware that map-generated plants don't have the bug). Spawn a bot to keep the server ticking when there is no other players (this step may not be necessary). Leave the server and rejoin. There should be no difference in visuals if the fix is applied. 
