### PR TITLE
Cmd sanitization crate & mine

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -39,6 +39,7 @@ void onInit(CBlob@ this)
 	this.checkInventoryAccessibleCarefully = true;
 
 	this.addCommandID("unpack");
+	this.addCommandID("unpack_client"); // just sets the drag...
 	this.addCommandID("getin");
 	this.addCommandID("getout");
 	this.addCommandID("stop unpack");
@@ -262,9 +263,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		if (sneaky_player.getTeamNum() == caller.getTeamNum())
 		{
-			CBitStream params;
-			params.write_netid(caller.getNetworkID());
-			CButton@ button = caller.CreateGenericButton(6, buttonpos, this, this.getCommandID("getout"), getTranslatedString("Get out"), params);
+			CButton@ button = caller.CreateGenericButton(6, buttonpos, this, this.getCommandID("getout"), getTranslatedString("Get out"));
 			if (putting)
 			{
 				button.SetEnabled(false);
@@ -276,17 +275,15 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		}
 		else // make fake buttons for enemy
 		{
-			CBitStream params;
-			params.write_netid(caller.getNetworkID());
 			if (carried is this)
 			{
 				// Fake get in button
-				caller.CreateGenericButton(4, buttonpos, this, this.getCommandID("getout"), getTranslatedString("Get inside"), params);
+				caller.CreateGenericButton(4, buttonpos, this, this.getCommandID("getout"), getTranslatedString("Get inside"));
 			}
 			else
 			{
 				// Fake inventory button
-				CButton@ button = caller.CreateGenericButton(13, buttonpos, this, this.getCommandID("getout"), getTranslatedString("Crate"), params);
+				CButton@ button = caller.CreateGenericButton(13, buttonpos, this, this.getCommandID("getout"), getTranslatedString("Crate"));
 				button.enableRadius = 20.0f;
 			}
 		}
@@ -313,19 +310,14 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	}
 	else if (hasSomethingPacked(this))
 	{
-		CBitStream params;
-		params.write_netid(caller.getNetworkID());
-		
 		string text = getTranslatedString("Unpack {ITEM}").replace("{ITEM}", getTranslatedString(this.get_string("packed name")));
-		CButton@ button = caller.CreateGenericButton(12, buttonpos, this, this.getCommandID("unpack"), text, params);
+		CButton@ button = caller.CreateGenericButton(12, buttonpos, this, this.getCommandID("unpack"), text);
 		
 		button.enableRadius = 20.0f;
 	}
 	else if (carried is this)
 	{
-		CBitStream params;
-		params.write_netid(caller.getNetworkID());
-		caller.CreateGenericButton(4, buttonpos, this, this.getCommandID("getin"), getTranslatedString("Get inside"), params);
+		caller.CreateGenericButton(4, buttonpos, this, this.getCommandID("getin"), getTranslatedString("Get inside"));
 	}
 	else if (this.getTeamNum() != caller.getTeamNum() && !this.isOverlapping(caller))
 	{
@@ -341,20 +333,29 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("unpack"))
+	if (cmd == this.getCommandID("unpack") && isServer())
 	{
 		if (hasSomethingPacked(this))
 		{
 			if (canUnpackHere(this))
 			{
+				CPlayer@ p = getNet().getActiveCommandPlayer();
+				if (p is null) return;
+					
+				CBlob@ caller = p.getBlob();
+				if (caller is null) return;
+
+				// range check
+				if (this.getDistanceTo(caller) > 32.0f) return;
+
+				this.server_setTeamNum(caller.getTeamNum());
+
 				this.set_u32("unpack time", getGameTime() + this.get_u32("unpack secs") * getTicksASecond());
+				this.Sync("unpack time", true);
+
 				this.getShape().setDrag(10.0f);
 
-				CBlob@ caller = getBlobByNetworkID(params.read_netid());
-				if (caller !is null) 
-				{ 
-					this.server_setTeamNum(caller.getTeamNum());
-				}
+				this.SendCommand(this.getCommandID("unpack_client"));
 			}
 		}
 		else
@@ -363,17 +364,41 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			this.server_Die();
 		}
 	}
