### PR TITLE
Wallclimbing improvement

### DIFF
--- a/Entities/Characters/MovementScripts/RunnerMovement.as
+++ b/Entities/Characters/MovementScripts/RunnerMovement.as
@@ -366,7 +366,8 @@ void onTick(CMovement@ this)
 					moveVars.wallrun_count = 1000;
 				}
 
-				if (set_contact_candidate && ((vel.y >= -0.0f && vel.y < slidespeed) || !wasNONE))
+				// set contact immediately if jumping at the wall from an angle; not immediately if hugging wall
+                if (set_contact_candidate && ((vel.y >= -0.0f && vel.y < slidespeed && Maths::Abs(blob.getOldVelocity().x) == 0) || Maths::Abs(blob.getOldVelocity().x) > 0 || !wasNONE))
 				{
 					// print("candidate passes, & our velocity is " + vel.y);
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Climbing 1, 2-block walls was annoying with the new, improved wallclimbing due to the wait-for-optimal-time mechanic when giving speedboosts. Changed it to give speedboosts immediately if your velocity.x was higher than 0 in previous tick (jumping at a wall from an angle). Tested online on Captains, works as intended.
