### PR TITLE
[fixed] No EmoteMenu.as in gamemode.cfg error 

### DIFF
--- a/Entities/Common/Emotes/EmoteHotkeys.as
+++ b/Entities/Common/Emotes/EmoteHotkeys.as
@@ -8,11 +8,11 @@ void onInit(CBlob@ this)
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
 
-    //Stop if there is no emote menu.
-    if(!getRules().hasScript("EmoteMenu.as"))
-    {
-        return;
-    }
+	//Stop if there is no emote menu.
+	if(!getRules().hasScript("EmoteMenu.as"))
+	{
+		return;
+	}
 
 	CPlayer@ me = getLocalPlayer();
 	if (me !is null)

--- a/Entities/Common/Emotes/EmoteHotkeys.as
+++ b/Entities/Common/Emotes/EmoteHotkeys.as
@@ -8,6 +8,12 @@ void onInit(CBlob@ this)
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
 
+    //Stop if there is no emote menu.
+    if(!getRules().hasScript("EmoteMenu.as"))
+    {
+        return;
+    }
+
 	CPlayer@ me = getLocalPlayer();
 	if (me !is null)
 	{
@@ -24,7 +30,7 @@ void onTick(CBlob@ this)
 		onInit(this);
 	}
 	
-	if (getHUD().hasMenus())
+	if (getHUD().hasMenus() || emoteBinds.size() == 0)
 	{
 		return;
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

If EmoteMenu.as is not in the gamemode.cfg, when a player spawns as a blob, it errors.
The EmoteMenu.as script, calls the function `LoadEmotes(rules, cfg)`, inside of which sets `this.set("emotes", @emotesDict);`
If EmoteMenu.as is not in gamemode.cfg, then the rules "emotes" is null.

In a player's blob, the script EmoteHotkeys.as, calls readEmoteBindings in onInit()
In that function, this happens `getRules().get("emotes", @emotes);`
Then it promptly uses the variable emotes, which may be null. Hence, the error.

This edit simply halts getting emotebinds if EmoteMenu.as isn't in rules.
It halts in onTick if the size of emotebinds was 0, as well, to prevent attempting to use an empty emotebinds.
This is done after "reload emotes", so one could possibly add EmoteMenu.as afterwards, tag rules with "reload emotes", and have it reload and work normally without extra fuss.

## Steps to Test or Reproduce

Play a gamemode without EmoteMenu.as in the script list. Spawn as a blob that has the script EmoteHotkeys.as