### PR TITLE
Make flag animations consistent

### DIFF
--- a/Entities/Industry/CTFShops/Outpost/Outpost.as
+++ b/Entities/Industry/CTFShops/Outpost/Outpost.as
@@ -37,8 +37,8 @@ void onInit(CBlob@ this)
 	CSpriteLayer@ flag = sprite.addSpriteLayer("flag layer", "Outpost.png", 32, 32);
 	if (flag !is null)
 	{
-		flag.addAnimation("default", 5, true);
-		int[] frames = { 11, 10, 9 };
+		flag.addAnimation("default", XORRandom(3) + 3, true);
+		int[] frames = { 9, 10, 11 };
 		flag.animation.AddFrames(frames);
 		flag.SetRelativeZ(0.8f);
 		flag.SetOffset(Vec2f(10.5f, -12.0f));

--- a/Entities/Industry/CTFShops/Outpost/Outpost.as
+++ b/Entities/Industry/CTFShops/Outpost/Outpost.as
@@ -38,7 +38,7 @@ void onInit(CBlob@ this)
 	if (flag !is null)
 	{
 		flag.addAnimation("default", 5, true);
-		int[] frames = { 9, 10, 11 };
+		int[] frames = { 11, 10, 9 };
 		flag.animation.AddFrames(frames);
 		flag.SetRelativeZ(0.8f);
 		flag.SetOffset(Vec2f(10.5f, -12.0f));

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -159,7 +159,7 @@ void onInit(CBlob@ this)
 	CSpriteLayer@ flag = sprite.addSpriteLayer("flag layer", sprite.getConsts().filename, 32, 32);
 	if (flag !is null)
 	{
-		flag.addAnimation("default", 5, true);
+		flag.addAnimation("default", XORRandom(3) + 3, true);
 		int[] frames = { 15, 14, 13 };
 		flag.animation.AddFrames(frames);
 		flag.SetRelativeZ(-0.8f);

--- a/Entities/Vehicles/Ballista/Ballista.as
+++ b/Entities/Vehicles/Ballista/Ballista.as
@@ -159,7 +159,7 @@ void onInit(CBlob@ this)
 	CSpriteLayer@ flag = sprite.addSpriteLayer("flag layer", sprite.getConsts().filename, 32, 32);
 	if (flag !is null)
 	{
-		flag.addAnimation("default", 3, true);
+		flag.addAnimation("default", 5, true);
 		int[] frames = { 15, 14, 13 };
 		flag.animation.AddFrames(frames);
 		flag.SetRelativeZ(-0.8f);

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -113,7 +113,7 @@ void onInit(CBlob@ this)
 	CSpriteLayer@ flag = sprite.addSpriteLayer("flag", sprite.getConsts().filename, 40, 56);
 	if (flag !is null)
 	{
-		flag.addAnimation("default", 5, true);
+		flag.addAnimation("default", XORRandom(3) + 3, true);
 		int[] frames = { 5, 4, 3 };
 		flag.animation.AddFrames(frames);
 		flag.SetRelativeZ(-5.0f);

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -113,7 +113,7 @@ void onInit(CBlob@ this)
 	CSpriteLayer@ flag = sprite.addSpriteLayer("flag", sprite.getConsts().filename, 40, 56);
 	if (flag !is null)
 	{
-		flag.addAnimation("default", 3, true);
+		flag.addAnimation("default", 5, true);
 		int[] frames = { 5, 4, 3 };
 		flag.animation.AddFrames(frames);
 		flag.SetRelativeZ(-5.0f);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This PR addresses [issue#1498](https://github.com/transhumandesign/kag-base/issues/1498). Flag animation speeds have been made consistent and based on the `CTF_FLAG` blob.

## Steps to Test or Reproduce

!spawn Outpost
!spawn Ballista
!spawn Warboat

In sandbox to view their flags.

Some useful information to include:

- All gamemodes relevant
- Objects affected are: Outpost, Ballista, Warboat
