### PR TITLE
[added] color vote titles depending on context, e.g. surrendering is …

### DIFF
--- a/Rules/CommonScripts/VoteCore.as
+++ b/Rules/CommonScripts/VoteCore.as
@@ -17,6 +17,26 @@ Vec2f getTopLeft()
 	return Vec2f(getScreenWidth() - 210, 182 + (Maths::Sin(getGameTime() / 10.0f) + 1.0f) * 3.0f);
 }
 
+SColor get_vote_color(string vote_title)
+{
+	if (vote_title.toLower().findFirst("kick", 0) >= 0)
+	{
+		return SColor(255, 255, 255, 0);
+	}
+
+	if (vote_title.toLower().findFirst("skip", 0) >= 0)
+	{
+		return SColor(255, 0, 0, 255);
+	}
+
+	if (vote_title.toLower().findFirst("surrender", 0) >= 0)
+	{
+		return SColor(255, 0, 255, 0);
+	}
+
+	return color_white;
+}
+
 //hooks
 
 void onRender(CRules@ this)
@@ -59,7 +79,8 @@ void onRender(CRules@ this)
 	GUI::DrawPane(tl, br, SColor(0x80ffffff));
 
 	GUI::SetFont("menu");
-	GUI::DrawText(vote_title, tl + Vec2f(Maths::Max(dim.x / 2 - text_dim.x / 2, 3.0), 3), color_white);
+
+	GUI::DrawText(vote_title, tl + Vec2f(Maths::Max(dim.x / 2 - text_dim.x / 2, 3.0), 3), get_vote_color(vote.title));
 
 	GUI::DrawText(getTranslatedString("Reason: {REASON}").replace("{REASON}", getTranslatedString(vote.reason)), tl + Vec2f(3, 3 + text_dim.y * 2), color_white);
 	GUI::DrawText(getTranslatedString("Cast by: {USER}").replace("{USER}", vote.byuser), tl + Vec2f(3, 3 + text_dim.y * 3), color_white);


### PR DESCRIPTION
This PR addresses https://github.com/transhumandesign/kag-base/issues/1599 by simply checking the vote data title and coloring the vote menu title according.

Result:
<img width="1015" alt="image" src="https://github.com/transhumandesign/kag-base/assets/29358582/7015df62-2792-4d40-83c5-92c38a7af668">

## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Give players the context at a glance by coloring the vote.

## Steps to Test or Reproduce
- Join a server
- Cast different votes and see the vote UI change its color

