### PR TITLE
[boat rebuild] Crate required space consistency

### DIFF
--- a/Entities/Common/Includes/MiniIconsInc.as
+++ b/Entities/Common/Includes/MiniIconsInc.as
@@ -13,6 +13,7 @@ namespace FactoryFrame
 		catapult = 4,
 		ballista,
 		mounted_bow,
+		outpost,
 
 		saw = 8,
 		drill,

--- a/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
+++ b/Entities/Industry/CTFShops/VehicleShop/VehicleShop.as
@@ -74,7 +74,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		this.getSprite().PlaySound("/ChaChing.ogg");
 
-		u16 caller, item;
+		/*u16 caller, item;
 		string name;
 
 		if (!params.saferead_netid(caller) || !params.saferead_netid(item) || !params.saferead_string(name))
@@ -93,6 +93,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			crate.set_Vec2f("required space", Vec2f(5, 5));
 			crate.set_s32("gold building amount", CTFCosts::outpost_gold);
 			crate.Tag("unpack_check_nobuild");
-		}
+		}*/
 	}
 }

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -9,6 +9,14 @@
 #include "GenericButtonCommon.as"
 #include "KnockedCommon.as"
 
+// crate tags and their uses
+
+// "parachute"      : this uses a parachute
+// "unpackall"       : this can unpack even if there is no "packed" blob
+// "unpack on land"    : this unpacks when touching ground
+// "destroy on touch"   : this dies when touching ground
+// "unpack_only_water"   : this can only unpack in water
+// "unpack_check_nobuild" : this can only unpack if block-type blobs arent in the way
 
 //proportion of distance allowed (1.0f == overlapping radius, 2.0f = within 1 extra radius)
 const f32 ally_allowed_distance = 2.0f;

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -722,10 +722,10 @@ bool canUnpackHere(CBlob@ this)
 		if (parent !is null)
 		{
 			inwater = parent.isInWater() || map.isInWater(parent.getPosition() + Vec2f(0.0f, parent.getRadius()));
-			return ((!water && (parent.isOnGround() || inwater)) || (water && inwater));
+			return ((!water && parent.isOnGround()) || (water && inwater));
 		}
 	}
-	const bool supported = ((!water && (this.isOnGround() || inwater)) || (water && inwater));
+	const bool supported = ((!water && this.isOnGround()) || (water && inwater));
 	return (supported);
 }
 

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -734,12 +734,10 @@ bool canUnpackHere(CBlob@ this)
 
 Vec2f crate_getOffsetPos(CBlob@ blob, CMap@ map)
 {
-	Vec2f halfSize = blob.get_Vec2f(required_space) * 0.5f;
-
-	Vec2f alignedWorldPos = map.getAlignedWorldPos(blob.getPosition() + Vec2f(0, -2)) + (Vec2f(0.5f, 0.0f) * map.tilesize);
-	Vec2f offsetPos = alignedWorldPos - Vec2f(halfSize.x , halfSize.y) * map.tilesize;
-	offsetPos += blob.get_Vec2f("space_offset") * map.tilesize;
-	offsetPos = map.getAlignedWorldPos(offsetPos);
+	Vec2f space = blob.get_Vec2f("required space");
+	space.x *= 0.5f;
+	space.y -= 1;
+	Vec2f offsetPos = map.getAlignedWorldPos(blob.getPosition() + Vec2f(4, 6) - space * map.tilesize);
 	return offsetPos;
 }
 

--- a/Entities/Items/Crate/CrateCommon.as
+++ b/Entities/Items/Crate/CrateCommon.as
@@ -1,3 +1,21 @@
+shared class Crate
+{
+	string name;
+	u8 frame;
+	Vec2f space;
+	u16 gold;
+	string[] tags;
+	
+	Crate(const string &in name, const u8 &in frame, const Vec2f &in space, const u16 &in gold = 0, const string &in tags = "")
+	{
+		this.name = name;
+		this.frame = frame;
+		this.space = space;
+		this.gold = gold;
+		this.tags = tags.split("\\"); //hack
+	}
+}
+
 bool hasSomethingPacked(CBlob @this)
 {
 	return (this.exists("packed") && this.get_string("packed").size() > 0);


### PR DESCRIPTION
## Status

- **READY**

## Description

Resolves #1450.

Specific crates are given their own unique 'required space' depending on the packed blob.
Here is a video showing the differences in unpacking space.

https://user-images.githubusercontent.com/68350259/211714922-5bc14112-a938-421e-ad07-37830ca3c7eb.mp4

## Steps to Test or Reproduce

a) Use ``!crate (name)`` or buy from vehicle/boat shops to get crates of a longboat, a warboat, and a ballista.
b) Unpack each one to assess if the required space is correct.

Note for reviewers:
Commit 1 & 2 are the necessary changes. 3 & 4 give no functional change.
