### PR TITLE
Small change to scoreboard age number.

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -773,7 +773,7 @@ void getMapName(CRules@ this)
 
 void drawAgeIcon(int age, Vec2f position)
 {
-    int number_gap = 9;
+    int number_gap = 8;
 	int years_frame_start = 48;
     if(age >= 10)
     {
@@ -784,6 +784,7 @@ void drawAgeIcon(int age, Vec2f position)
     }
     GUI::DrawIcon("AccoladeBadges", years_frame_start + age, Vec2f(16, 16), position, 0.5f, 0);
     position.x += 4;
+	if(age == 1) position.x -= 1; // fix y letter offset for number 1
     GUI::DrawIcon("AccoladeBadges", 58, Vec2f(16, 16), position, 0.5f, 0); // y letter
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Slightly redused the distance between numbers in 2 digit ages, also fixed "y" letter offset being too far away from number 1

Differences:
before - 
![image](https://github.com/transhumandesign/kag-base/assets/26719582/8e5a6b47-5b2f-49d2-84d4-5edb01b78548)
![image](https://github.com/transhumandesign/kag-base/assets/26719582/e28f3f7b-bbce-46ad-bd12-e500276166dc)

after - 
![image](https://github.com/transhumandesign/kag-base/assets/26719582/4e42ae8e-0ca7-461e-b527-f3594fe2d5e2)
![image](https://github.com/transhumandesign/kag-base/assets/26719582/b97f6bc9-9527-452a-8ac5-b5065746cd23)

