### PR TITLE
[fixed] Lanterns sprite not updating on client join

### DIFF
--- a/Entities/Industry/CTFShops/Storage/Storage.as
+++ b/Entities/Industry/CTFShops/Storage/Storage.as
@@ -133,6 +133,12 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		CInventory@ inv = caller.getInventory();
 		if (inv is null) return;
 
+		CBlob@ carried = caller.getCarriedBlob();
+		if (carried !is null && carried.hasTag("temp blob"))
+		{
+			carried.server_Die();
+		}
+
 		if (inv.getItemsCount() > 0)
 		{
 			CBitStream params;

--- a/Entities/Industry/CTFShops/Storage/Storage.as
+++ b/Entities/Industry/CTFShops/Storage/Storage.as
@@ -133,12 +133,6 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		CInventory@ inv = caller.getInventory();
 		if (inv is null) return;
 
-		CBlob@ carried = caller.getCarriedBlob();
-		if (carried !is null && carried.hasTag("temp blob"))
-		{
-			carried.server_Die();
-		}
-
 		if (inv.getItemsCount() > 0)
 		{
 			CBitStream params;
@@ -156,6 +150,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		CBlob@ caller = getBlobByNetworkID(params.read_u16());
 		if (caller is null) return;
+
+		CBlob@ carried = caller.getCarriedBlob();
+		if (carried !is null && carried.hasTag("temp blob"))
+		{
+			carried.server_Die();
+		}
 
 		CInventory@ inv = caller.getInventory();
 		if (inv is null) return;

--- a/Entities/Industry/CTFShops/Storage/Storage.as
+++ b/Entities/Industry/CTFShops/Storage/Storage.as
@@ -75,6 +75,20 @@ void onInit(CSprite@ this)
 		rope.SetOffset(Vec2f(5.0f, -8.0f));
 		rope.SetRelativeZ(2);
 	}
+	
+	// Lantern
+	CSpriteLayer@ lantern = this.addSpriteLayer("lantern", "Lantern.png", 8, 8);
+	if (lantern !is null)
+	{
+		{
+			lantern.addAnimation("default", 3, true);
+			int[] frames = { 0, 1, 2 };
+			lantern.animation.AddFrames(frames);
+		}
+		lantern.SetOffset(Vec2f(7.0f, -4.0f));
+		lantern.SetRelativeZ(3);
+		lantern.SetVisible(false);
+	}
 }
 
 void onInit(CBlob@ this)
@@ -94,19 +108,18 @@ void onTick(CBlob@ this)
 
 void PickupOverlap(CBlob@ this)
 {
-	if (getNet().isServer())
+	if (!isServer()) return;
+
+	Vec2f tl, br;
+	this.getShape().getBoundingRect(tl, br);
+	CBlob@[] blobs;
+	getMap().getBlobsInBox(tl, br, @blobs);
+	for (uint i = 0; i < blobs.length; i++)
 	{
-		Vec2f tl, br;
-		this.getShape().getBoundingRect(tl, br);
-		CBlob@[] blobs;
-		this.getMap().getBlobsInBox(tl, br, @blobs);
-		for (uint i = 0; i < blobs.length; i++)
+		CBlob@ blob = blobs[i];
+		if (!blob.isAttached() && blob.isOnGround() && blob.hasTag("material") && blob.getName() != "mat_arrows")
 		{
-			CBlob@ blob = blobs[i];
-			if (!blob.isAttached() && blob.isOnGround() && blob.hasTag("material") && blob.getName() != "mat_arrows")
-			{
-				this.server_PutInInventory(blob);
-			}
+			this.server_PutInInventory(blob);
 		}
 	}
 }
@@ -117,7 +130,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	if (caller.getTeamNum() == this.getTeamNum() && caller.isOverlapping(this))
 	{
-		CInventory @inv = caller.getInventory();
+		CInventory@ inv = caller.getInventory();
 		if (inv is null) return;
 
 		if (inv.getItemsCount() > 0)
@@ -131,36 +144,21 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (getNet().isServer())
+	if (!isServer()) return;
+	
+	if (cmd == this.getCommandID("store inventory"))
 	{
-		if (cmd == this.getCommandID("store inventory"))
+		CBlob@ caller = getBlobByNetworkID(params.read_u16());
+		if (caller is null) return;
+
+		CInventory@ inv = caller.getInventory();
+		if (inv is null) return;
+
+		while (inv.getItemsCount() > 0)
 		{
-			CBlob@ caller = getBlobByNetworkID(params.read_u16());
-			if (caller !is null)
-			{
-				CInventory @inv = caller.getInventory();
-				if (caller.getConfig() == "builder")
-				{
-					CBlob@ carried = caller.getCarriedBlob();
-					if (carried !is null)
-					{
-						// TODO: find a better way to check and clear blocks + blob blocks || fix the fundamental problem, blob blocks not double checking requirement prior to placement.
-						if (carried.hasTag("temp blob"))
-						{
-							carried.server_Die();
-						}
-					}
-				}
-				if (inv !is null)
-				{
-					while (inv.getItemsCount() > 0)
-					{
-						CBlob @item = inv.getItem(0);
-						caller.server_PutOutInventory(item);
-						this.server_PutInInventory(item);
-					}
-				}
-			}
+			CBlob@ item = inv.getItem(0);
+			caller.server_PutOutInventory(item);
+			this.server_PutInInventory(item);
 		}
 	}
 }
