### PR TITLE
Cmd sanitization controls

### DIFF
--- a/Entities/Characters/Archer/ArcherCommon.as
+++ b/Entities/Characters/Archer/ArcherCommon.as
@@ -214,7 +214,9 @@ bool hasArrows(CBlob@ this)
 
 bool hasArrows(CBlob@ this, u8 arrowType)
 {
-	return arrowType < ArrowType::count && this.getBlobCount(arrowTypeNames[arrowType]) > 0;
+	if (this is null) return false;
+	
+	return arrowType < arrowTypeNames.length && this.hasBlob(arrowTypeNames[arrowType], 1);
 }
 
 bool hasAnyArrows(CBlob@ this)

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -930,9 +930,6 @@ void onCycle(CBitStream@ params)
 		if (hasArrows(this, type))
 		{
 			CycleToArrowType(this, archer, type);
-			CBitStream sparams;
-			sparams.write_u8(type);
-			this.SendCommand(this.getCommandID("switch"), sparams);
 			break;
 		}
 	}
@@ -960,9 +957,6 @@ void onSwitch(CBitStream@ params)
 	if (hasArrows(this, type))
 	{
 		CycleToArrowType(this, archer, type);
-		CBitStream sparams;
-		sparams.write_u8(type);
-		this.SendCommand(this.getCommandID("switch"), sparams);
 	}
 }
 
@@ -1145,31 +1139,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	else if (cmd == this.getCommandID(grapple_sync_cmd) && isClient())
 	{
 		HandleGrapple(this, params, !canSend(this));
-	}
-	else if (cmd == this.getCommandID("switch") && isServer())
-	{
-		CPlayer@ callerp = getNet().getActiveCommandPlayer();
-		if (callerp is null) return;
-
-		CBlob@ caller = callerp.getBlob();
-		if (caller is null) return;
-
-		if (caller !is this) return;
-
-		// switch to arrow
-		ArcherInfo@ archer;
-		if (!this.get("archerInfo", @archer))
-		{
-			return;
-		}
-
-		u8 type;
-		if (!params.saferead_u8(type)) return;
-
-		if (hasArrows(this, type))
-		{
-			CycleToArrowType(this, archer, type);
-		}
 	}
 	else if (isServer())
 	{

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -7,7 +7,8 @@
 #include "ShieldCommon.as";
 #include "KnockedCommon.as"
 #include "Help.as";
-#include "Requirements.as"
+#include "Requirements.as";
+#include "StandardControlsCommon.as";
 
 
 //attacks limited to the one time per-actor before reset.
@@ -81,6 +82,12 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().net_threshold_multiplier = 0.5f;
 	this.Tag("player");
 	this.Tag("flesh");
+
+	ControlsSwitch@ controls_switch = @onSwitch;
+	this.set("onSwitch handle", @controls_switch);
+
+	ControlsCycle@ controls_cycle = @onCycle;
+	this.set("onCycle handle", @controls_cycle);
 
 	this.addCommandID("activate/throw bomb");
 
@@ -1068,33 +1075,75 @@ void SwordCursorUpdate(CBlob@ this, KnightInfo@ knight)
 		}
 }
 
