### PR TITLE
[boat rebuild] Improved vehicle capturing

### DIFF
--- a/Entities/Industry/CTFShops/Outpost/Outpost.as
+++ b/Entities/Industry/CTFShops/Outpost/Outpost.as
@@ -30,6 +30,9 @@ void onInit(CBlob@ this)
 	this.set_Vec2f("travel offset", Vec2f(-10, 0));
 	this.inventoryButtonPos = Vec2f(12, -12);
 
+	// add custom capture zone
+	getMap().server_AddMovingSector(Vec2f(-16.0f, -8.0f), Vec2f(16.0f, 16.0f), "capture zone "+this.getNetworkID(), this.getNetworkID());
+
 	CSprite@ sprite = this.getSprite();
 	CSpriteLayer@ flag = sprite.addSpriteLayer("flag layer", "Outpost.png", 32, 32);
 	if (flag !is null)

--- a/Entities/Vehicles/Airships/Airship.as
+++ b/Entities/Vehicles/Airships/Airship.as
@@ -23,6 +23,9 @@ void onInit(CBlob@ this)
 	this.getShape().SetOffset(Vec2f(-6, 16));
 	this.getShape().getConsts().bullet = true;
 	this.getShape().getConsts().transports = true;
+	
+	// add custom capture zone
+	getMap().server_AddMovingSector(Vec2f(-40.0f, -16.0f), Vec2f(15.0f, 4.0f), "capture zone "+this.getNetworkID(), this.getNetworkID());
 
 	// additional shapes
 

--- a/Entities/Vehicles/Boats/Dinghy.as
+++ b/Entities/Vehicles/Boats/Dinghy.as
@@ -27,7 +27,7 @@ void onInit(CBlob@ this)
 	this.getShape().SetCenterOfMassOffset(Vec2f(-1.5f, 4.5f));
 	this.getShape().getConsts().transports = true;
 	this.Tag("medium weight");
-	this.Tag("short raid time"); // captures quicker
+	this.set_u16("capture time", 10); // captures quicker
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Vehicles/Boats/Dinghy.as
+++ b/Entities/Vehicles/Boats/Dinghy.as
@@ -28,6 +28,8 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().transports = true;
 	this.Tag("medium weight");
 	this.set_u16("capture time", 10); // captures quicker
+	
+	getMap().server_AddMovingSector(Vec2f(-12.0f, -12.0f), Vec2f(12.0f, 0.0f), "capture zone "+this.getNetworkID(), this.getNetworkID());
 }
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)

--- a/Entities/Vehicles/Boats/LongBoat.as
+++ b/Entities/Vehicles/Boats/LongBoat.as
@@ -28,6 +28,9 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().bullet = false;
 	this.set_f32("map dmg modifier", 150.0f);
 
+	// add custom capture zone
+	getMap().server_AddMovingSector(Vec2f(-30.0f, -16.0f), Vec2f(25.0f, 4.0f), "capture zone "+this.getNetworkID(), this.getNetworkID());
+
 	//block knight sword
 	this.Tag("blocks sword");
 

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -123,10 +123,13 @@ void onInit(CBlob@ this)
 
 	this.set_f32("oar offset", 54.0f);
 
+	CMap@ map = getMap();
 	// add pole ladder
-	getMap().server_AddMovingSector(Vec2f(-28.0f, -32.0f), Vec2f(-12.0f, 0.0f), "ladder", this.getNetworkID());
+	map.server_AddMovingSector(Vec2f(-28.0f, -32.0f), Vec2f(-12.0f, 0.0f), "ladder", this.getNetworkID());
 	// add back ladder
-	getMap().server_AddMovingSector(Vec2f(-50.0f, 0.0f), Vec2f(-35.0f, 20.0f), "ladder", this.getNetworkID());
+	map.server_AddMovingSector(Vec2f(-50.0f, 0.0f), Vec2f(-35.0f, 20.0f), "ladder", this.getNetworkID());
+	// add custom capture zone
+	map.server_AddMovingSector(Vec2f(-40.0f, -30.0f), Vec2f(10.0f, 5.0f), "capture zone "+this.getNetworkID(), this.getNetworkID());
 
 	//set custom minimap icon
 	this.SetMinimapOutsideBehaviour(CBlob::minimap_snap);
@@ -134,7 +137,7 @@ void onInit(CBlob@ this)
 	this.SetMinimapRenderAlways(true);
 
 	// mounted bow
