### PR TITLE
Use `getActiveCommandPlayer` in shop logic

### DIFF
--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -129,20 +129,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 	if (cmd == this.getCommandID("shop buy"))
 	{
-		if (this.hasTag("shop disabled"))
-			return;
+		if (!isServer) { return; }
 
-		u16 callerID;
-		if (!params.saferead_u16(callerID))
-			return;
+		if (this.hasTag("shop disabled")) { return; }
+
 		bool spawnToInventory = params.read_bool();
 		bool spawnInCrate = params.read_bool();
 		bool producing = params.read_bool();
 		u8 s_index = params.read_u8();
 		bool hotkey = params.read_bool();
 
-		CBlob@ caller = getBlobByNetworkID(callerID);
+		CPlayer@ callerPlayer = getNet().getActiveCommandPlayer();
+		if (callerPlayer is null) { return; }
+
+		CBlob@ caller = callerPlayer.getBlob();
 		if (caller is null) { return; }
+
 		CInventory@ inv = caller.getInventory();
 
 		if (this.getHealth() <= 0)
@@ -401,7 +403,6 @@ void addShopItemsToMenu(CBlob@ this, CGridMenu@ menu, CBlob@ caller)
 			if (s_item is null || caller is null) { continue; }
 			CBitStream params;
 
-			params.write_u16(caller.getNetworkID());
 			params.write_bool(s_item.spawnToInventory);
 			params.write_bool(s_item.spawnInCrate);
 			params.write_bool(s_item.producing);
@@ -454,7 +455,6 @@ void BuildShopMenu(CBlob@ this, CBlob @caller, string description, Vec2f offset,
 		for (uint i = 0; i < keybindCount; i++)
 		{
 			CBitStream params;
-			params.write_u16(caller.getNetworkID());
 			params.write_bool(shopitems[i].spawnToInventory);
 			params.write_bool(shopitems[i].spawnInCrate);
 			params.write_bool(shopitems[i].producing);

--- a/Entities/Common/Factory/Shop.as
+++ b/Entities/Common/Factory/Shop.as
@@ -149,7 +149,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		if (this.getHealth() <= 0)
 		{
-			caller.ClearMenus();
 			return;
 		}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When the `caller` blob occasionally had a `null` player, then the shop script would crash. We could just add a null player check, but we might as well not read the caller from the stream. Getting the player from the netcode is more robust.

This also makes it so that the command handler early returns if `!isServer`. It should not be the case that all players receive the `"shop buy"` command...

## Steps to Test or Reproduce

Test shops on dedicated servers for robustness. Test corner cases.