### PR TITLE
Reduce occurences of falldamage caused by trampolines

### DIFF
--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -6,6 +6,8 @@
 
 void onInit(CBlob@ this)
 {
+	this.getShape().getConsts().bullet = true;
+
 	this.getCurrentScript().removeIfTag = "dead";
 	this.Tag("medium weight");
 

--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -33,32 +33,13 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	{
 		bool doknockdown = true;
 
-		if (damage > 0.0f)
+		if (damage > 0.1f)
 		{
-			// check if we aren't touching a trampoline
-			CBlob@[] overlapping;
-
-			if (this.getOverlapping(@overlapping))
-			{
-				for (uint i = 0; i < overlapping.length; i++)
-				{
-					CBlob@ b = overlapping[i];
-
-					if (b.hasTag("no falldamage"))
-					{
-						return;
-					}
-				}
-			}
-
-			if (damage > 0.1f)
-			{
-				this.server_Hit(this, point1, normal, damage, Hitters::fall);
-			}
-			else
-			{
-				doknockdown = false;
-			}
+			this.server_Hit(this, point1, normal, damage, Hitters::fall);
+		}
+		else if (damage > 0.0f)
+		{
+			doknockdown = false;
 		}
 
 		if (doknockdown)

--- a/Entities/Common/Movement/FallDamageCommon.as
+++ b/Entities/Common/Movement/FallDamageCommon.as
@@ -54,3 +54,15 @@ f32 FallDamageAmount(float vely)
 	}
 	return 0.0f;
 }
+
+void CancelFallDamageThisTick(CBlob@ blob)
+{
+	blob.setVelocity(Vec2f_zero);
+	blob.set_u32("falldamage prevent", getGameTime());
+}
+
+bool isFallDamageCancelledThisTick(CBlob@ blob)
+{
+	return blob.exists("falldamage prevent")
+		&& (blob.get_u32("falldamage prevent") == getGameTime());
+}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Even when `bullet` mode (aka CCD) is enabled, players falling fast onto trampolines will still get fall stun due to the fact that Box2D is not aware of how trampolines work, as they behave like a non-solid collision. Within the same tick, the player might hit both the trampoline and the ground.

This PR introduces a somewhat hacky workaround which makes it so that `doesCollideWithBlob` tags the player not to get fall damage this tick, should we expect the blob to be bounced.

It would be possible to make it to that the trampoline is solid to those blobs instead, however, it seems to make it so that the trampoline is pushed back by the collision (which is undesired), and there are probably other unintended side effects.

## Steps to Test or Reproduce

**N/A** until physics `bullet` mode is properly fixed, so you cannot try this ATM until this is changed.

Assuming a build is available with `bullet` mode unconditionally enabled for all entities (or until a PR is merged to introduce this to player and other entities):

1. Test both localhost and a local server
2. Place a trampoline
3. Try to fall very fast on the trampoline and in various ways, you shouldn't get stun
4. Press down while falling: you should still get damage