### PR TITLE
[modified] Update tunnel menu to display options in consistent order

### DIFF
--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -5,6 +5,28 @@
 #include "KnockedCommon.as";
 #include "GenericButtonCommon.as";
 
+// Wrapper class that overrides opCmp to allow sorting by position
+class PositionComparableCBlobWrapper 
+{
+	CBlob@ blob;
+
+	PositionComparableCBlobWrapper(CBlob@ p_blob)
+	{
+		@blob = p_blob;
+	}
+
+	// Compare by x-coordinate, then y-coordinate
+	int opCmp(PositionComparableCBlobWrapper@ other)
+	{
+		int xDiff = blob.getPosition().x - other.blob.getPosition().x;
+		if (xDiff != 0)
+		{
+			return xDiff;
+		}
+		return blob.getPosition().y - other.blob.getPosition().y;
+	}
+}
+
 void onInit(CBlob@ this)
 {
 	this.addCommandID("travel");
@@ -50,61 +72,34 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	onTunnelCommand(this, cmd, params);
 }
 
-// get all team tunnels sorted by team distance
+// get all team tunnels sorted by position
 
 bool getTunnelsForButtons(CBlob@ this, CBlob@[]@ tunnels)
 {
 	CBlob@[] list;
 	getBlobsByTag("travel tunnel", @list);
-	Vec2f thisPos = this.getPosition();
 
-	// add left tunnels
+	PositionComparableCBlobWrapper@[] comparableList;
 	for (uint i = 0; i < list.length; i++)
 	{
 		CBlob@ blob = list[i];
-		if (blob !is this && blob.getTeamNum() == this.getTeamNum() && blob.getPosition().x < thisPos.x)
-		{
-			bool added = false;
-			const f32 distToBlob = (blob.getPosition() - thisPos).getLength();
-			for (uint tunnelInd = 0; tunnelInd < tunnels.length; tunnelInd++)
-			{
-				CBlob@ tunnel = tunnels[tunnelInd];
-				if ((tunnel.getPosition() - thisPos).getLength() < distToBlob)
-				{
-					tunnels.insert(tunnelInd, blob);
-					added = true;
-					break;
-				}
-			}
-			if (!added)
-				tunnels.push_back(blob);
-		}
+		PositionComparableCBlobWrapper wrapper(blob);
+		comparableList.push_back(wrapper);
 	}
 
-	tunnels.push_back(null);	// add you are here
+	comparableList.sortAsc();
 
-	// add right tunnels
-	const uint tunnelIndStart = tunnels.length;
-
-	for (uint i = 0; i < list.length; i++)
+	for (uint i = 0; i < comparableList.length; i++)
 	{
-		CBlob@ blob = list[i];
-		if (blob !is this && blob.getTeamNum() == this.getTeamNum() && blob.getPosition().x >= thisPos.x)
+		CBlob@ tunnel = comparableList[i].blob;
+		if (tunnel is this)
 		{
-			bool added = false;
-			const f32 distToBlob = (blob.getPosition() - thisPos).getLength();
-			for (uint tunnelInd = tunnelIndStart; tunnelInd < tunnels.length; tunnelInd++)
-			{
-				CBlob@ tunnel = tunnels[tunnelInd];
-				if ((tunnel.getPosition() - thisPos).getLength() > distToBlob)
-				{
-					tunnels.insert(tunnelInd, blob);
-					added = true;
-					break;
-				}
-			}
-			if (!added)
-				tunnels.push_back(blob);
+			// Add "You are here"
+			tunnels.push_back(null);
+		}
+		else if (tunnel.getTeamNum() == this.getTeamNum())
+		{
+			tunnels.push_back(tunnel);
 		}
 	}
 	return tunnels.length > 0;

--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -82,9 +82,12 @@ bool getTunnelsForButtons(CBlob@ this, CBlob@[]@ tunnels)
 	PositionComparableCBlobWrapper@[] comparableList;
 	for (uint i = 0; i < list.length; i++)
 	{
-		CBlob@ blob = list[i];
-		PositionComparableCBlobWrapper wrapper(blob);
-		comparableList.push_back(wrapper);
+		CBlob@ tunnel = list[i];
+		if (tunnel.getTeamNum() == this.getTeamNum())
+		{
+			PositionComparableCBlobWrapper wrapper(tunnel);
+			comparableList.push_back(wrapper);
+		}
 	}
 
 	comparableList.sortAsc();
@@ -97,8 +100,8 @@ bool getTunnelsForButtons(CBlob@ this, CBlob@[]@ tunnels)
 			// Add "You are here"
 			tunnels.push_back(null);
 		}
-		else if (tunnel.getTeamNum() == this.getTeamNum())
-		{
+		else 
+		{			
 			tunnels.push_back(tunnel);
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**

## Description

Resolves #1568 by sorting tunnels according to map position (x-coordinate, then y-coordinate) instead of sorting by distance from the current tunnel.

## Steps to Test or Reproduce

Create a series of tunnels/halls/outposts at different elevations, and try to visit each tunnel. You should be able to visit a given tunnel by clicking the same button position (e.g. 2nd from left) consistently, no matter which tunnel you're traveling from.

Example video:

https://user-images.githubusercontent.com/22576116/213897695-50560e17-c67c-4ee8-893e-8256e6bf498e.mp4

Note: I mentioned in the issue that we may wish to flip the vertical sorting for red team (i.e. bottom-to-top instead of top-to-bottom). I did not implement that in this PR.