### PR TITLE
Cmd sanitization teammenu

### DIFF
--- a/Rules/CommonScripts/TeamMenuJustSpectator.as
+++ b/Rules/CommonScripts/TeamMenuJustSpectator.as
@@ -4,12 +4,31 @@ const int BUTTON_SIZE = 4;
 
 void onInit(CRules@ this)
 {
-	this.addCommandID("pick teams"); // dumb client->client command, TODO: add func callbacks for cgridmenu in engine
-	this.addCommandID("pick spectator"); // dumb client->client command, TODO: add func callbacks for cgridmenu in engine
-	this.addCommandID("pick none"); // dumb client->client command, TODO: add func callbacks for cgridmenu in engine
-
 	AddIconToken("$TEAMS$", "GUI/MenuItems.png", Vec2f(32, 32), 1);
 	AddIconToken("$SPECTATOR$", "GUI/MenuItems.png", Vec2f(32, 32), 19);
+}
+
+void Callback_PickTeams(CBitStream@ params)
+{
+	CPlayer@ player = getLocalPlayer();
+	if (player is null) return;
+
+	player.client_ChangeTeam(getRules().getSpectatorTeamNum());
+	getHUD().ClearMenus();
+}
+
+void Callback_PickSpectator(CBitStream@ params)
+{
+	CPlayer@ player = getLocalPlayer();
+	if (player is null) return;
+
+	player.client_ChangeTeam(-1);
+	getHUD().ClearMenus();
+}
+
+void Callback_PickNone(CBitStream@ params)
+{
+	getHUD().ClearMenus();
 }
 
 void ShowTeamMenu(CRules@ this)
@@ -25,42 +44,17 @@ void ShowTeamMenu(CRules@ this)
 	if (menu !is null)
 	{
 		CBitStream exitParams;
-		menu.AddKeyCommand(KEY_ESCAPE, this.getCommandID("pick none"), exitParams);
-		menu.SetDefaultCommand(this.getCommandID("pick none"), exitParams);
+		menu.AddKeyCallback(KEY_ESCAPE, "TeamMenuJustSpectator.as", "Callback_PickNone", exitParams);
+		menu.SetDefaultCallback("TeamMenuJustSpectator.as", "Callback_PickNone", exitParams);
 
 		CBitStream params;
 		if (local.getTeamNum() == this.getSpectatorTeamNum())
 		{
-			CGridButton@ button = menu.AddButton("$TEAMS$", getTranslatedString("Auto-pick teams"), this.getCommandID("pick teams"), Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
+			CGridButton@ button = menu.AddButton("$TEAMS$", getTranslatedString("Auto-pick teams"), "TeamMenuJustSpectator.as", "Callback_PickTeams", Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
 		}
 		else
 		{
-			CGridButton@ button = menu.AddButton("$SPECTATOR$", getTranslatedString("Spectator"), this.getCommandID("pick spectator"), Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
+			CGridButton@ button = menu.AddButton("$SPECTATOR$", getTranslatedString("Spectator"), "TeamMenuJustSpectator.as", "Callback_PickSpectator", Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
 		}
-	}
-}
-
-// the actual team changing is done in the player management script -> onPlayerRequestSpawn()
-void onCommand(CRules@ this, u8 cmd, CBitStream @params)
-{
-	if (cmd == this.getCommandID("pick teams") && isClient())
-	{
-		CPlayer@ player = getLocalPlayer();
-		if (player is null) return;
-
-		player.client_ChangeTeam(-1);
-		getHUD().ClearMenus();
-	}
-	else if (cmd == this.getCommandID("pick spectator") && isClient())
-	{
-		CPlayer@ player = getLocalPlayer();
-		if (player is null) return;
-
-		player.client_ChangeTeam(this.getSpectatorTeamNum());
-		getHUD().ClearMenus();
-	}
-	else if (cmd == this.getCommandID("pick none") && isClient())
-	{
-		getHUD().ClearMenus();
 	}
 }

--- a/Rules/CommonScripts/TeamMenuJustSpectator.as
+++ b/Rules/CommonScripts/TeamMenuJustSpectator.as
@@ -4,9 +4,9 @@ const int BUTTON_SIZE = 4;
 
 void onInit(CRules@ this)
 {
-	this.addCommandID("pick teams");
-	this.addCommandID("pick spectator");
-	this.addCommandID("pick none");
+	this.addCommandID("pick teams"); // dumb client->client command, TODO: add func callbacks for cgridmenu in engine
+	this.addCommandID("pick spectator"); // dumb client->client command, TODO: add func callbacks for cgridmenu in engine
+	this.addCommandID("pick none"); // dumb client->client command, TODO: add func callbacks for cgridmenu in engine
 
 	AddIconToken("$TEAMS$", "GUI/MenuItems.png", Vec2f(32, 32), 1);
 	AddIconToken("$SPECTATOR$", "GUI/MenuItems.png", Vec2f(32, 32), 19);
@@ -28,9 +28,7 @@ void ShowTeamMenu(CRules@ this)
 		menu.AddKeyCommand(KEY_ESCAPE, this.getCommandID("pick none"), exitParams);
 		menu.SetDefaultCommand(this.getCommandID("pick none"), exitParams);
 
-
 		CBitStream params;
-		params.write_u16(local.getNetworkID());
 		if (local.getTeamNum() == this.getSpectatorTeamNum())
 		{
 			CGridButton@ button = menu.AddButton("$TEAMS$", getTranslatedString("Auto-pick teams"), this.getCommandID("pick teams"), Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
@@ -43,28 +41,25 @@ void ShowTeamMenu(CRules@ this)
 }
 
 // the actual team changing is done in the player management script -> onPlayerRequestSpawn()
-
-void ReadChangeTeam(CRules@ this, CBitStream @params, int team)
-{
-	CPlayer@ player = getPlayerByNetworkId(params.read_u16());
-	if (player is getLocalPlayer())
-	{
-		player.client_ChangeTeam(team);
-		getHUD().ClearMenus();
-	}
-}
-
 void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("pick teams"))
+	if (cmd == this.getCommandID("pick teams") && isClient())
 	{
-		ReadChangeTeam(this, params, -1);
+		CPlayer@ player = getLocalPlayer();
+		if (player is null) return;
+
+		player.client_ChangeTeam(-1);
+		getHUD().ClearMenus();
 	}
-	else if (cmd == this.getCommandID("pick spectator"))
+	else if (cmd == this.getCommandID("pick spectator") && isClient())
 	{
-		ReadChangeTeam(this, params, this.getSpectatorTeamNum());
+		CPlayer@ player = getLocalPlayer();
+		if (player is null) return;
+
+		player.client_ChangeTeam(this.getSpectatorTeamNum());
+		getHUD().ClearMenus();
 	}
-	else if (cmd == this.getCommandID("pick none"))
+	else if (cmd == this.getCommandID("pick none") && isClient())
 	{
 		getHUD().ClearMenus();
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

TeamMenu.as, TeamMenuJustSpectator.as
	Replaced client->client cgridmenu commands with func callbacks, needs #224 Crimson to work 
	also got rid of ReadChangeTeam() because functions with 2 lines are dumb as fuck
