### PR TITLE
Do not show player pointing frames for chat bubbles

### DIFF
--- a/Entities/Characters/Scripts/RunnerAnimCommon.as
+++ b/Entities/Characters/Scripts/RunnerAnimCommon.as
@@ -6,7 +6,7 @@ void defaultIdleAnim(CSprite@ this, CBlob@ blob, int direction)
 	{
 		this.SetAnimation("crouch");
 	}
-	else if (is_emote(blob))
+	else if (is_emote(blob, true))
 	{
 		this.SetAnimation("point");
 		this.animation.frame = 1 + direction;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes #1627

## Steps to Test or Reproduce

1. Use any emote, your player should look like they're pointing in the direction you're aiming.
2. Open chat with enter, the speech bubble should show but your player shouldn't be pointing towards anything.