### PR TITLE
[modified] removed black screen during map voting

### DIFF
--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -342,7 +342,8 @@ class MapVotesMenu
 
 		if (shouldNag)
 		{
-			GUI::DrawRectangle(Vec2f_zero, ScreenDim, SColor(0, 0, 0, 0)); //end game taint screen
+			// rationale for disabling: https://github.com/transhumandesign/kag-base/pull/1675
+			// GUI::DrawRectangle(Vec2f_zero, ScreenDim, SColor(200, 0, 0, 0)); //end game taint screen
 		}
 
 		GUI::SetFont("menu");

--- a/Rules/CommonScripts/MapVotesCommon.as
+++ b/Rules/CommonScripts/MapVotesCommon.as
@@ -342,7 +342,7 @@ class MapVotesMenu
 
 		if (shouldNag)
 		{
-			GUI::DrawRectangle(Vec2f_zero, ScreenDim, SColor(200, 0, 0, 0));
+			GUI::DrawRectangle(Vec2f_zero, ScreenDim, SColor(0, 0, 0, 0)); //end game taint screen
 		}
 
 		GUI::SetFont("menu");


### PR DESCRIPTION
## Status

**READY**

## Description

As it stands now, players that want to hangout and destroy building at the end of the game are met with a black screen preventing them from seeing what they are doing. To remove the black screen, players resort on clicking on the random map button as quickly as possible to be able to hangout or destroy something before the game finishes. 
By removing the black screen, players that want to hangout without caring about end game map voting won't be incentivized to speedrun click on "random map." This should make the map voting feature more useful.

This PR remove the black screen at the end of the games in the hopes to decrease the number of random map voters.

This is before this PR :
![before](https://github.com/transhumandesign/kag-base/assets/8329299/4858ffa4-77bb-44ce-902d-c1b6db476983)

This is after this PR :
![after](https://github.com/transhumandesign/kag-base/assets/8329299/da4f1dd6-c788-4b99-8bad-78ae352b087e)
