### PR TITLE
Wallclimb rework

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -246,8 +246,6 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 						if (this.get("moveVars", @moveVars))
 						{
 							moveVars.walljumped_side = Walljump::NONE;
-							moveVars.wallrun_start = pos.y;
-							moveVars.wallrun_current = pos.y;
 						}
 					}
 				}

--- a/Entities/Characters/Archer/ClimbArrows.as
+++ b/Entities/Characters/Archer/ClimbArrows.as
@@ -33,6 +33,8 @@ void onTick(CBlob@ this)
 
 				if (vel.LengthSquared() < 1)
 				{
+					moveVars.walljumped_side = Walljump::NONE;
+
 					moveVars.jumpCount = -1;
 					Vec2f vel = this.getVelocity();
 					if (vel.y > 0)

--- a/Entities/Characters/MovementScripts/RunnerCommon.as
+++ b/Entities/Characters/MovementScripts/RunnerCommon.as
@@ -38,9 +38,7 @@ shared class RunnerMoveVars
 	// moved from tags...
 	bool walljumped;
 	s32 walljumped_side;
-	s32 wallrun_length;
-	f32 wallrun_start;
-	f32 wallrun_current;
+	int wallrun_count;
 	bool wallclimbing;
 	bool wallsliding;
 };

--- a/Entities/Characters/MovementScripts/RunnerMovementInit.as
+++ b/Entities/Characters/MovementScripts/RunnerMovementInit.as
@@ -31,9 +31,6 @@ void onInit(CMovement@ this)
 	//
 	moveVars.walljumped = false;
 	moveVars.walljumped_side = Walljump::NONE;
-	moveVars.wallrun_length = 2;
-	moveVars.wallrun_start = -1.0f;
-	moveVars.wallrun_current = -1.0f;
 	moveVars.wallclimbing = false;
 	moveVars.wallsliding = false;
 	//


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

1. Removed non-deterministic behavior. The previous code relied on `getGameTime()`, meaning that climbing was not consistent.
2. Capped the maximum number of climbs to 2 per wall (instead of non-deterministic 2~3 in practice).
3. Increased the boost a climb gives to compensate for the above.
    - What climbs are technically feasible is mostly similar to the current vanilla state - except more consistent (and slightly easier).
4. The way the code triggers climbs is vastly different:
    - If you are jumping from the ground, then your first climb will be granted when your velocity stalls or becomes negative. This has the effect of granting "ideal climbs" when holding up+direction towards a wall when jumping from the ground, instead of requiring to perfectly time pressing the direction key.
        - As a result, you can trigger climbs almost immediately if you do small jumps if that's what you want. This may contextually be helpful - e.g. in knight combat, or when climbing 2 air gap wide towers. 
    - If you are walljumping from a wall to another, then your first climb will be granted immediately.
    - The secondary climb will be granted at some point as your upwards velocity reduces.
5. When hitting your head against the ceiling and you still have a wallclimb left, then it will be granted (unlike vanilla). This makes walljumping in this scenario significantly more consistent.
6. Climbing arrows reset the wallclimb counter, so you can do a new full wallclimb counter after climbing arrows, effectively letting you reach higher heights.
7. The minimum time before wallclimb/walljump has been decreased.
    - As a result, boosting from the top of a tower is made easier for all classes (especially non-knights), though the usefulness of that is limited for non-knight.

## Steps to Test or Reproduce

Test every climbing scenario you can imagine