### PR TITLE
[dev] remove isflammable from grain

### DIFF
--- a/Entities/Natural/Farming/Grain.cfg
+++ b/Entities/Natural/Farming/Grain.cfg
@@ -67,7 +67,6 @@ $name                                  = grain
 @$scripts                              = Grain.as;
 									     DecayInWater.as;
 										 UnsetTeam.as;
-										 IsFlammable.as;
 										 IgnoreDamage.as;
 										 Eatable.as;
 										 Timeout.as;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

since grain has both ignoredamage.as and isflammable.as, setting grain on fire ended up making it produce the same sound and particles as hitting bedrock does

## Steps to Test or Reproduce

try to set grain on fire. u cant