-	else if (cmd == this.getCommandID("stop unpack"))
+	else if (cmd == this.getCommandID("unpack_client") && isClient())
 	{
-		this.set_u32("unpack time", 0);
+		this.getShape().setDrag(10.0f);
 	}
-	else if (cmd == this.getCommandID("getin"))
+	else if (cmd == this.getCommandID("stop unpack") && isServer())
 	{
-		if (this.getHealth() <= 0)
-		{
-			return;
-		}
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
+
+		// range check
+		f32 distance = this.getDistanceTo(caller);
+		if (distance > 32.0f) return;
+
+		this.set_u32("unpack time", 0);
+		this.Sync("unpack time", true);
+	}
+	else if (cmd == this.getCommandID("getin") && isServer())
+	{
+		// i don't know why this check is here so not touching it...
+		if (this.getHealth() <= 0) return;
+
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
+
+		// only getin if caller is holding this crate
+		CBlob@ helditem = caller.getCarriedBlob();
+		if (helditem is null) return;
+		if (helditem !is this) return;
+
 		CInventory@ inv = this.getInventory();
 		if (caller !is null && inv !is null) 
 		{
@@ -384,10 +409,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				CBlob@ item = inv.getItem(i);
 				if (item.getName() == "mine" && item.getTeamNum() != caller.getTeamNum())
 				{
-					CBitStream params;
-					params.write_netid(caller.getNetworkID());
-					params.write_netid(item.getNetworkID());
-					this.SendCommand(this.getCommandID("boobytrap"), params);
+					BoobyTrap(this, caller, item);
 					return;
 				}
 			}
@@ -406,9 +428,18 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			this.setVelocity(velocity);
 		}
 	}
-	else if (cmd == this.getCommandID("getout"))
+	else if (cmd == this.getCommandID("getout") && isServer())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
+
+		// range check
+		f32 distance = this.getDistanceTo(caller);
+		if (distance > 32.0f) return;
+
 		CBlob@ sneaky_player = getPlayerInside(this);
 		if (caller !is null && sneaky_player !is null)
 		{
@@ -420,37 +451,74 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				}
 			}
 			this.Tag("crate escaped");
+			this.Sync("crate escaped", true);
 			this.server_PutOutInventory(sneaky_player);
 		}
 		// Attack self to pop out items
 		this.server_Hit(this, this.getPosition(), Vec2f(), 100.0f, Hitters::crush, true);
 		this.server_Die();
 	}
-	else if (cmd == this.getCommandID("boobytrap"))
+	else if (cmd == this.getCommandID("boobytrap") && isServer())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
-		CBlob@ mine = getBlobByNetworkID(params.read_netid());
-		if (caller !is null && mine !is null && this.get_u32("boobytrap_cooldown_time") <= getGameTime())
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
+
+		// range check
+		f32 distance = this.getDistanceTo(caller);
+		if (distance > 32.0f) return;
+
+		CInventory@ inv = this.getInventory();
+		for (int i = 0; i < inv.getItemsCount(); i++)
 		{
-			this.set_u32("boobytrap_cooldown_time", getGameTime() + 30);
-			this.server_PutOutInventory(mine);
-			Vec2f pos = this.getPosition();
-			pos.y = this.getTeamNum() == caller.getTeamNum() ? pos.y - 5
-						: caller.getPosition().y - caller.getRadius() - 5;
-			pos.y = Maths::Min(pos.y, this.getPosition().y - 5);
-			mine.setPosition(pos);
-			mine.setVelocity(Vec2f((caller.getPosition().x - mine.getPosition().x) / 30.0f, -5.0f));
-			mine.set_u8("mine_timer", 255);
-			mine.SendCommand(mine.getCommandID("mine_primed"));
+			CBlob@ item = inv.getItem(i);
+			if (item.hasTag("player"))
+			{
+				// This command should not have been sent if there's a player in the crate
+				return;
+			}
+			if (item.getName() == "mine" && item.getTeamNum() != caller.getTeamNum())
+			{
+				// tell server to activate trap
+				BoobyTrap(this, caller, item);
+				break;
+			}
 		}
 	}
