### PR TITLE
Cmd sanitization activatable clusterfuck

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -1,7 +1,7 @@
 // Archer logic
 
 #include "ArcherCommon.as"
-#include "ThrowCommon.as"
+#include "ActivationThrowCommon.as"
 #include "KnockedCommon.as"
 #include "Hitters.as"
 #include "RunnerCommon.as"

--- a/Entities/Characters/Builder/BuilderLogic.as
+++ b/Entities/Characters/Builder/BuilderLogic.as
@@ -2,7 +2,7 @@
 
 #include "Hitters.as";
 #include "BuilderCommon.as";
-#include "ThrowCommon.as";
+#include "ActivationThrowCommon.as"
 #include "RunnerCommon.as";
 #include "Help.as";
 #include "Requirements.as"

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1,6 +1,6 @@
 // Knight logic
 
-#include "ThrowCommon.as"
+#include "ActivationThrowCommon.as"
 #include "KnightCommon.as";
 #include "RunnerCommon.as";
 #include "Hitters.as";
@@ -1145,72 +1145,71 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		CycleToBombType(this, type);
 	}
-	else if (cmd == this.getCommandID("activate/throw"))
+	else if (cmd == this.getCommandID("activate/throw") && isServer())
 	{
 		SetFirstAvailableBomb(this);
 	}
