### PR TITLE
Mounted bow will face the mid of map

### DIFF
--- a/Entities/Structures/MountedBow/MountedBow.as
+++ b/Entities/Structures/MountedBow/MountedBow.as
@@ -74,6 +74,11 @@ void onInit(CBlob@ this)
 				ammo.server_Die();
 		}
 	}
+
+	CMap@ map = getMap();
+	if (map is null) return;
+
+	this.SetFacingLeft(this.getPosition().x/4 > map.tilemapwidth);
 }
 
 f32 getAimAngle(CBlob@ this, VehicleInfo@ v)


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Mounted bow now faces the center of map.
Might be some very hidden and counterintuitive issue with it, but i might not imagine something critical for that. Since the shape is 7.5\15.5 it shouldn't slip off the corners on already existing maps.

## Steps to Test or Reproduce

1. Load into localhost or on a server
2. Execute a chat command `!spawn mounted_bow` while standing on the left or right side of the map

Some useful information to include:

Couldn't test in multiplayer test\on server because i can't setup environment and launch the game successfuly, for some reason.
However works fine on localhost