### PR TITLE
[fixed] Health bar not scaling with camera zoom

### DIFF
--- a/Entities/Common/GUI/HealthBar.as
+++ b/Entities/Common/GUI/HealthBar.as
@@ -17,9 +17,10 @@ void onRender(CSprite@ this)
 	if (mouseOnBlob)
 	{
 		//VV right here VV
-		Vec2f pos2d = blob.getScreenPos() + Vec2f(0, 20);
+		const f32 zoom = getCamera().targetDistance * getDriver().getResolutionScaleFactor();
+		Vec2f pos2d = blob.getScreenPos() + Vec2f(0, 30);
 		Vec2f dim = Vec2f(24, 8);
-		const f32 y = blob.getHeight() * 2.4f;
+		const f32 y = blob.getHeight() * zoom;
 		const f32 initialHealth = blob.getInitialHealth();
 		if (initialHealth > 0.0f)
 		{


### PR DESCRIPTION
## Status

- **READY**

## Description

* Fixes minor visual bug where the health bar moves far away from it's blob when the camera is zoomed out

## Steps to Test or Reproduce

Spawn a vehicle/outpost and zoom out your camera. With the fix the health bar won't move too far away from the vehicle.
