### PR TITLE
[fixed] emitters/receivers incorrectly blocked water

### DIFF
--- a/Entities/Structures/Components/Passive/Emitter/Emitter.as
+++ b/Entities/Structures/Components/Passive/Emitter/Emitter.as
@@ -41,6 +41,9 @@ void onInit(CBlob@ this)
 
 	// used by TileBackground.as
 	this.set_TileType("background tile", CMap::tile_wood_back);
+
+	// background, let water overlap
+	this.getShape().getConsts().waterPasses = true;
 }
 
 void onSetStatic(CBlob@ this, const bool isStatic)

--- a/Entities/Structures/Components/Passive/Receiver/Receiver.as
+++ b/Entities/Structures/Components/Passive/Receiver/Receiver.as
@@ -65,6 +65,9 @@ void onInit(CBlob@ this)
 	// used by TileBackground.as
 	this.set_TileType("background tile", CMap::tile_wood_back);
 
+	// background, let water overlap
+	this.getShape().getConsts().waterPasses = true;
+
 	if (getNet().isServer())
 	{
 		u16[] emitter;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Emitters/receivers are background mechanisms and should not block water. Tested all other mechanisms, all other ones had correct behavior.

The added code is the same that is used for other mechanisms.

## Steps to Test or Reproduce

1. Use `!spawnwater` in sandbox
2. Place mechanisms