-void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
+// clientside
+void onCycle(CBitStream@ params)
 {
-	if (cmd == this.getCommandID("cycle"))  //from standardcontrols
+	u16 this_id;
+	if (!params.saferead_u16(this_id)) return;
+
+	CBlob@ this = getBlobByNetworkID(this_id);
+	if (this is null) return;
+
+	if (bombTypeNames.length == 0) return;
+
+	// cycle bombs
+	u8 type = this.get_u8("bomb type");
+	int count = 0;
+	while (count < bombTypeNames.length)
 	{
-		// cycle bombs
-		u8 type = this.get_u8("bomb type");
-		int count = 0;
-		while (count < bombTypeNames.length)
-		{
-			type++;
-			count++;
-			if (type >= bombTypeNames.length)
-				type = 0;
-			if (hasBombs(this, type))
-			{
-				CycleToBombType(this, type);
-				break;
-			}
-		}
-	}
-	else if (cmd == this.getCommandID("switch"))
-	{
-		u8 type;
-		if (params.saferead_u8(type) && hasBombs(this, type))
+		type++;
+		count++;
+		if (type >= bombTypeNames.length)
+			type = 0;
+		if (hasBombs(this, type))
 		{
 			CycleToBombType(this, type);
+			CBitStream sparams;
+			sparams.write_u8(type);
+			this.SendCommand(this.getCommandID("switch"), sparams);
+			break;
 		}
+	}
+}
+
+void onSwitch(CBitStream@ params)
+{
+	u16 this_id;
+	if (!params.saferead_u16(this_id)) return;
+
+	CBlob@ this = getBlobByNetworkID(this_id);
+	if (this is null) return;
+
+	if (bombTypeNames.length == 0) return;
+
+	u8 type;
+	if (!params.saferead_u8(type)) return;
+
+	if (hasBombs(this, type))
+	{
+		CycleToBombType(this, type);
+		CBitStream sparams;
+		sparams.write_u8(type);
+		this.SendCommand(this.getCommandID("switch"), sparams);
+	}
+}
+
+void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
+{
+	if (cmd == this.getCommandID("switch") && isServer())
+	{
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+
+		if (caller !is this) return;
+		// cycle bombs
+		u8 type;
+		if (!params.saferead_u8(type)) return;
+
+		CycleToBombType(this, type);
 	}
 	else if (cmd == this.getCommandID("activate/throw"))
 	{

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -19,9 +19,7 @@ void onInit(CBlob@ this)
 	this.addCommandID("putinheld");
 	this.addCommandID("getout");
 	this.addCommandID("detach");
-	this.addCommandID("cycle");
 	this.addCommandID("switch");
-	this.addCommandID("tap inventory key");
 
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -36,56 +34,80 @@ void onInit(CBlob@ this)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (!getNet().isServer())                                // server only!
-	{
-		return;
-	}
+	if (!isServer()) return;
 
 	if (cmd == this.getCommandID("putinheld"))
 	{
-		CBlob@ owner = getBlobByNetworkID(params.read_netid());
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
 
-		putInHeld(owner);
-	}
-	else if (cmd == this.getCommandID("tap inventory key"))
-	{
-		CBlob@ owner = getBlobByNetworkID(params.read_netid());
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+		if (caller !is this) return;
+		if (caller.isInInventory()) return;
+		if (caller.isAttached()) return;
 
-		if (!putInHeld(owner))
-		{
-			this.SendCommand(this.getCommandID("cycle"));
-		}
+		CBlob@ held = this.getCarriedBlob();
+		if (held is null) return;
+
+		putInHeld(caller);
 	}
 	else if (cmd == this.getCommandID("pickup"))
 	{
-		CBlob@ owner = getBlobByNetworkID(params.read_netid());
-		CBlob@ pick = getBlobByNetworkID(params.read_netid());
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
 
-		if (owner !is null 
-		    && !owner.isInInventory()
-		    && !owner.isAttached()
-		    && pick !is null 
-		    && !pick.isAttached()
-		    && pick.canBePickedUp(owner))
-		{
-			owner.server_Pickup(pick);
-		}
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+		if (caller !is this) return;
+		if (caller.isInInventory()) return;
+		if (caller.isAttached()) return;
+
+		u16 pickedup_id;
+		if (!params.saferead_u16(pickedup_id)) return;
+
+		CBlob@ pickedup = getBlobByNetworkID(pickedup_id);
+		if (pickedup is null) return;
+
+		if (!pickedup.canBePickedUp(caller)) return;
+
+		if (pickedup.isAttached()) return;
+
+		caller.server_Pickup(pickedup);
 	}
 	else if (cmd == this.getCommandID("detach"))
 	{
-		CBlob@ obj = getBlobByNetworkID(params.read_netid());
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
 
-		if (obj !is null)
-		{
-			this.server_DetachFrom(obj);
-		}
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+		if (caller !is this) return;
+
+		u16 attached_id;
+		if (!params.saferead_u16(attached_id)) return;
+
+		CBlob@ attached = getBlobByNetworkID(attached_id);
+		if (attached is null) return;
+		
+		if (!this.isAttachedTo(attached)) return;
+
+		this.server_DetachFrom(attached);
 	}
 	else if (cmd == this.getCommandID("getout"))
 	{
-		if (this.getInventoryBlob() !is null)
-		{
-			this.getInventoryBlob().server_PutOutInventory(this);
-		}
+		CBlob@ inv = this.getInventoryBlob();
+		if (inv is null) return;
+
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+
+		if (caller !is this) return;
+
+		inv.server_PutOutInventory(this);
 	}
 }
 
@@ -94,7 +116,6 @@ bool putInHeld(CBlob@ owner)
 	if (owner is null) return false;
 
 	CBlob@ held = owner.getCarriedBlob();
-
 	if (held is null) return false;
 
 	return owner.server_PutInInventory(held);
@@ -113,7 +134,7 @@ bool ClickGridMenu(CBlob@ this, int button)
 			{
 				if (gbutton is null)    // carrying something, put it in
 				{
-					server_PutInHeld(this, gmenu.getOwner());
+					client_PutInHeld(this);
 				}
 				else // take something
 				{
@@ -209,15 +230,13 @@ void onTick(CBlob@ this)
 
 	if (this.isInInventory())
 	{
-		if (this.isKeyJustPressed(key_pickup))
+		if (this.isKeyJustPressed(key_pickup) && isClient())
 		{
 			CBlob@ invblob = this.getInventoryBlob();
 			// Use the inventoryblob command if it has one (crate for example)
 			if (invblob.hasCommandID("getout"))
 			{
-				CBitStream params;
-				params.write_u16(this.getNetworkID());
-				invblob.SendCommand(invblob.getCommandID("getout"), params);
+				invblob.SendCommand(invblob.getCommandID("getout"));
 			}
 			else
 			{
@@ -255,11 +274,28 @@ void onTick(CBlob@ this)
 		}
 		else if (this.isKeyJustReleased(key_inventory))
 		{
-			if (isTap(this, 7))     // tap - put thing in inventory
+			u8 minimum_ticks = 5;
+			if (this.getName() == "builder") minimum_ticks = 3; // they have to switch blocks faaaaast
+
+			if (isTap(this, minimum_ticks))     // tap - put thing in inventory
 			{
-				CBitStream params;
-				params.write_netid(this.getNetworkID());
-				this.SendCommand(this.getCommandID("tap inventory key"), params);
+				CBlob@ held = this.getCarriedBlob();
+				if (held !is null)
+				{
+					this.SendCommand(this.getCommandID("putinheld"));
+				}
+				else
+				{
+					ControlsCycle@ onCycle;
+					if (this.get("onCycle handle", @onCycle))
+					{
+						CBitStream params;
+						params.write_u16(this.getNetworkID());
+						params.ResetBitIndex();
+
+						onCycle(params);
+					}
+				}
 
 				this.ClearMenus();
 				return;
@@ -321,9 +357,16 @@ void onTick(CBlob@ this)
 		{
 			if (controls.isKeyJustPressed(keybinds[i]))
 			{
-				CBitStream params;
-				params.write_u8(i);
-				this.SendCommand(this.getCommandID("switch"), params);
+				ControlsSwitch@ onSwitch;
+				if (this.get("onSwitch handle", @onSwitch))
+				{
+					CBitStream params;
+					params.write_u16(this.getNetworkID());
+					params.write_u8(i);
+					params.ResetBitIndex();
+
+					onSwitch(params);
+				}
 			}
 		}
 	}

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -414,8 +414,10 @@ void AdjustCamera(CBlob@ this, bool is_in_render)
 
 	f32 zoom_target = 1.0f;
 
-	if (zoomModifier) {
-		switch (zoomModifierLevel) {
+	if (zoomModifier) 
+	{
+		switch (zoomModifierLevel) 
+		{
 			case 0:	zoom_target = 0.5f; zoomLevel = 0; break;
 			case 1: zoom_target = 0.5625f; zoomLevel = 0; break;
 			case 2: zoom_target = 0.625f; zoomLevel = 0; break;
@@ -424,8 +426,11 @@ void AdjustCamera(CBlob@ this, bool is_in_render)
 			case 5: zoom_target = 1.5f; zoomLevel = 1; break;
 			case 6: zoom_target = 2.0f; zoomLevel = 2; break;
 		}
-	} else {
-		switch (zoomLevel) {
+	} 
+	else 
+	{
+		switch (zoomLevel) 
+		{
 			case 0: zoom_target = 0.5f; zoomModifierLevel = 0; break;
 			case 1: zoom_target = 1.0f; zoomModifierLevel = 4; break;
 			case 2:	zoom_target = 2.0f; zoomModifierLevel = 6; break;

--- a/Entities/Common/Controls/StandardControlsCommon.as
+++ b/Entities/Common/Controls/StandardControlsCommon.as
@@ -1,21 +1,24 @@
+funcdef void ControlsSwitch(CBitStream@);
+funcdef void ControlsCycle(CBitStream@);
 
-void server_Pickup(CBlob@ this, CBlob@ picker, CBlob@ pickBlob)
+void client_Pickup(CBlob@ this, CBlob@ pickBlob)
 {
-	if (pickBlob is null || picker is null || pickBlob.isAttached())
-		return;
+    if (!isClient()) return;
+
+	if (this is null || pickBlob is null || pickBlob.isAttached()) return;
+
 	CBitStream params;
-	params.write_netid(picker.getNetworkID());
 	params.write_netid(pickBlob.getNetworkID());
 	this.SendCommand(this.getCommandID("pickup"), params);
 }
 
-void server_PutInHeld(CBlob@ this, CBlob@ picker)
+void client_PutInHeld(CBlob@ this)
 {
-	if (picker is null)
-		return;
-	CBitStream params;
-	params.write_netid(picker.getNetworkID());
-	this.SendCommand(this.getCommandID("putinheld"), params);
+    if (!isClient()) return;
+
+	if (this is null) return;
+
+	this.SendCommand(this.getCommandID("putinheld"));
 }
 
 void Tap(CBlob@ this)

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -15,8 +15,6 @@ void onInit(CBlob@ this)
 	CBlob@[] closestblobs;
 	this.set("closest blobs", closestblobs);
 
-//	this.addCommandID("detach"); in StandardControls
-
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";
 
@@ -143,7 +141,7 @@ void onTick(CBlob@ this)
 				if (ap.getOccupied() !is null && ap.name != "PICKUP")
 				{
 					CBitStream params;
-					params.write_netid(ap.getOccupied().getNetworkID());
+					params.write_u16(ap.getOccupied().getNetworkID());
 					this.SendCommand(this.getCommandID("detach"), params);
 					this.set_bool("release click", false);
 					break;
@@ -155,7 +153,6 @@ void onTick(CBlob@ this)
 			ClearPickupBlobs(this);
 			client_SendThrowCommand(this);
 			this.set_bool("release click", false);
-
 		}
 		else
 		{
@@ -215,7 +212,7 @@ void onTick(CBlob@ this)
 					{
 						// NOTE: optimisation: use selected-option-blobs-in-radius
 						@closest = @GetBetterAlternativePickupBlobs(blobsInRadius, closest);
-						server_Pickup(this, this, closest);
+						client_Pickup(this, closest);
 					}
 				}
 			}
@@ -254,7 +251,7 @@ void onTick(CBlob@ this)
 				this.get("closest blobs", @closestBlobs);
 				if (closestBlobs.length > 0)
 				{
-					server_Pickup(this, this, closestBlobs[0]);
+					client_Pickup(this, closestBlobs[0]);
 				}
 			}
 			ClearPickupBlobs(this);

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -406,9 +406,18 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			this.setVelocity(velocity);
 		}
 	}
-	else if (cmd == this.getCommandID("getout"))
+	else if (cmd == this.getCommandID("getout") && isServer())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ caller = p.getBlob();
+		if (caller is null) return;
+
+		// range check
+		f32 distance = this.getDistanceTo(caller);
+		if (distance > 32.0f) return;
+
 		CBlob@ sneaky_player = getPlayerInside(this);
 		if (caller !is null && sneaky_player !is null)
 		{
@@ -420,6 +429,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				}
 			}
 			this.Tag("crate escaped");
+			this.Sync("crate escaped", true);
 			this.server_PutOutInventory(sneaky_player);
 		}
 		// Attack self to pop out items


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

StandardControls.as, StandardControlsCommon.as, StandardPickup.as
	"pickup" - was and remains client->server, sanitized
	"putinheld" - was and remains client->server, sanitized
	"getout" - was and remains client->server, sanitized
	"detach" - was and remains client->server, sanitized
	"cycle" - replaced with func callback (ArcherLogic, KnightLogic)
	"switch" - is now client->server command called from a func callback (ArcherLogic, KnightLogic)
	"tap inventory key" - removed, unnecessary
	changed minimum tap inventory key time to cycle item/putinheld to 5 from 7
	and to 3 for builder (they have to switch blocks fast)
Crate.as
	"getout" - sanitized version from cmd-sanitization-crate&mine
BuilderInventory.as
	Removed quickswap (was a failure, unused, sanitizing it is not worth my time)