-	else if (cmd == this.getCommandID("activate"))
+	else if (cmd == this.getCommandID("activate") && isServer())
 	{
-		CBlob@ carrier = this.getAttachments().getAttachmentPointByName("PICKUP").getOccupied();
-		if (carrier !is null)
-		{
-			DumpOutItems(this, 5.0f, carrier.getVelocity(), false);
-		}
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
+
+		// only activate if caller is holding this crate
+		CBlob@ helditem = caller.getCarriedBlob();
+		if (helditem is null) return;
+		if (helditem !is this) return;
+
+		DumpOutItems(this, 5.0f, caller.getVelocity(), false);
+	}
+}
+
+void BoobyTrap(CBlob@ this, CBlob@ caller, CBlob@ mine)
+{
+	if (caller !is null && mine !is null && this.get_u32("boobytrap_cooldown_time") <= getGameTime())
+	{
+		this.set_u32("boobytrap_cooldown_time", getGameTime() + 30);
+		this.Sync("boobytrap_cooldown_time", true);
+		this.server_PutOutInventory(mine);
+		Vec2f pos = this.getPosition();
+		pos.y = this.getTeamNum() == caller.getTeamNum() ? pos.y - 5
+					: caller.getPosition().y - caller.getRadius() - 5;
+		pos.y = Maths::Min(pos.y, this.getPosition().y - 5);
+		mine.setPosition(pos);
+		mine.setVelocity(Vec2f((caller.getPosition().x - mine.getPosition().x) / 30.0f, -5.0f));
+		mine.set_u8("mine_timer", 255);
+		mine.SendCommand(mine.getCommandID("mine_primed"));
 	}
 }
 
@@ -536,10 +604,8 @@ void onCreateInventoryMenu(CBlob@ this, CBlob@ forBlob, CGridMenu @gridmenu)
 		}
 		if (item.getName() == "mine" && item.getTeamNum() != forBlob.getTeamNum())
 		{
-			CBitStream params;
-			params.write_netid(forBlob.getNetworkID());
-			params.write_netid(item.getNetworkID());
-			this.SendCommand(this.getCommandID("boobytrap"), params);
+			// tell server to activate trap
+			this.SendCommand(this.getCommandID("boobytrap"));
 			break;
 		}
 	}

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -517,8 +517,15 @@ void BoobyTrap(CBlob@ this, CBlob@ caller, CBlob@ mine)
 		pos.y = Maths::Min(pos.y, this.getPosition().y - 5);
 		mine.setPosition(pos);
 		mine.setVelocity(Vec2f((caller.getPosition().x - mine.getPosition().x) / 30.0f, -5.0f));
+
+		// maybe add MineCommon.as in the future..?
 		mine.set_u8("mine_timer", 255);
-		mine.SendCommand(mine.getCommandID("mine_primed"));
+		mine.Sync("mine_timer", true);
+		mine.set_u8("mine_state", 1);
+		mine.Sync("mine_state", true);
+		mine.getShape().checkCollisionsAgain = true;
+
+		mine.SendCommand(mine.getCommandID("mine_primed_client"));
 	}
 }
 

--- a/Entities/Items/Explosives/Mine/Mine.as
+++ b/Entities/Items/Explosives/Mine/Mine.as
@@ -86,7 +86,6 @@ void onTick(CBlob@ this)
 				if (this.get_u8(MINE_STATE) == PRIMED) return;
 
 				this.set_u8(MINE_STATE, PRIMED);
