### PR TITLE
Cmd sanitization colorednametoggle

### DIFF
--- a/Rules/CommonScripts/ColoredNameToggle.as
+++ b/Rules/CommonScripts/ColoredNameToggle.as
@@ -10,7 +10,7 @@ void onInit(CRules@ this)
 
     ChatCommands::RegisterCommand(ToggleNameColorCommand());
 
-    if(getNet().isClient())
+    if (isClient())
     {
         ignoreInitial = true;
     }
@@ -18,13 +18,13 @@ void onInit(CRules@ this)
 
 void loadAdminPreferences(CRules@ rules)
 {
-    if(getNet().isClient())
+    if (isClient())
     {
         CPlayer@ player = getLocalPlayer();
         ConfigFile admin_prefs = ConfigFile();
-        if(admin_prefs.loadFile("../Cache/admin_prefs.cfg"))
+        if (admin_prefs.loadFile("../Cache/admin_prefs.cfg"))
         {
-            if(admin_prefs.exists("name_color"))
+            if (admin_prefs.exists("name_color"))
             {
                 bool name_color = admin_prefs.read_bool("name_color");
                 rules.set_bool(getToggleID(player), name_color);
@@ -43,7 +43,7 @@ void onNewPlayerJoin(CRules@ this, CPlayer@ player)
 
     sendNameColorCommand(this, player, this.get_bool(getToggleID(player)));
 
-    if(isSpecial(player))
+    if (isSpecial(player))
     {
         CBitStream params;
         params.write_string(player.getUsername());
@@ -53,29 +53,29 @@ void onNewPlayerJoin(CRules@ this, CPlayer@ player)
 
 void onCommand(CRules@ this, u8 cmd, CBitStream@ params)
 {
-    if (cmd == this.getCommandID(toggle_command))
+    if (cmd == this.getCommandID(toggle_command) && isClient())
     {
         string toggleID = params.read_string();
         bool visible = params.read_bool();
         this.set_bool(toggleID, visible);
 
-        if(ignoreInitial)
+        if (ignoreInitial)
         {
             ignoreInitial = false;
             return;
         }
 
-        if(getNet().isClient() && toggleID == getToggleID(getLocalPlayer()))
+        if (toggleID == getToggleID(getLocalPlayer()))
         {
             ConfigFile admin_prefs = ConfigFile();
             admin_prefs.add_bool("name_color", visible);
             admin_prefs.saveFile("admin_prefs.cfg");
         }
     }
-    else if(cmd == this.getCommandID(prefs_command))
+    else if (cmd == this.getCommandID(prefs_command) && isClient())
     {
         string username = params.read_string();
-        if(getLocalPlayer() !is null && username == getLocalPlayer().getUsername())
+        if (getLocalPlayer() !is null && username == getLocalPlayer().getUsername())
         {
             loadAdminPreferences(this);
         }

--- a/Rules/CommonScripts/ColoredNameToggleCommon.as
+++ b/Rules/CommonScripts/ColoredNameToggleCommon.as
@@ -45,6 +45,8 @@ void sendNameColorCommand(CRules@ rules, CPlayer@ player, bool nameColorOn)
 {
 	string toggleID = getToggleID(player);
 
+	rules.set_bool(toggleID, nameColorOn);
+
 	CBitStream params;
 	params.write_string(toggleID);
 	params.write_bool(nameColorOn);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

ColoredNameToggle.as, ColoredNameToggleCommon.as
	"toggle colored name command" - was server->server and server->client, is now server->client only. 
	"request admin prefs" - was server->client, no intervention needed (added if isClient() to make things clear)
