### PR TITLE
[modified] Kick AFK to spectator when seeding servers

### DIFF
--- a/Rules/CommonScripts/KickAFK.as
+++ b/Rules/CommonScripts/KickAFK.as
@@ -1,6 +1,7 @@
 // kicks players that dont play for a given time
 // by norill
 // move people with kick immunity to spec instead of doing nothing -mazey
+// move people into spec if seeding servers -gingerbeard
 
 #define CLIENT_ONLY
 #include "AdminLogic.as"
@@ -13,6 +14,9 @@ const uint checkInterval = 90;
 const uint totalToKickSeconds = 60 * 2 + 30;
 const uint warnToKickSeconds = 60;
 const uint idleToWarnSeconds = totalToKickSeconds - warnToKickSeconds;
+const f32 seedingPercent = 0.5f;
+
+const string[] ignoredSeedingGamemodes = { "Sandbox", "Challenge" };
 
 void onTick(CRules@ this)
 {
@@ -21,15 +25,15 @@ void onTick(CRules@ this)
 
 	CPlayer@ p = getLocalPlayer();
 	CControls@ controls = getControls();
-	if (p is null ||											//no player
-		controls is null ||										//no controls
-		p.getTeamNum() == getRules().getSpectatorTeamNum() ||	//or spectator
-		getNet().isServer())								//or we're running the server
-	{
+	if (p is null || controls is null || isServer())
 		return;
-	}
 
-	bool kickImmunity = getSecurity().checkAccess_Feature(p, "kick_immunity");
+	if (p.getTeamNum() == this.getSpectatorTeamNum())
+		return;
+
+	const bool kickImmunity = getSecurity().checkAccess_Feature(p, "kick_immunity");
+	const bool seeding = getPlayerCount() <= sv_maxplayers * seedingPercent && ignoredSeedingGamemodes.find(this.gamemode_name) == -1;
+	const bool kickToSpectator = kickImmunity || seeding;
 
 	//not updated yet or numbers from last game?
 	if(controls.lastKeyPressTime == 0 || controls.lastKeyPressTime > getGameTime())
@@ -58,7 +62,7 @@ void onTick(CRules@ this)
 			{
 				//you have been warned
 				client_AddToChat("Seems like you are currently away from your keyboard.", SColor(255, 255, 100, 32));
-				client_AddToChat("Move around or you will be " + (kickImmunity ? "moved to spectator" : "kicked") + " in "+warnToKickSeconds+" seconds!", SColor(255, 255, 100, 32));
+				client_AddToChat("Move around or you will be " + (kickToSpectator ? "moved to spectator" : "kicked") + " in "+warnToKickSeconds+" seconds!", SColor(255, 255, 100, 32));
 				warned = true;
 				warnTime = time;
 			}
@@ -68,16 +72,20 @@ void onTick(CRules@ this)
 	if (warned && time - warnTime > warnToKickSeconds)
 	{
 		//so long, sucker
-		client_AddToChat("You were " + (kickImmunity ? "moved to spectator" : "kicked") + " for being AFK too long.", SColor(255, 240, 50, 0));
+		client_AddToChat("You were " + (kickToSpectator ? "moved to spectator" : "kicked") + " for being AFK too long.", SColor(255, 240, 50, 0));
 		warned = false;
-		if (!kickImmunity)
+		if (!kickToSpectator)
 		{
 			getNet().DisconnectClient();
 		}
+		else if (kickImmunity)
+		{
+			joinNewSpecTeam(this, p); //Force-swap to spec team.
+			client_AddToChat("You have just been swapped to spectator team, type !m to get back.", SColor(255,0,0,0));
+		}
 		else
 		{
-			joinNewSpecTeam(this, getLocalPlayer()); //Force-swap to spec team.
-			client_AddToChat("You have just been swapped to spectator team, type !m to get back.", SColor(255,0,0,0));
+			p.client_ChangeTeam(this.getSpectatorTeamNum());
 		}
 	}
 }
@@ -99,15 +107,10 @@ void RemoveWarning()
 
 bool onClientProcessChat(CRules@ this, const string &in textIn, string &out textOut, CPlayer@ player)
 {
-	textOut = textIn;
-
-	if (player is null) return true;
-
-	// Return if it's not the local player
-	if (not player.isMyPlayer()) return true;
-
-	//but register a movement
-	DidInput();
+	if (player !is null && player.isMyPlayer())
+	{
+		DidInput();
+	}
 
 	return true;
 }


### PR DESCRIPTION
## Status

- **READY**

## Description

Resolves #1398 

Implementation as follows:
* AFK Players will be sent into spectator if the server is below half-capacity (threshold subject to change).
* AFK players will be kicked off servers regardless of player count on Sandbox and Challenge game modes.

## Steps to Test or Reproduce
1) Go onto a dedicated server.
2) Wait to be kicked. If the player count is below 50% capacity then you will be sent into spectator.
3) Use bots to simulate AFK kicking over 50% capacity.