@@ -177,153 +175,82 @@ void onRemoveFromInventory(CBlob@ this, CBlob@ blob)
 
 void updateLayers(CBlob@ this, CBlob@ blob)
 {
+	if (!isClient()) return;
+
 	const string blobName = blob.getName();
-	if (!checkName(blobName))
-	{
-		return;
-	}
 	CSprite@ sprite = this.getSprite();
 	CInventory@ inv = this.getInventory();
-	int blobCount = inv.getCount(blobName);
+	const int blobCount = inv.getCount(blobName);
+	bool visible = false;
 	if (blobName == "mat_stone")
 	{
 		CSpriteLayer@ stone = sprite.getSpriteLayer("mat_stone");
 		if (blobCount > 0)
 		{
-			if (blobCount >= 200)
-			{
-				stone.SetFrameIndex(2);
-			}
-			else if (blobCount >= 100)
-			{
-				stone.SetFrameIndex(1);
-			}
-			else
-			{
-				stone.SetFrameIndex(0);
-			}
-			stone.SetVisible(true);
+			const u8 frame = blobCount >= 200 ? 2 :
+							 blobCount >= 100 ? 1 : 0;
+			stone.SetFrameIndex(frame);
+			visible = true;
 		}
-		else
-		{
-			stone.SetVisible(false);
-		}
+
+		stone.SetVisible(visible);
 	}
 	else if (blobName == "mat_wood")
 	{
 		CSpriteLayer@ wood = sprite.getSpriteLayer("mat_wood");
 		if (blobCount > 0)
 		{
-			if (blobCount >= 200)
-			{
-				wood.SetFrameIndex(2);
-			}
-			else if (blobCount >= 100)
-			{
-				wood.SetFrameIndex(1);
-			}
-			else
-			{
-				wood.SetFrameIndex(0);
-			}
-			wood.SetVisible(true);
+			const u8 frame = blobCount >= 200 ? 2 :
+							 blobCount >= 100 ? 1 : 0;
+			wood.SetFrameIndex(frame);
+			visible = true;
 		}
-		else
-		{
-			wood.SetVisible(false);
-		}
+
+		wood.SetVisible(visible);
 	}
 	else if (blobName == "mat_gold")
 	{
 		CSpriteLayer@ gold = sprite.getSpriteLayer("mat_gold");
 		if (blobCount > 0)
 		{
-			if (blobCount >= 200)
-			{
-				gold.SetFrameIndex(2);
-			}
-			else if (blobCount >= 100)
-			{
-				gold.SetFrameIndex(1);
-			}
-			else
-			{
-				gold.SetFrameIndex(0);
-			}
-			gold.SetVisible(true);
+			const u8 frame = blobCount >= 200 ? 2 :
+							 blobCount >= 100 ? 1 : 0;
+			gold.SetFrameIndex(frame);
+			visible = true;
 		}
-		else
-		{
-			gold.SetVisible(false);
-		}
+
+		gold.SetVisible(visible);
 	}
 	else if (blobName == "mat_bombs")
 	{
 		CSpriteLayer@ bombs = sprite.getSpriteLayer("mat_bombs");
 		if (blobCount > 0)
 		{
-			if (blobCount >= 2)
-			{
-				bombs.SetFrameIndex(1);
-			}
-			else
-			{
-				bombs.SetFrameIndex(0);
-			}
-			bombs.SetVisible(true);
+			const u8 frame = blobCount >= 2 ? 1 : 0;
+			bombs.SetFrameIndex(frame);
+			visible = true;
 		}
-		else
-		{
-			bombs.SetVisible(false);
-		}
+
+		bombs.SetVisible(visible);
 	}
 	else if (blobName == "lantern")
 	{
+		CSpriteLayer@ lantern = sprite.getSpriteLayer("lantern");
 		if (blobCount > 0)
 		{
-			AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("LANTERN");
-			if (getNet().isServer() && point.getOccupied() is null)
+			for (int i = 0; i < inv.getItemsCount(); i++)
 			{
-				CBlob@ lantern = server_CreateBlob("lantern");
-				if (lantern !is null)
+				CBlob@ item = inv.getItem(i);
+				if (item.getName() == "lantern" && item.get_bool("lantern lit"))
 				{
-					lantern.server_setTeamNum(this.getTeamNum());
-					lantern.getShape().getConsts().collidable = false;
-					this.server_AttachTo(lantern, "LANTERN");
-					blob.set_u16("lantern id", lantern.getNetworkID());
-					Sound::Play("SparkleShort.ogg", lantern.getPosition());
+					visible = true;
+					break;
 				}
 			}
 		}
-		else
-		{
-			if (blob.exists("lantern id"))
-			{
-				CBlob@ lantern = getBlobByNetworkID(blob.get_u16("lantern id"));
-				if (lantern !is null)
-				{
-					lantern.server_Die();
-				}
-			}
-		}
-	}
-}
 
