### PR TITLE
[modified] flipping siege vehicles requires capturing them first

### DIFF
--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -226,12 +226,15 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
 	if (!canSeeButtons(this, caller)) return;
 
-	if (isOverlapping(this, caller) && !caller.isAttached())
+	if (!isOverlapping(this, caller) || caller.isAttached()) return;
+
+	// must cap to use flip/ammo buttons
+	if (this.getTeamNum() != caller.getTeamNum()) return;
+
+	if (!Vehicle_AddFlipButton(this, caller))
 	{
-		if (!Vehicle_AddFlipButton(this, caller) && caller.getTeamNum() == this.getTeamNum())
-		{
-			Vehicle_AddLoadAmmoButton(this, caller);
-		}
+		// no flip button? try adding ammo load button
+		Vehicle_AddLoadAmmoButton(this, caller);
 	}
 }
 

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -147,14 +147,20 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	if (!canSeeButtons(this, caller)) return;
 
 	CBlob@ occupiedBlob = this.getAttachments().getAttachmentPointByName("MAG").getOccupied();
-	if (
-		!Vehicle_AddFlipButton(this, caller) &&
-		this.getTeamNum() == caller.getTeamNum() &&
-		isOverlapping(this, caller) &&
-		!caller.isAttached() &&
-		(occupiedBlob is null || !occupiedBlob.hasTag("player"))
-	) {
-		Vehicle_AddLoadAmmoButton(this, caller);
+
+	// must cap to use flip/ammo buttons
+	if (this.getTeamNum() != caller.getTeamNum()) return;
+
+	if (!Vehicle_AddFlipButton(this, caller))
+	{
+		// no flip button? try adding ammo load button
+		if (
+			isOverlapping(this, caller) &&
+			!caller.isAttached() &&
+			(occupiedBlob is null || !occupiedBlob.hasTag("player"))
+		) {
+			Vehicle_AddLoadAmmoButton(this, caller);
+		}
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Makes it so you can only flip siege vehicles (catapult, ballista) when you are in the same team as the vehicle. You get crushed when that happens.

Supersedes the implementation of that feature from #1273.

This was quickly hacked together, maybe we should instead take steps so that flipping siege can't crush a player in the first place instead. I don't think this has massive gameplay implications, though.

## Steps to Test or Reproduce

Attempt to flip a catapult or ballista when in a different team - you should only be able to load ammo. Switch teams, and try again.