### PR TITLE
[boat rebuild] Boat bomb arrow resistance

### DIFF
--- a/Entities/Vehicles/Boats/LongBoat.as
+++ b/Entities/Vehicles/Boats/LongBoat.as
@@ -32,6 +32,9 @@ void onInit(CBlob@ this)
 	//block knight sword
 	this.Tag("blocks sword");
 
+	//bomb arrow damage value
+	this.set_f32("bomb resistance", 2.5f);
+
 	// additional shape
 
 	Vec2f[] frontShape;

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -29,6 +29,9 @@ void onInit(CBlob@ this)
 	//block knight sword
 	this.Tag("blocks sword");
 
+	//bomb arrow damage value
+	this.set_f32("bomb resistance", 3.1f);
+
 	this.getShape().SetOffset(Vec2f(0, 16));
 	this.getShape().getConsts().bullet = false;
 	this.getShape().getConsts().transports = true;

--- a/Entities/Vehicles/Common/WoodVehicleDamages.as
+++ b/Entities/Vehicles/Common/WoodVehicleDamages.as
@@ -35,7 +35,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			break;
 
 		case Hitters::arrow:
-			dmg = this.getMass() > 1000.0f ? 1.0f : 0.5f;
+			dmg = this.getMass() > 1000.0f ? 0.2f : 0.5f;
 			break;
 
 		case Hitters::ballista:

--- a/Entities/Vehicles/Common/WoodVehicleDamages.as
+++ b/Entities/Vehicles/Common/WoodVehicleDamages.as
@@ -31,7 +31,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			break;
 
 		case Hitters::bomb_arrow:
-			dmg *= 8.0f;
+			dmg *= this.exists("bomb resistance") ? this.get_f32("bomb resistance") : 8.0f;
 			break;
 
 		case Hitters::arrow:


### PR DESCRIPTION
Part of #1614 & related to #1404
* Warboat can withstand 8-9 bomb arrows before sinking.
* Longboat can withstand 3-4 bomb arrows before sinking.
* Longboat is much stronger against normal arrows (previously only 22 arrows could sink one!).

