### PR TITLE
[dev] Less "match_time" sync

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -700,10 +700,14 @@ void drawHoverExplanation(int hovered_accolade, int hovered_age, int hovered_tie
 
 void onTick(CRules@ this)
 {
-	if(isServer() && this.getCurrentState() == GAME)
+	if (this.getCurrentState() == GAME)
 	{
 		this.add_u32("match_time", 1);
-		this.Sync("match_time", true);
+
+		if (isServer() && this.get_u32("match_time") % (10 * getTicksASecond()) == 0)
+		{
+			this.Sync("match_time", true);
+		}
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**

## Description

u32 "match_time" is synchronized every ten seconds instead of every tick.
There is no functional difference. This aims to limit spam in server logs while debugging.

## Steps to Test or Reproduce
1) Go onto a dedicated server as a moderator.
2) Start the match with chat command ``!startgame``.
3) Use ``/rcon /g_debug 1`` in rcon to activate server sync prints. View the console.
