### PR TITLE
Slightly optimize `RegrowPlants`' `findTileByCoords`

### DIFF
--- a/Rules/CommonScripts/RegrowPlants.as
+++ b/Rules/CommonScripts/RegrowPlants.as
@@ -212,12 +212,11 @@ void onSetTile(CMap@ this, u32 index, TileType newtile, TileType oldtile)
 	}
 }
 
-u32 findTileByCoords(TileInfo@[] tiles, Vec2f coords)
+u32 findTileByCoords(const TileInfo@[] &in tiles, Vec2f coords)
 {
 	for (u32 i = 1; i < tiles.size(); i++)
 	{
-		TileInfo tile = tiles[i];
-		if (tile.coords == coords)
+		if (tiles[i].coords == coords)
 		{
 			return i;
 		}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Partly mitigates #1354

Profiling shows that object copies within the function is a significant performance hit, which the AS optimizer cannot/is not able to elide.  
This is not a complete fix but a quick improvement because the function's complexity is still `O(n)` with regards to the tile count and should be solved to close the issue.

## Steps to Test or Reproduce

See issue.