-				this.Sync(MINE_STATE, true);
 
 				this.getShape().checkCollisionsAgain = true;
 
@@ -105,6 +104,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
 	if (cmd == this.getCommandID("mine_primed_client") && isClient())
 	{
+		this.set_u8(MINE_STATE, PRIMED);
+		
 		this.getShape().checkCollisionsAgain = true;
 
 		CSprite@ sprite = this.getSprite();

--- a/Entities/Items/Explosives/Mine/Mine.as
+++ b/Entities/Items/Explosives/Mine/Mine.as
@@ -8,7 +8,6 @@ const u8 MINE_PRIMING_TIME = 45;
 const string MINE_STATE = "mine_state";
 const string MINE_TIMER = "mine_timer";
 const string MINE_PRIMING = "mine_priming";
-const string MINE_PRIMED = "mine_primed";
 
 enum State
 {
@@ -54,7 +53,7 @@ void onInit(CBlob@ this)
 	}
 
 	this.set_u8(MINE_TIMER, 0);
-	this.addCommandID(MINE_PRIMED);
+	this.addCommandID("mine_primed_client");
 
 	this.getCurrentScript().tickIfTag = MINE_PRIMING;
 }
@@ -67,7 +66,7 @@ void onInit(CSprite@ this)
 
 void onTick(CBlob@ this)
 {
-	if (getNet().isServer())
+	if (isServer())
 	{
 		//tick down
 		if (this.getVelocity().LengthSquared() < 1.0f && !this.isAttached())
@@ -79,7 +78,19 @@ void onTick(CBlob@ this)
 			if (timer >= MINE_PRIMING_TIME)
 			{
 				this.Untag(MINE_PRIMING);
-				this.SendCommand(this.getCommandID(MINE_PRIMED));
+
+				if (this.isAttached()) return;
+
+				if (this.isInInventory()) return;
+
+				if (this.get_u8(MINE_STATE) == PRIMED) return;
+
+				this.set_u8(MINE_STATE, PRIMED);
+				this.Sync(MINE_STATE, true);
+
+				this.getShape().checkCollisionsAgain = true;
+
+				this.SendCommand(this.getCommandID("mine_primed_client"));
 			}
 		}
 		//reset if bumped/moved
@@ -92,15 +103,8 @@ void onTick(CBlob@ this)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
-	if (cmd == this.getCommandID(MINE_PRIMED))
+	if (cmd == this.getCommandID("mine_primed_client") && isClient())
 	{
-		if (this.isAttached()) return;
-
-		if (this.isInInventory()) return;
-
-		if (this.get_u8(MINE_STATE) == PRIMED) return;
-
-		this.set_u8(MINE_STATE, PRIMED);
 		this.getShape().checkCollisionsAgain = true;
 
 		CSprite@ sprite = this.getSprite();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Crate.as
	"unpack" - was client->server->client, is now client->server. uses getActiveCommandPlayer(), added range check, added "unpack_client" command for the client part of it (just setting drag)
	"stop unpack" - was and remains client->server. uses getActiveCommandPlayer(), added range check. syncs prop now
	"getin" - was and remains client->server. uses getActiveCommandPlayer(). only getin if holding the crate on server. 
	"getout" - was and remains client->server. uses getActiveCommandPlayer(). added range check.
	"boobytrap" - was client->server->client, is now only a client->server command. uses getActiveCommandPlayer(), added range check.
	"activate" - this was a server->server command so the changes in here are unnecessary, check sanitization-activatableclusterfuck
	range checks are 32.0f (buttons are 20.0f)
	removed "mine_primed" command call inside "boobytrap" (server->server), replaced with normal code & added "mine_primed_client" call (maybe MineCommon.as in the future?)
Mine.as
	replaced "mine_primed" (server->server && server->client) with "mine_primed_client"