### PR TITLE
Make /help command show other commands with correct prefix (/ instead of !)

### DIFF
--- a/Rules/CommonScripts/ChatCommands/MiscCommands.as
+++ b/Rules/CommonScripts/ChatCommands/MiscCommands.as
@@ -23,7 +23,7 @@ class HelpCommand : ChatCommand
 			for (uint i = 0; i < command.aliases.size(); i++)
 			{
 				string alias = command.aliases[i];
-				string cmdName = "!" + alias;
+				string cmdName = "/" + alias;
 				if (command.usage != "")
 				{
 					cmdName += " " + command.usage;


### PR DESCRIPTION
## Status

(pick one)

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Part two of my previous commands pr, i didnt know about this command.
