### PR TITLE
Fixed quarters limbo

### DIFF
--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -348,16 +348,14 @@ void updateLayer(CSprite@ sprite, string name, int index, bool visible, bool rem
 
 bool bedAvailable(CBlob@ this)
 {
+	if (this.getHealth() <= 0.0f) return false;
+
 	AttachmentPoint@ bed = this.getAttachments().getAttachmentPointByName("BED");
 	if (bed !is null)
 	{
-		CBlob@ patient = bed.getOccupied();
-		if (patient !is null)
-		{
-			return false;
-		}
+		return bed.getOccupied() is null;
 	}
-	return true;
+	return false;
 }
 
 bool requiresTreatment(CBlob@ this, CBlob@ caller)


### PR DESCRIPTION
## Status

- **READY**

## Description

Closes duplicate pull request #1303

Here's a demonstration of the bug that is fixed in this pr.

https://user-images.githubusercontent.com/68350259/213346755-4b7a81af-467a-46de-a04a-bb316733901c.mp4

and here is the bug in a public game

https://user-images.githubusercontent.com/68350259/213349964-f4f3dda6-d5af-43e1-94ad-4ef7d16c8d76.mp4

## Steps to Test or Reproduce

Test on a **dedicated server**.
Reproducing this bug is a tad difficult, as you have to attach to the quarters at about the same tick the quarters is destroyed.
The timing can be done easier by spawning a quarters on top of a crate and using the collapse as a cue to attach to the quarters (as shown in the first video).

With the applied fix, the player will not attach if the quarters is dead. Print statements is a reliable way to confirm if the fix works.
