### PR TITLE
Change setting blob facing side to be deterministic

### DIFF
--- a/Entities/Common/Movement/FaceAimPosition.as
+++ b/Entities/Common/Movement/FaceAimPosition.as
@@ -4,7 +4,6 @@ void onInit(CMovement@ this)
 {
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
-	this.getCurrentScript().tickFrequency = 3;
 }
 
 void onTick(CMovement@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

The tickfrequency of FaceAimPosition was 3.
Since movement is dependent on the position a blob is facing (you walk faster when walking in the direction you're facing), this could mean that the same exact inputs reproduced in the same conditions could give different results.

This is the same as the deterministic wallclimb behaviour mentioned in https://github.com/transhumandesign/kag-base/pull/1603

## Steps to Test or Reproduce

- Spawn bots every tick and make them repeat the same actions (make them move their cursor a bit as well)
- Notice how some bots divert to different routes even with the same exact input. This is because when they change their facing direction, in some cases they will do it a tick or two later.
- Test again with this PR. Movement seems to be now fully deterministic.
