### PR TITLE
Cmd sanitization mechanisms

### DIFF
--- a/Entities/Structures/Components/Passive/Magazine/Magazine.as
+++ b/Entities/Structures/Components/Passive/Magazine/Magazine.as
@@ -37,7 +37,7 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 	Magazine component(position);
 	this.set("component", component);
 
-	if (getNet().isServer())
+	if (isServer())
 	{
 		MapPowerGrid@ grid;
 		if (!getRules().get("power grid", @grid)) return;
@@ -83,9 +83,6 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		return;
 	}
-
-	CBitStream params;
-	params.write_u16(LOAD ? carried.getNetworkID() : caller.getNetworkID());
 		
 	CBlob@ target = LOAD ? carried : item;
 	string iconName = "$" + target.getName() + "$";
@@ -99,8 +96,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	Vec2f_zero,																									// button offset
 	this, 																										// button attachment
 	this.getCommandID(LOAD ? "load" : "unload"), 																// command id
-	getTranslatedString(LOAD ? "Load {ITEM}" : "Unload {ITEM}").replace("{ITEM}", target.getInventoryName()),	// description
-	params);																									// cbitstream
+	getTranslatedString(LOAD ? "Load {ITEM}" : "Unload {ITEM}").replace("{ITEM}", target.getInventoryName()));	// description
 		
 	button.radius = 8.0f;
 	button.enableRadius = 22.0f;
@@ -108,14 +104,18 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (!getNet().isServer()) return;
-
-	if (cmd == this.getCommandID("load"))
+	if (cmd == this.getCommandID("load") && isServer())
 	{
-		u16 id;
-		if (!params.saferead_u16(id)) return;
+		CPlayer@ player = getNet().getActiveCommandPlayer();
+		if (player is null) return;
+					
+		CBlob@ caller = player.getBlob();
+		if (caller is null) return;
 
-		CBlob@ carried = getBlobByNetworkID(id);
+		// range check
+		if (this.getDistanceTo(caller) > 22.0f) return;
+
+		CBlob@ carried = caller.getCarriedBlob();
 		if (carried is null) return;
 
 		CBlob@ item = this.getInventory().getItem(0);
@@ -143,12 +143,17 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 		}
 	}
-	else if (cmd == this.getCommandID("unload"))
+	else if (cmd == this.getCommandID("unload") && isServer())
 	{
-		u16 id;
-		if (!params.saferead_u16(id)) return;
+		CPlayer@ player = getNet().getActiveCommandPlayer();
+		if (player is null) return;
+					
+		CBlob@ caller = player.getBlob();
+		if (caller is null) return;
 
-		CBlob@ caller = getBlobByNetworkID(id);
+		// range check
+		if (this.getDistanceTo(caller) > 22.0f) return;
+
 		if (caller is null) return;
 
 		CBlob@ item = this.getInventory().getItem(0);

--- a/Entities/Structures/Components/Source/Lever/Lever.as
+++ b/Entities/Structures/Components/Source/Lever/Lever.as
@@ -27,6 +27,7 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().waterPasses = true;
 
 	this.addCommandID("toggle");
+	this.addCommandID("toggle client");
 
 	AddIconToken("$lever_0$", "Lever.png", Vec2f(16, 16), 4);
 	AddIconToken("$lever_1$", "Lever.png", Vec2f(16, 16), 5);
@@ -43,7 +44,7 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 
 	this.set_u8("state", 0);
 
-	if (getNet().isServer())
+	if (isServer())
 	{
 		MapPowerGrid@ grid;
 		if (!getRules().get("power grid", @grid)) return;
@@ -92,28 +93,36 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("toggle"))
+	if (cmd == this.getCommandID("toggle") && isServer())
 	{
-		if (getNet().isServer())
-		{
-			Component@ component = null;
-			if (!this.get("component", @component)) return;
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+					
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
 
-			MapPowerGrid@ grid;
-			if (!getRules().get("power grid", @grid)) return;
+		// range check
+		if (this.getDistanceTo(caller) > 20.0f) return;
 
-			u8 state = this.get_u8("state") == 0? 1 : 0;
-			u8 info = state == 0? INFO_SOURCE : INFO_SOURCE | INFO_ACTIVE;
+		Component@ component = null;
+		if (!this.get("component", @component)) return;
 
-			this.set_u8("state", state);
-			this.Sync("state", true);
+		MapPowerGrid@ grid;
+		if (!getRules().get("power grid", @grid)) return;
 
-			grid.setInfo(
-			component.x,                        // x
-			component.y,                        // y
-			info);                              // information
-		}
+		u8 state = this.get_u8("state") == 0? 1 : 0;
+		u8 info = state == 0? INFO_SOURCE : INFO_SOURCE | INFO_ACTIVE;
 
+		this.set_u8("state", state);
+		this.Sync("state", true);
+
+		grid.setInfo(
+		component.x,                        // x
+		component.y,                        // y
+		info);                              // information
+	}
+	if (cmd == this.getCommandID("toggle client") && isClient())
+	{
 		CSprite@ sprite = this.getSprite();
 		if (sprite is null) return;
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

PushButton.as
	"activate" - was client->server->client, is client->server now, uses getActiveCommandPlayer(), added range check. added "activate client" command which runs the client code.
Lever.as
	"toggle" - was client->server->client, is client->server now, uses getActiveCommandPlayer(), added range check. added "toggle client" command which runs the client code.
PressurePlate.as
	"activate" and "deactivate" - was server->server and server->client (i think), are now functions that are called server-side rather than commands. added "activate client" and "deactivate client" which run the client-side code.
CoinSlot.as
	"activate" - was client->server->client, is client->server now, uses getActiveCommandPlayer(), added range check. added "activate client" command which runs the client code.
Magazine.as
	"load" - was client->server, still is, uses getActiveCommandPlayer(), range check
	"unload" - was client->server, still is, uses getActiveCommandPlayer(), range check
