### PR TITLE
[modified] localhost debug editor requires holding build mod + lmb/rmb

### DIFF
--- a/Rules/CommonScripts/Editor.as
+++ b/Rules/CommonScripts/Editor.as
@@ -4,7 +4,7 @@
 
 void onTick(CRules@ this)
 {
-	if (!sv_test || !getNet().isServer())
+	if (!sv_test || !isServer() || !isClient()) // sv_test localhost only
 	{
 		return;
 	}
@@ -13,9 +13,12 @@ void onTick(CRules@ this)
 	CMap@ map = getMap();
 	if (p !is null && p.isMod())
 	{
-		// delete blob
+		if (!getControls().ActionKeyPressed(AK_BUILD_MODIFIER))
+		{
+			return;
+		}
 
-		if (getControls().isKeyJustPressed(KEY_KEY_X))
+		if (getControls().ActionKeyPressed(AK_ACTION2))
 		{
 			Vec2f pos = getBottomOfCursor(getControls().getMouseWorldPos());
 			CBlob@ behindBlob = getMap().getBlobAtPosition(pos);
@@ -29,7 +32,8 @@ void onTick(CRules@ this)
 				map.server_SetTile(pos, CMap::tile_empty);
 			}
 		}
-		if (getControls().isKeyJustPressed(KEY_KEY_Z))
+
+		if (getControls().ActionKeyPressed(AK_ACTION1))
 		{
 			Vec2f pos = getBottomOfCursor(getControls().getMouseWorldPos());
 			map.server_SetTile(pos, CMap::tile_castle);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

- Closes #1629
- Makes it so that placing and breaking tiles lets you hold the keys, so you can place or break a bunch of tiles easily to debug things

## Steps to Test or Reproduce

1. Set `sv_test = 1` in autoconfig.
2. Start the game in localhost mode (e.g. singleplayer).
3. Hold the builder modifier key (check keybindings) and hit action1 (LMB) to place a stone block, action2 (RMB) to break blocks