-void onDie(CBlob@ this)
-{
-	if (this.exists("lantern id"))
-	{
-		CBlob@ lantern = getBlobByNetworkID(this.get_u16("lantern id"));
-		if (lantern !is null)
-		{
-			lantern.server_Die();
-		}
+		lantern.SetVisible(visible);
 	}
-}
-
-bool checkName(string blobName)
-{
-	return (blobName == "mat_stone" || blobName == "mat_wood" || blobName == "mat_gold" || blobName == "mat_bombs" || blobName == "lantern");
 }
 
 bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)

--- a/Entities/Industry/CTFShops/Storage/Storage.cfg
+++ b/Entities/Industry/CTFShops/Storage/Storage.cfg
@@ -49,12 +49,8 @@ bool block_lightpasses                            = no
 bool block_snaptogrid                             = no
 
 $movement_factory                                 =
-
 $brain_factory                                    =
-
-$attachment_factory                               = box2d_attachment
-@$attachment_scripts                              =
-@$attachment_points                               = LANTERN; -7; -4; 0; 0; 0;
+$attachment_factory                               =
 
 $inventory_factory                                = generic_inventory
 @$inventory_scripts                               = 

--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -5,40 +5,41 @@ void onInit(CBlob@ this)
 	this.SetLight(true);
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 255, 240, 171));
-	this.addCommandID("light on");
-	this.addCommandID("light off");
-	AddIconToken("$lantern on$", "Lantern.png", Vec2f(8, 8), 0);
-	AddIconToken("$lantern off$", "Lantern.png", Vec2f(8, 8), 3);
 
 	this.Tag("dont deactivate");
 	this.Tag("fire source");
 	this.Tag("ignore_arrow");
 	this.Tag("ignore fall");
+	
+	this.set_bool("lantern lit", true); //isLight() causes problems
 
 	this.getCurrentScript().runFlags |= Script::tick_inwater;
 }
 
+bool onReceiveCreateData(CBlob@ this, CBitStream@ stream)
+{
+	this.getSprite().SetAnimation(this.get_bool("lantern lit") ? "fire" : "nofire");
+	this.inventoryIconFrame = this.get_bool("lantern lit") ? 0 : 3;
+	return true;
+}
+
 void onTick(CBlob@ this)
 {
-	if (this.isLight() && this.isInWater())
+	if (this.get_bool("lantern lit"))
 	{
 		Light(this, false);
 	}
 }
 
-void Light(CBlob@ this, bool on)
+void Light(CBlob@ this, const bool &in lit)
 {
-	if (!on)
-	{
-		this.SetLight(false);
-		this.getSprite().SetAnimation("nofire");
-	}
-	else
-	{
-		this.SetLight(true);
-		this.getSprite().SetAnimation("fire");
-	}
+	this.SetLight(lit);
+	this.inventoryIconFrame = lit ? 0 : 3;
+
+	this.getSprite().SetAnimation(lit ? "fire" : "nofire");
 	this.getSprite().PlaySound("SparkleShort.ogg");
+	
+	this.set_bool("lantern lit", lit);
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
@@ -46,10 +47,9 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("activate"))
 	{
 		if (this.isInWater()) return;
-		
-		Light(this, !this.isLight());
-	}
 
+		Light(this, !this.get_bool("lantern lit"));
+	}
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)

--- a/Entities/Items/Sponge/SpongeCommon.as
+++ b/Entities/Items/Sponge/SpongeCommon.as
@@ -2,17 +2,16 @@
 const int ABSORB_COUNT = 100;
 const string ABSORBED_PROP = "absorbed";
 
-
 void spongeUpdateSprite(CSprite@ this, u8 absorbed)
 {
 	uint16 old_frame_index = this.getFrameIndex();
 	this.animation.setFrameFromRatio(f32(absorbed) / ABSORB_COUNT);
+	this.getBlob().inventoryIconFrame = this.animation.frame;
 	if (old_frame_index > this.getFrameIndex())
 	{
 		makeSteamPuff(this.getBlob());
 	}
 }
-
 
 void makeSteamParticle(CBlob@ this, const Vec2f vel, const string filename = "SmallSteam")
 {


### PR DESCRIPTION
## Status

- **READY**
## Description

Closes #1245, #1217, #1287, #1264

* Fixes problems with lantern desync.
* Lanterns' inventory icons change when off/on.

* Included sponge inventory frames from #1264 ,
credit to @mugg91 .

## Steps to Test or Reproduce
Test on a dedicated server.
A) Turn off a lantern. Rejoin the server. With the applied fixes, it should look the same as before.
B) Turn off a lantern and put it into your inventory. With the applied changes, it will appear off.
C) Put lanterns into a storage. The storage will display a lit lantern if at least one of the lanterns is on. Otherwise it will be unlit.
D) Absorb water with a sponge and put it into your inventory. It should appear the same.
