### PR TITLE
[modified] Round up respawn timer with slight offset

### DIFF
--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -99,7 +99,8 @@ shared class CTFSpawns : RespawnSystem
 			if (info.can_spawn_time > 0)
 			{
 				info.can_spawn_time--;
-				spawn_property = u8(Maths::Min(250, (info.can_spawn_time / 30)));
+				// Round time up (except for final few ticks)
+				spawn_property = u8(Maths::Min(250, ((info.can_spawn_time + getTicksASecond() - 5) / getTicksASecond())));
 			}
 
 			string propname = "ctf spawn time " + info.username;

--- a/Rules/Sandbox/Scripts/Sandbox_Rules.as
+++ b/Rules/Sandbox/Scripts/Sandbox_Rules.as
@@ -88,7 +88,8 @@ shared class SandboxSpawns : RespawnSystem
 			if (info.can_spawn_time > 0)
 			{
 				info.can_spawn_time--;
-				spawn_property = u8(Maths::Min(250, (info.can_spawn_time / 30)));
+				// Round time up (except for final few ticks)
+				spawn_property = u8(Maths::Min(250, ((info.can_spawn_time + getTicksASecond() - 5) / getTicksASecond())));
 			}
 
 			string propname = "Sandbox spawn time " + info.username;

--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -106,7 +106,8 @@ shared class TDMSpawns : RespawnSystem
 			}
 
 			info.can_spawn_time--;
-			spawn_property = u8(Maths::Min(250, (info.can_spawn_time / 30)));
+			// Round time up (except for final few ticks)
+			spawn_property = u8(Maths::Min(250, ((info.can_spawn_time + getTicksASecond() - 5) / getTicksASecond())));
 		}
 
 		string propname = "tdm spawn time " + info.username;


### PR DESCRIPTION
## Status

- **READY**

## Description

Currently, the respawn timer in CTF/TDM always rounds down, so the timer will say "Respawning in: 0" for an entire second before you actually spawn. This causes psychological pain when you're really eager to spawn.

This PR adds a slight offset so that the timer mostly rounds up, except for the last few ticks of a second. 

This way, the timer can still briefly show 0 before you actually spawn. I'm open to changing that if people don't like it, but I feel like it's satisfying to see the timer actually hit 0.

Only the displayed value is different. The actual time to respawn is unchanged.

## Steps to Test or Reproduce

1. Join a CTF or TDM game
2. Die and watch the respawn timer count down
3. The total respawn time should not change, but when the timer hits 0, the player respawns momentarily after (rather than waiting a whole second)

## Notes
- The respawn timer is kinda janky if you die during build phase or in sandbox because it briefly counts down before the server force-respawns you, and the timer doesn't reset. But that's just existing behavior (might create an issue for it)
- The timer in TTH already rounds up, albeit without ever showing 0