### PR TITLE
[fixed?] Crate button being hard to press at high speeds

### DIFF
--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -174,7 +174,9 @@ void onTick(CBlob@ this)
 	{
 		if (this.get_bool("release click"))
 		{
-			ButtonOrMenuClick(this, this.getPosition(), true, isTap(this) && this.get_bool("can button tap"));
+			CBlob@ carry = this.getCarriedBlob();
+			ButtonOrMenuClick(this, carry !is null? carry.getPosition() : this.getPosition(),
+							  true, isTap(this) && this.get_bool("can button tap"));
 		}
 
 		this.ClearButtons();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Tapping E should select your held item's button even when you're going fast.
Addresses #1545 

I don't fully get why this works, but it seems like it does. Haven't tested on a laggy server. Also it might make it slightly harder to tap E to open a shop if you're holding a log or something and going really fast?

## Steps to Test or Reproduce

Get a crate, or a scroll of doom or something
Jump off a cliff
Tap E
