### PR TITLE
[fixed] script-side hack-fix for not being able to zoom in and out in spectator/while dead on capped framerate

### DIFF
--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -136,7 +136,7 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 	}
 }
 
-void onRender(CRules@ this)
+void SpecCamera(CRules@ this)
 {
 	//death effect
 	CCamera@ camera = getCamera();
@@ -158,6 +158,14 @@ void onRender(CRules@ this)
 		{
 			Spectator(this);
 		}
+	}
+}
+
+void onRender(CRules@ this)
+{
+	if (!v_capped)
+	{
+		SpecCamera(this);
 	}
 
 	if (targetPlayer() !is null && getLocalPlayerBlob() is null)
@@ -218,6 +226,11 @@ void onRender(CRules@ this)
 
 void onTick(CRules@ this)
 {
+	if (v_capped)
+	{
+		SpecCamera(this);
+	}
+
 	if (isCinematic())
 	{
 		Vec2f mapDim = getMap().getMapDimensions();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/579

All ways to get scroll input from the player do not work in onRender hooks if you are on capped framerate ever since the uncapped framerate option was added to the game.

According to GoldenGuy:
```
cuz input checking from render hooks is garbage
controls related stuff should only be used in ontick hooks
dont want to explain why
```

This PR fixes it by running the code which checks for scrolling input in onTick if you are on capped framerate rather than in onRender.

## Steps to Test or Reproduce

test zooming in and out while in spec/while dead both while using capped framerate and uncapped
