### PR TITLE
Staging: work around clipped text in dlc/patreon boxes

### DIFF
--- a/GUI/guiHeadsPack.xml
+++ b/GUI/guiHeadsPack.xml
@@ -185,6 +185,7 @@ Proceeds go to continued development of King Arthur's Gold." />
           <bool name="TabGroup" value="true" />
           <int name="TabOrder" value="-1" />
           <bool name="NoClip" value="false" />
+          <bool name="RestrainTextInside" value="false" />
           <bool name="Border" value="false" />
           <bool name="OverrideColorEnabled" value="false" />
           <bool name="OverrideBGColorEnabled" value="false" />

--- a/GUI/guiPatreon.xml
+++ b/GUI/guiPatreon.xml
@@ -185,6 +185,7 @@ Proceeds go to continued hosting and development of King Arthur's Gold." />
           <bool name="TabGroup" value="true" />
           <int name="TabOrder" value="-1" />
           <bool name="NoClip" value="false" />
+          <bool name="RestrainTextInside" value="false" />
           <bool name="Border" value="false" />
           <bool name="OverrideColorEnabled" value="false" />
           <bool name="OverrideBGColorEnabled" value="false" />


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Closes https://github.com/AsuMagic/kag-staging/issues/157 -- cba to debug why Irrlicht decided to use a clip rect of height 90px for that text when nothing seems to use that as a value. Nothing else seems like it should be affected, anyway.

## Steps to Test or Reproduce

1. Use staging
2. Get the patreon & DLC boxes to open (from the customization settings)