-	else if (cmd == this.getCommandID("activate/throw bomb"))
+	else if (cmd == this.getCommandID("activate/throw bomb") && isServer())
 	{
-		if (isServer())
+		Vec2f pos = this.getVelocity();
+		Vec2f vector = this.getAimPos() - this.getPosition();
+		Vec2f vel = this.getVelocity();
+
+		u8 bombType; 
+		if (!params.saferead_u8(bombType)) return;
+
+		CBlob @carried = this.getCarriedBlob();
+
+		if (carried !is null)
 		{
-			Vec2f pos = params.read_Vec2f();
-			Vec2f vector = params.read_Vec2f();
-			Vec2f vel = params.read_Vec2f();
-			u8 bombType = params.read_u8();
-
-			CBlob @carried = this.getCarriedBlob();
-
-			if (carried !is null)
+			bool holding_bomb = false;
+			// are we actually holding a bomb or something else?
+			for (uint i = 0; i < bombNames.length; i++)
 			{
-				bool holding_bomb = false;
-				// are we actually holding a bomb or something else?
-				for (uint i = 0; i < bombNames.length; i++)
+				if(carried.getName() == bombNames[i])
 				{
-					if(carried.getName() == bombNames[i])
-					{
-						holding_bomb = true;
-						DoThrow(this, carried, pos, vector, vel);
-					}
-				}
-
-				if (!holding_bomb)
-				{
-					ActivateBlob(this, carried, pos, vector, vel);
+					holding_bomb = true;
+					DoThrow(this, carried, pos, vector, vel);
 				}
 			}
-			else
-			{
-				if (bombType >= bombTypeNames.length)
-					return;
 
-				const string bombTypeName = bombTypeNames[bombType];
-				this.Tag(bombTypeName + " done activate");
-				if (hasItem(this, bombTypeName))
+			if (!holding_bomb)
+			{
+				ActivateBlob(this, carried, pos, vector, vel);
+			}
+		}
+		else
+		{
+			if (bombType >= bombTypeNames.length)
+				return;
+
+			const string bombTypeName = bombTypeNames[bombType];
+			this.Tag(bombTypeName + " done activate");
+			if (hasItem(this, bombTypeName))
+			{
+				if (bombType == 0)
 				{
-					if (bombType == 0)
+					CBlob @blob = server_CreateBlob("bomb", this.getTeamNum(), this.getPosition());
+					if (blob !is null)
 					{
-						CBlob @blob = server_CreateBlob("bomb", this.getTeamNum(), this.getPosition());
-						if (blob !is null)
-						{
-							TakeItem(this, bombTypeName);
-							this.server_Pickup(blob);
-						}
+						TakeItem(this, bombTypeName);
+						this.server_Pickup(blob);
 					}
-					else if (bombType == 1)
+				}
+				else if (bombType == 1)
+				{
+					CBlob @blob = server_CreateBlob("waterbomb", this.getTeamNum(), this.getPosition());
+					if (blob !is null)
 					{
-						CBlob @blob = server_CreateBlob("waterbomb", this.getTeamNum(), this.getPosition());
-						if (blob !is null)
-						{
-							TakeItem(this, bombTypeName);
-							this.server_Pickup(blob);
-							blob.set_f32("map_damage_ratio", 0.0f);
-							blob.set_f32("explosive_damage", 0.0f);
-							blob.set_f32("explosive_radius", 92.0f);
-							blob.set_bool("map_damage_raycast", false);
-							blob.set_string("custom_explosion_sound", "/GlassBreak");
-							blob.set_u8("custom_hitter", Hitters::water);
-							blob.Tag("splash ray cast");
-						}
+						TakeItem(this, bombTypeName);
+						this.server_Pickup(blob);
+						blob.set_f32("map_damage_ratio", 0.0f);
+						blob.set_f32("explosive_damage", 0.0f);
+						blob.set_f32("explosive_radius", 92.0f);
+						blob.set_bool("map_damage_raycast", false);
+						blob.set_string("custom_explosion_sound", "/GlassBreak");
+						blob.set_u8("custom_hitter", Hitters::water);
+						blob.Tag("splash ray cast");
 					}
 				}
 			}

--- a/Entities/Common/Building/BlobPlacement.as
+++ b/Entities/Common/Building/BlobPlacement.as
@@ -1,6 +1,6 @@
 // Blob can place blocks on grid
 
-#include "ThrowCommon.as";
+#include "ActivationThrowCommon.as"
 #include "PlacementCommon.as";
 #include "BuildBlock.as";
 #include "CheckSpam.as";

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -2,7 +2,7 @@
 // add to blob and sprite
 
 #include "StandardControlsCommon.as"
-#include "ThrowCommon.as"
+#include "ActivationThrowCommon.as"
 #include "WheelMenuCommon.as"
 #include "KnockedCommon.as"
 

--- a/Entities/Common/Throwing/Activatable.as
+++ b/Entities/Common/Throwing/Activatable.as
@@ -1,5 +1,4 @@
 // Attach this to objects activatable with ActivateHeldObject.as
-// then implement onCommand
 
 void onInit(CBlob@ this)
 {

--- a/Entities/Common/Throwing/Activatable.as
+++ b/Entities/Common/Throwing/Activatable.as
@@ -1,8 +1,0 @@
-// Attach this to objects activatable with ActivateHeldObject.as
-
-void onInit(CBlob@ this)
-{
-	this.Tag("activatable");
-	this.addCommandID("activate");
-	this.getCurrentScript().runFlags |= Script::remove_after_this;
-}

--- a/Entities/Common/Throwing/ActivateHeldObject.as
+++ b/Entities/Common/Throwing/ActivateHeldObject.as
@@ -1,19 +1,4 @@
-
-// USAGE:
-//  add strings to "names to activate" array
-//  add "activate" commands to those objects
-//  light and throw them with client_SendThrowOrActivateCommand( this ); in ThrowCommon.as
-//  Tag("dont deactivate") to have repeated activation
-
-/**  also...
- * Means this object can throw other objects with client_SendThrowCommand( this ); in ThrowCommon.as
- *
- * for custom throw scales (eg for a super-strong unit) use
- *  the "throw scale" property, default to 1.0f.
- *
- */
-
-#include "ThrowCommon.as";
+#include "ActivationThrowCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -34,11 +19,11 @@ void onInit(CBlob@ this)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("activate/throw"))
+	if (cmd == this.getCommandID("activate/throw") && isServer())
 	{
-		Vec2f pos = params.read_Vec2f();
-		Vec2f vector = params.read_Vec2f();
-		Vec2f vel = params.read_Vec2f();
+		Vec2f pos = this.getVelocity();
+		Vec2f vector = this.getAimPos() - this.getPosition();
+		Vec2f vel = this.getVelocity();
 		CBlob @carried = this.getCarriedBlob();
 		if (carried !is null)
 		{
@@ -55,16 +40,16 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 		}
 	}
-	else if (cmd == this.getCommandID("throw"))
+	else if (cmd == this.getCommandID("throw") && isServer())
 	{
-		Vec2f pos = params.read_Vec2f();
-		Vec2f vector = params.read_Vec2f();
-		Vec2f vel = params.read_Vec2f();
+		Vec2f pos = this.getVelocity();
+		Vec2f vector = this.getAimPos() - this.getPosition();
+		Vec2f vel = this.getVelocity();
 		CBlob @carried = this.getCarriedBlob();
 
 		if (carried !is null)
 		{
-			if (isServer() && !carried.hasTag("custom throw"))
+			if (!carried.hasTag("custom throw"))
 			{
 				DoThrow(this, carried, pos, vector, vel);
 			}

--- a/Entities/Items/Containers/Chest/Chest.as
+++ b/Entities/Items/Containers/Chest/Chest.as
@@ -5,10 +5,8 @@
 
 void onInit(CBlob@ this)
 {
-	// Activatable.as adds the following
-	// this.Tag("activatable");
-	// this.addCommandID("activate");
-	this.addCommandID("activate client");
+	this.Tag("activatable");
+	this.addCommandID("activate");
 
 	// used by RunnerMovement.as & ActivateHeldObject.as
 	this.Tag("medium weight");

--- a/Entities/Items/Containers/Chest/Chest.cfg
+++ b/Entities/Items/Containers/Chest/Chest.cfg
@@ -67,7 +67,6 @@ $inventory_factory                                =
 
 $name                                             = chest
 @$scripts                                         = Chest.as;
-                                                    Activatable.as;
                                                     StoneStructureHit.as;
                                                     Stone.as;
                                                     NoPlayerCollision.as;

--- a/Entities/Items/Containers/Present/Present.as
+++ b/Entities/Items/Containers/Present/Present.as
@@ -5,7 +5,8 @@
 
 void onInit(CBlob@ this)
 {
-	this.addCommandID("activate client");
+	this.Tag("activatable");
+	this.addCommandID("activate");
 
 	this.Tag("medium weight");
 

--- a/Entities/Items/Containers/Present/Present.cfg
+++ b/Entities/Items/Containers/Present/Present.cfg
@@ -52,7 +52,6 @@ $inventory_factory                                =
 
 $name                                             = present
 @$scripts                                         = Present.as;
-                                                    Activatable.as;
                                                     Wooden.as;
                                                     NoPlayerCollision.as;
 f32_health                                        = 8.0

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -39,6 +39,8 @@ void onInit(CBlob@ this)
 {
 	this.checkInventoryAccessibleCarefully = true;
 
+	this.Tag("activatable");
+
 	this.addCommandID("unpack");
 	this.addCommandID("unpack_client"); // just sets the drag...
 	this.addCommandID("getin");

--- a/Entities/Items/Crate/Crate.cfg
+++ b/Entities/Items/Crate/Crate.cfg
@@ -82,7 +82,6 @@ $name                                             = crate
 													Crate.as;
 													CrateAutoPickup.as;
 													EmoteBubble.as;
-													Activatable.as;
 													ClamberableCollision.as;
 													SetTeamToCarrier.as;
 													DecayIfSpammed;

--- a/Entities/Items/Explosives/Bomb.cfg
+++ b/Entities/Items/Explosives/Bomb.cfg
@@ -56,7 +56,6 @@ $name                                             = bomb
 @$scripts                                         = Bomb.as;
 													BombPhysics.as;
 													BombTimer.as;
-													Activatable.as;
 													CheapFakeRolling.as;
 													SetTeamToCarrier.as;
 													SetDamageToCarrier.as;

--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -110,14 +110,18 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			}
 			break;
 		case Hitters::keg:
-			if (!this.hasTag("exploding") && isServer())
+			if (isServer())
 			{
-				this.SendCommand(this.getCommandID("activate"));
-			}
-			//set fuse to shortest fuse time - either current time or new random time
-			//so it doesn't explode at the exact same time as hitter keg
-			this.set_s32("explosion_timer", Maths::Min(this.get_s32("explosion_timer"), getGameTime() + XORRandom(this.get_f32("keg_time")) / 3));
+				if (!this.hasTag("exploding"))
+				{
+					this.SendCommand(this.getCommandID("activate"));
+				}
 
+				//set fuse to shortest fuse time - either current time or new random time
+				//so it doesn't explode at the exact same time as hitter keg
+				this.set_s32("explosion_timer", Maths::Min(this.get_s32("explosion_timer"), getGameTime() + XORRandom(this.get_f32("keg_time")) / 3));
+				this.Sync("explosion_timer", true);
+			}
 			damage *= 0.0f; //invincible to allow keg chain reaction
 			break;
 		default:

--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -104,13 +104,13 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			damage *= 0.25f; //quarter damage from these
 			break;
 		case Hitters::water:
-			if (hitterBlob.getName() == "bucket" && this.hasTag("exploding"))
+			if (hitterBlob.getName() == "bucket" && this.hasTag("exploding") && isServer())
 			{
 				this.SendCommand(this.getCommandID("deactivate"));
 			}
 			break;
 		case Hitters::keg:
-			if (!this.hasTag("exploding"))
+			if (!this.hasTag("exploding") && isServer())
 			{
 				this.SendCommand(this.getCommandID("activate"));
 			}

--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -60,7 +60,7 @@ void onTick(CSprite@ this)
 
 void onTick(CBlob@ this)
 {
-	if (this.isInFlames() && !this.hasTag("exploding"))
+	if (this.isInFlames() && !this.hasTag("exploding") && isServer())
 	{
 		this.SendCommand(this.getCommandID("activate"));
 	}

--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -1,5 +1,6 @@
 // Keg logic
 #include "Hitters.as";
+#include "ActivationThrowCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -62,7 +63,7 @@ void onTick(CBlob@ this)
 {
 	if (this.isInFlames() && !this.hasTag("exploding") && isServer())
 	{
-		this.SendCommand(this.getCommandID("activate"));
+		server_Activate(this);
 	}
 }
 
@@ -106,7 +107,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		case Hitters::water:
 			if (hitterBlob.getName() == "bucket" && this.hasTag("exploding") && isServer())
 			{
-				this.SendCommand(this.getCommandID("deactivate"));
+				server_Deactivate(this);
 			}
 			break;
 		case Hitters::keg:
@@ -114,7 +115,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			{
 				if (!this.hasTag("exploding"))
 				{
-					this.SendCommand(this.getCommandID("activate"));
+					server_Activate(this);
 				}
 
 				//set fuse to shortest fuse time - either current time or new random time

--- a/Entities/Items/Explosives/Keg.cfg
+++ b/Entities/Items/Explosives/Keg.cfg
@@ -68,7 +68,6 @@ $inventory_factory                                =
 $name                                             = keg
 @$scripts                                         = Wooden.as;
 													FakeRolling.as;
-													Activatable.as;
 													KegVoodoo.as;
 													Keg.as;
 													ExplodeOnDie.as;

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -1,4 +1,4 @@
-//#include "ThrowCommon.as";
+#include "ActivationThrowCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -15,7 +15,12 @@ void onInit(CBlob@ this)
 	this.set_f32("keg_time", 300.0f);
 	this.set_bool("explosive_teamkill", true);
 
-	this.addCommandID("deactivate");
+	Activate@ activation_handle = @onActivate;
+	this.set("activate handle", @activation_handle);
+
+	Activate@ @deactivation_handle = @onDeactivate;
+	this.set("deactivate handle", @deactivation_handle);
+
 	this.addCommandID("activate client");
 	this.addCommandID("deactivate client");
 
@@ -28,7 +33,7 @@ void onTick(CBlob@ this)
 	// HACK, TODO: add a script for stuff like this or something
 	if (!this.hasTag("activated") && isServer()) //admin frozen?
 	{
-		this.SendCommand(this.getCommandID("deactivate"));
+		server_Deactivate(this);
 	}
 	else
 	{
@@ -61,40 +66,70 @@ void onTick(CBlob@ this)
 	}
 }
 
+/* custom callback
+Kegs can be activated by:
+Arrow.as - fire arrow hit
+ActivateHeldObject.as - "activate/throw" command ActivateBlob (called in KnightLogic.as)
+Keg.as - onHit by keg
+Keg.as - onTick, in flames
+There is no instance of kegs being activated with a direct client->server command */
+void onActivate(CBitStream@ params)
+{
+	if (!isServer()) return;
+
+	u16 this_id;
+	if (!params.saferead_u16(this_id)) return;
+
+	CBlob@ this = getBlobByNetworkID(this_id);
+	if (this is null) return;
+
+	this.Tag("activated");
+	this.set_s32("explosion_timer", getGameTime() + this.get_f32("keg_time"));
+	this.Tag("exploding");
+
+	this.Sync("activated", true);
+	this.Sync("explosion_timer", true);
+	this.Sync("exploding", true);
+
+	// not sure if necessary for server
+	this.SetLight(true);
+	this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
+
+	this.SendCommand(this.getCommandID("activate client"));
+}
+
+/* custom callback
+Kegs can be deactivated by:
+Keg.as - onHit by bucket
+KegVoodoo.as - onTick for freeze-by-admin check
+There is no instance of kegs being activated with a direct client->server command */
+void onDeactivate(CBitStream@ params)
+{
+	if (!isServer()) return;
+
+	u16 this_id;
+	if (!params.saferead_u16(this_id)) return;
+
+	CBlob@ this = getBlobByNetworkID(this_id);
+	if (this is null) return;
+
+	this.Untag("activated");
+	this.set_s32("explosion_timer", 0);
+	this.Untag("exploding");
+
+	this.Sync("activated", true);
+	this.Sync("explosion_timer", true);
+	this.Sync("exploding", true);
+
+	// not sure if necessary for server
+	this.SetLight(false);
+
+	this.SendCommand(this.getCommandID("deactivate client"));
+}
+
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("activate") && isServer()) // added in Activatable.as
-	{
-		CPlayer@ callerp = getNet().getActiveCommandPlayer();
-		/*
-		Kegs can be activated by:
-		Arrow.as - fire arrow hit, SERVERSIDE
-		KnightLogic.as - "activate/throw bomb" command, SERVERSIDE
-		ActivateHeldObject.as - "activate/throw" command ActivateBlob, SERVERSIDE
-		Keg.as - onHit by keg, SERVERSIDE
-		There is no instance of kegs being activated with a direct client->server command
-		*/
-		bool from_server = (callerp is null);
-		if (!from_server)
-		{
-			return;
-		}
-
-		this.Tag("activated");
-		this.set_s32("explosion_timer", getGameTime() + this.get_f32("keg_time"));
-		this.Tag("exploding");
-
-		this.Sync("activated", true);
-		this.Sync("explosion_timer", true);
-		this.Sync("exploding", true);
-
-		// not sure if necessary for server
-		this.SetLight(true);
-		this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-
-		this.SendCommand(this.getCommandID("activate client"));
-	}
-	else if (cmd == this.getCommandID("activate client") && isClient())
+	if (cmd == this.getCommandID("activate client") && isClient())
 	{
 		this.SetLight(true);
 		this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
@@ -102,35 +137,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		this.getSprite().SetEmitSoundSpeed(1.0f);
 		this.getSprite().SetEmitSoundVolume(1.0f);
 		this.getSprite().SetEmitSoundPaused(false);
-	}
-	else if (cmd == this.getCommandID("deactivate") && isServer())
-	{
-		CPlayer@ callerp = getNet().getActiveCommandPlayer();
-		/*
-		Kegs can be deactivated by:
-		Keg.as - onHit by bucket, SERVERSIDE
-		Keg.as - onTick, in flames, SERVERSIDE
-		KegVoodoo.as - onTick for freeze-by-admin check, SERVERSIDE
-		There is no instance of kegs being activated with a direct client->server command
-		*/
-		bool from_server = (callerp is null);
-		if (!from_server)
-		{
-			return;
-		}
-
-		this.Untag("activated");
-		this.set_s32("explosion_timer", 0);
-		this.Untag("exploding");
-
-		this.Sync("activated", true);
-		this.Sync("explosion_timer", true);
-		this.Sync("exploding", true);
-
-		// not sure if necessary for server
-		this.SetLight(false);
-
-		this.SendCommand(this.getCommandID("deactivate client"));
 	}
 	else if (cmd == this.getCommandID("deactivate client") && isClient())
 	{
@@ -150,16 +156,17 @@ void Boom(CBlob@ this)
 	this.server_SetHealth(-1.0f);
 	this.server_Die();
 
-	if (getNet().isClient()) {
+	if (isClient()) 
+	{
 		// screenshake when close to a Keg
 
 		CBlob @blob = getLocalPlayerBlob();
-		CPlayer @player = getLocalPlayer();
+		CPlayer@ player = getLocalPlayer();
 		Vec2f pos;
 
 	    CCamera @camera = getCamera();
-		if (camera !is null) {
-			
+		if (camera !is null) 
+		{
 			// If the player is a spectating, base their location off of their camera.	
 			if (player !is null && player.getTeamNum() == getRules().getSpectatorTeamNum())
 			{
@@ -176,7 +183,8 @@ void Boom(CBlob@ this)
 
 			pos -= this.getPosition();
 			f32 dist = pos.Length();
-			if (dist < 300) {
+			if (dist < 300) 
+			{
 				ShakeScreen(200, 60, this.getPosition());
 			}
 		}

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -20,7 +20,7 @@ void onInit(CBlob@ this)
 	Activate@ activation_handle = @onActivate;
 	this.set("activate handle", @activation_handle);
 
-	Activate@ @deactivation_handle = @onDeactivate;
+	Activate@ deactivation_handle = @onDeactivate;
 	this.set("deactivate handle", @deactivation_handle);
 
 	this.addCommandID("activate client");

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -70,7 +70,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		Kegs can be activated by:
 		Arrow.as - fire arrow hit, SERVERSIDE
 		KnightLogic.as - "activate/throw bomb" command, SERVERSIDE
-		ActivateHeldObject.as - "activate/throw" command, SERVERSIDE
+		ActivateHeldObject.as - "activate/throw" command ActivateBlob, SERVERSIDE
 		Keg.as - onHit by keg, SERVERSIDE
 		There is no instance of kegs being activated with a direct client->server command
 		*/

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -15,6 +15,8 @@ void onInit(CBlob@ this)
 	this.set_f32("keg_time", 300.0f);
 	this.set_bool("explosive_teamkill", true);
 
+	this.Tag("activatable");
+
 	Activate@ activation_handle = @onActivate;
 	this.set("activate handle", @activation_handle);
 

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -109,6 +109,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		/*
 		Kegs can be deactivated by:
 		Keg.as - onHit by bucket, SERVERSIDE
+		Keg.as - onTick, in flames, SERVERSIDE
 		KegVoodoo.as - onTick for freeze-by-admin check, SERVERSIDE
 		There is no instance of kegs being activated with a direct client->server command
 		*/

--- a/Entities/Items/Explosives/Satchel.as
+++ b/Entities/Items/Explosives/Satchel.as
@@ -15,6 +15,8 @@ void onInit(CBlob@ this)
 	this.getShape().getVars().waterDragScale = 24.0f;
 	this.getCurrentScript().tickIfTag = "exploding";
 
+	this.Tag("activatable");
+
 	Activate@ func = @onActivate;
 	this.set("activate handle", @func);
 }

--- a/Entities/Items/Explosives/Satchel.as
+++ b/Entities/Items/Explosives/Satchel.as
@@ -209,9 +209,24 @@ void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("activate"))
+	if (cmd == this.getCommandID("activate") && isServer())
 	{
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		/*
+		Satchels can be activated by:
+		ActivateHeldObject.as - "activate/throw" command ActivateBlob, SERVERSIDE
+		There is no instance of lanterns being activated with a direct client->server command
+		*/
+		bool from_server = (callerp is null);
+		if (!from_server)
+		{
+			return;
+		}
+
 		this.Tag("exploding");
 		this.Tag("activated");
+
+		this.Sync("exploding", true);
+		this.Sync("activated", true);
 	}
 }

--- a/Entities/Items/Explosives/Satchel.cfg
+++ b/Entities/Items/Explosives/Satchel.cfg
@@ -74,7 +74,6 @@ $inventory_factory                      =
 
 $name                                   = satchel
 @$scripts                               = Satchel.as;
-										  Activatable.as;
 										  NoPlayerCollision.as;
 										  NoCollisionOnGround.as;
 										  BombPhysics.as;

--- a/Entities/Items/Explosives/WaterBomb.cfg
+++ b/Entities/Items/Explosives/WaterBomb.cfg
@@ -51,7 +51,6 @@ $name                                             = waterbomb
 @$scripts                                         = Bomb.as;
 													BombPhysics.as;
 													BombTimer.as;
-													Activatable.as;
 													CheapFakeRolling.as;
 													SetTeamToCarrier.as;
 													SetDamageToCarrier.as;

--- a/Entities/Items/Lantern/Lantern.as
+++ b/Entities/Items/Lantern/Lantern.as
@@ -7,6 +7,8 @@ void onInit(CBlob@ this)
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 255, 240, 171));
 
+	this.Tag("activatable");
+
 	this.Tag("dont deactivate");
 	this.Tag("fire source");
 	this.Tag("ignore_arrow");

--- a/Entities/Items/Lantern/Lantern.cfg
+++ b/Entities/Items/Lantern/Lantern.cfg
@@ -57,7 +57,6 @@ $name                                             = lantern
 													DecayInWater.as;
 													Lantern.as;
 													NoPlayerCollision.as;
-													Activatable.as;
 													SetTeamToCarrier.as;
 													DecayIfSpammed;
 													OffscreenThrottle.as;

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -559,7 +559,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 
 		if (arrowType == ArrowType::fire)
 		{
-			if (hitBlob.getName() == "keg" && !hitBlob.hasTag("exploding"))
+			if (hitBlob.getName() == "keg" && !hitBlob.hasTag("exploding") && isServer())
 			{
 				hitBlob.SendCommand(hitBlob.getCommandID("activate"));
 			}

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -8,6 +8,7 @@
 #include "KnockedCommon.as";
 #include "DoorCommon.as";
 #include "FireplaceCommon.as";
+#include "ActivationThrowCommon.as"
 
 const s32 bomb_fuse = 120;
 const f32 arrowMediumSpeed = 8.0f;
@@ -561,7 +562,7 @@ f32 ArrowHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlo
 		{
 			if (hitBlob.getName() == "keg" && !hitBlob.hasTag("exploding") && isServer())
 			{
-				hitBlob.SendCommand(hitBlob.getCommandID("activate"));
+				server_Activate(hitBlob);
 			}
 
 			if (hitShield)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

KegVoodoo.as, Keg.as, Arrow.as
	"activate" - Was a server->server and server->client command, possibly client->server in certain cases where it shouldn't have been. (ActivateHeldObject.as/KnightLogic.as/Arrow.as/Keg.as). Is now a callback for server->server. Added "activate client", which runs the clientside code.
	"deactivate" - Was a server->server and server->client command (Keg.as/KegVoodoo.as). Is now a callback for server->server. Added "deactivate client", which runs the clientside code.
Lantern.as
	"activate" - Was a server->server and server->client command ("activate/throw" ActivateHeldObject.as). Is now a callback for server->server. Added "activate client", which runs the clientside code.
Satchel.as
	"activate" - Was a server->server and server->client command ("activate/throw" ActivateHeldObject.as). Is now a callback for server->server.
Crate.as
	"activate" - Was a server->server and server->client command ("activate/throw" ActivateHeldObject.as). Is now a callback for server->server. Might conflict with sanitization-crate&mine?
ThrowCommon.as - renamed to ActivationThrowCommon.as
	Added activation/deactivation funcdefs and functions to call callbacks
KnightLogic.as, ActivateHeldObject.as
	"activate/throw", "activate/throw bomb", "throw" sanitized
Activatable.as
	This was used, for some reason, for both blobs activatable with a button (chests/presents, where command usage is ok) and for blobs activatable with space (which led to it being used a server->server command). Removed.
!!! Need deltas to be updated on server before onCommand is run for this PR
