### PR TITLE
[changed] Blobs on fire aren't allowed to be put into inventories

### DIFF
--- a/Entities/Common/FireScripts/IsFlammable.as
+++ b/Entities/Common/FireScripts/IsFlammable.as
@@ -119,3 +119,8 @@ void onTick(CBlob@ this)
 
 	// (flax roof cottages!)
 }
+
+bool canBePutInInventory(CBlob@ this, CBlob@ inventoryBlob)
+{
+	return !this.hasTag(burning_tag);
+}


### PR DESCRIPTION
## Status

- **READY**

## Description

Closes #1521 & resolves #1401

## Steps to Test or Reproduce

1) Burn a drill, log or grain.
2) Attempt to place it into your inventory. With the applied change, it will not be possible until the blob stops burning.