### PR TITLE
[fixed] Allow slashing/jabbing team corpses and disallow hitting held corpses

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1742,24 +1742,23 @@ void SetFirstAvailableBomb(CBlob@ this)
 // Blame Fuzzle.
 bool canHit(CBlob@ this, CBlob@ b)
 {
-
 	if (b.hasTag("invincible") || b.hasTag("temp blob"))
 		return false;
+	
+	// don't hit picked up items (except players and specially tagged items)
+	return b.hasTag("player") || b.hasTag("slash_while_in_hand") || !isBlobBeingCarried(b);
+}
 
-	// don't hit picked up items
+bool isBlobBeingCarried(CBlob@ b)
+{	
 	CAttachment@ att = b.getAttachments();
-	if (att !is null)
+	if (att is null)
 	{
-		AttachmentPoint@ point = att.getAttachmentPointByName("PICKUP");
-		if (point !is null && !point.socket &&
-			b.isAttachedToPoint("PICKUP") && !b.hasTag("slash_while_in_hand")) return false;
+		return false;
 	}
 
-	if (b.hasTag("dead"))
-		return true;
-
-	return true;
-
+	// Look for a "PICKUP" attachment point where socket=false and occupied=true
+	return att.getAttachmentPoint("PICKUP", false, true) !is null;
 }
 
 void onRemoveFromInventory(CBlob@ this, CBlob@ blob)

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1314,7 +1314,7 @@ void DoAttack(CBlob@ this, f32 damage, f32 aimangle, f32 arcdegrees, u8 type, in
 					velocity.Normalize();
 					velocity *= 12; // knockback force is same regardless of distance
 
-					if (rayb.getTeamNum() != this.getTeamNum())
+					if (rayb.getTeamNum() != this.getTeamNum() || rayb.hasTag("dead player"))
 					{
 						this.server_Hit(rayb, rayInfos[j].hitpos, velocity, temp_damage, type, true);
 					}

--- a/Entities/Characters/Scripts/RunnerDeath.as
+++ b/Entities/Characters/Scripts/RunnerDeath.as
@@ -40,12 +40,20 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			}
 		}
 
-		// add pickup attachment so we can pickup body
+		// add/convert pickup attachment so we can pickup body
 		CAttachment@ a = this.getAttachments();
 
 		if (a !is null)
 		{
-			AttachmentPoint@ ap = a.AddAttachmentPoint("PICKUP", false);
+			AttachmentPoint@ point = a.getAttachmentPointByName("PICKUP");
+			if (point is null)
+			{
+				AttachmentPoint@ ap = a.AddAttachmentPoint("PICKUP", false);
+			}
+			else
+			{
+				point.socket = false;
+			}
 		}
 
 		// sound

--- a/Entities/Characters/Scripts/RunnerDeath.as
+++ b/Entities/Characters/Scripts/RunnerDeath.as
@@ -40,20 +40,19 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			}
 		}
 
-		// add/convert pickup attachment so we can pickup body
+		// add pickup attachment so we can pickup body
 		CAttachment@ a = this.getAttachments();
 
 		if (a !is null)
 		{
 			AttachmentPoint@ point = a.getAttachmentPointByName("PICKUP");
-			if (point is null)
+			if (point !is null && point.socket)
 			{
-				AttachmentPoint@ ap = a.AddAttachmentPoint("PICKUP", false);
+				// Invalidate existing pickup attachment
+				point.name = "PICKUP_OLD";
 			}
-			else
-			{
-				point.socket = false;
-			}
+
+			AttachmentPoint@ ap = a.AddAttachmentPoint("PICKUP", false);
 		}
 
 		// sound

--- a/Entities/Characters/Scripts/RunnerDeath.as
+++ b/Entities/Characters/Scripts/RunnerDeath.as
@@ -45,13 +45,6 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 		if (a !is null)
 		{
-			AttachmentPoint@ point = a.getAttachmentPointByName("PICKUP");
-			if (point !is null && point.socket)
-			{
-				// Invalidate existing pickup attachment
-				point.name = "PICKUP_OLD";
-			}
-
 			AttachmentPoint@ ap = a.AddAttachmentPoint("PICKUP", false);
 		}
 


### PR DESCRIPTION
## Status

- **READY**

## Description

Resolves #1578 by re-enabling the ability to slash/jab your teammates' corpses.
Also prevents held corpses from getting hit - a missed case from #1083/#1102.

## Steps to Test or Reproduce

1. Set up a dedicated server
2. Join with at least two players/clients
3. Kill someone to create a corpse
4. Ensure that the corpse can be damaged by slashing/jabbing from knights of any team
5. Have a player pick up the corpse
6. Ensure that the nobody can slash/jab the held corpse, regardless of the team of the holder/attacker/corpse