-	if (getNet().isServer())// && hasTech( this, "mounted bow"))
+	if (isServer())// && hasTech( this, "mounted bow"))
 	{
 		CBlob@ bow = server_CreateBlob("mounted_bow");
 		if (bow !is null)

--- a/Entities/Vehicles/Common/VehicleConvert.as
+++ b/Entities/Vehicles/Common/VehicleConvert.as
@@ -16,6 +16,7 @@ const string short_raid_tag = "short raid time";
 void onInit(CBlob@ this)
 {
 	this.getCurrentScript().tickFrequency = 15;
+	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	
 	if (isServer())
 	{
@@ -51,10 +52,16 @@ int GetCaptureTime(CBlob@ blob)
 
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
-	if (!this.hasTag("convert on sit"))
-		return;
+	if (!isServer()) return;
 
-	if (attachedPoint.socket &&
+	if (this.isAttached() && this.hasTag(raid_tag))
+	{
+		ResetProperties(this);
+		SyncProperties(this);
+	}
+
+	if (this.hasTag("convert on sit") && 
+			attachedPoint.socket &&
 	        attached.getTeamNum() != this.getTeamNum() &&
 	        attached.hasTag("player"))
 	{

--- a/Entities/Vehicles/Common/VehicleConvert.as
+++ b/Entities/Vehicles/Common/VehicleConvert.as
@@ -139,31 +139,34 @@ void onTick(CBlob@ this)
 
 void onChangeTeam(CBlob@ this, const int oldTeam)
 {
-	if (this.getTeamNum() >= 0 && this.getTeamNum() < 10)
+	ConvertPoints(this, "VEHICLE,BOW,DOOR");
+
+	if (this.getTeamNum() < 10)
 	{
 		CSprite@ sprite = this.getSprite();
 		if (sprite !is null)
 		{
 			sprite.PlaySound("/VehicleCapture");
 		}
-
-		ConvertPoint(this, "VEHICLE");
-		ConvertPoint(this, "DOOR");
 	}
 }
 
-void ConvertPoint(CBlob@ this, const string pointName)
+void ConvertPoints(CBlob@ this, const string pointNames)
 {
-	CAttachment@ att = this.getAttachments();
-	if (att is null) return;
-	AttachmentPoint@ point = att.getAttachmentPointByName(pointName);
-	if (point !is null)
+	if (!isServer()) return;
+
+	AttachmentPoint@[] aps;
+	if (!this.getAttachmentPoints(@aps)) return;
+
+	for (u8 i = 0; i < aps.length; i++)
 	{
+		AttachmentPoint@ point = aps[i];
 		CBlob@ blob = point.getOccupied();
-		if (blob !is null)
-		{
-			blob.server_setTeamNum(this.getTeamNum());
-		}
+		if (blob is null) continue;
+		
+		if (pointNames.find(point.name) == -1) continue;
+		
+		blob.server_setTeamNum(this.getTeamNum());
 	}
 }
 

--- a/Entities/Vehicles/Common/VehicleConvert.as
+++ b/Entities/Vehicles/Common/VehicleConvert.as
@@ -146,7 +146,7 @@ void onTick(CBlob@ this)
 
 void onChangeTeam(CBlob@ this, const int oldTeam)
 {
-	ConvertPoints(this, "VEHICLE,BOW,DOOR");
+	ConvertAttachments(this);
 
 	if (this.getTeamNum() < 10)
 	{
@@ -158,7 +158,9 @@ void onChangeTeam(CBlob@ this, const int oldTeam)
 	}
 }
 
-void ConvertPoints(CBlob@ this, const string pointNames)
+const string[] convertPoints = { "VEHICLE", "BOW", "DOOR" };
+
+void ConvertAttachments(CBlob@ this)
 {
 	if (!isServer()) return;
 
@@ -171,7 +173,7 @@ void ConvertPoints(CBlob@ this, const string pointNames)
 		CBlob@ blob = point.getOccupied();
 		if (blob is null) continue;
 		
-		if (pointNames.find(point.name) == -1) continue;
+		if (convertPoints.find(point.name) == -1) continue;
 		
 		blob.server_setTeamNum(this.getTeamNum());
 	}


### PR DESCRIPTION
## Status

- **READY**

## Description

A few minor improvements to vehicle capturing.

* Commit 1: Fixed a bug where the mounted bow on a warship would not change teams.
* Commit 3: Attached vehicles can only be converted by their parent (The vehicle that they are attached to).
* Commit 4: Introduces customizable capture zones, which fixes a problem with outposts being capped outside of walls. More in detail farther down.

## Steps to Test or Reproduce

A: Test to see the warboat's mounted bow change team when the warboat is captured.
B: Attach a catapult to a warboat/longboat. Now try to capture the catapult. You should only see the boat being captured.
C: Place one layer of blocks around an outpost. You shouldn't be able to capture it outside of the blocks.

devs & modders listen:
Capture zones are customizable. For example, here is the zoning I've added for boats;

![Capture Zones](https://user-images.githubusercontent.com/68350259/210746374-c1f8d6ef-736e-4a6e-ad5a-c7d272f3ee6c.png)

The zones may seem a bit small, but capturing is triggered when you touch the zone, not when you are all the way inside. You can see zones in game by using ``/g_debug 2`` in your console.

If a blob's script doesn't define a capture zone, its default capture zone will be based off its radius.