### PR TITLE
Cmd sanitization building

### DIFF
--- a/Entities/Common/Building/BlobPlacement.as
+++ b/Entities/Common/Building/BlobPlacement.as
@@ -8,15 +8,43 @@
 #include "Requirements.as"
 #include "RunnerTextures.as"
 
-bool PlaceBlob(CBlob@ this, CBlob @blob, Vec2f cursorPos, bool repairing = false, CBlob@ repairBlob = null)
+bool PlaceBlob(CBlob@ this, CBlob@ blob, Vec2f cursorPos, bool repairing = false, CBlob@ repairBlob = null)
 {
 	if (blob !is null)
 	{
+		// convert aimpos to tileaimpos (on server this time);
+		Vec2f pos = this.getPosition();
+		Vec2f mouseNorm = cursorPos - pos;
+		f32 mouseLen = mouseNorm.Length();
+		const f32 maxLen = MAX_BUILD_LENGTH;
+		mouseNorm /= mouseLen;
+
+		Vec2f tileaimpos;
+
+		if (mouseLen > maxLen * getMap().tilesize)
+		{
+			f32 d = maxLen * getMap().tilesize;
+			Vec2f p = pos + Vec2f(d * mouseNorm.x, d * mouseNorm.y);
+			tileaimpos = getMap().getTileWorldPosition(getMap().getTileSpacePosition(p));
+		}
+		else
+		{
+			tileaimpos = getMap().getTileWorldPosition(getMap().getTileSpacePosition(cursorPos));
+		}
+
+		// out of range
+		if (mouseLen >= getMaxBuildDistance(this))
+		{
+			return false;
+		} 
+
+		cursorPos = getBottomOfCursor(tileaimpos, blob);
+
 		if (!serverBlobCheck(this, blob, cursorPos, repairing, repairBlob))
 			return false;
 
 		u32 delay = getCurrentBuildDelay(this);
-		SetBuildDelay(this, delay / 2); // Set a smaller delay to compensate for lag/late packets etc
+		SetBuildDelay(this, delay);
 
 		CShape@ shape = blob.getShape();
 		shape.server_SetActive(true);
@@ -206,7 +234,6 @@ void onInit(CBlob@ this)
 
 	this.addCommandID("placeBlob");
 	this.addCommandID("repairBlob");
-	this.addCommandID("settleLadder");
 	this.addCommandID("rotateBlob");
 
 	this.set_u16("build_angle", 0);
@@ -394,7 +421,8 @@ void onTick(CBlob@ this)
 
 					CBitStream params;
 					params.write_u16(carryBlob.getNetworkID());
-					params.write_Vec2f(getBottomOfCursor(bc.tileAimPos, carryBlob));
+					params.write_Vec2f(this.getAimPos()); // we're gonna send the aimpos and double-check range on server for safety
+					//params.write_Vec2f(getBottomOfCursor(bc.tileAimPos, carryBlob));
 
 					if (currentBlobAtPos !is null && carryBlob.getName() == currentBlobAtPos.getName() && currentBlobAtPos.getHealth() < currentBlobAtPos.getInitialHealth() && currentBlobAtPos.getName() != "ladder")
 					{
@@ -420,8 +448,11 @@ void onTick(CBlob@ this)
 			{
 				s8 rotateDir = controls.ActionKeyPressed(AK_BUILD_MODIFIER) ? -1 : 1;
 
+				u16 new_angle = (360 + this.get_u16("build_angle") + 90 * rotateDir) % 360;
+				this.set_u16("build_angle", new_angle);
+
 				CBitStream params;
-				params.write_u16((360 + this.get_u16("build_angle") + 90 * rotateDir) % 360);
+				params.write_u16(new_angle);
 				this.SendCommand(this.getCommandID("rotateBlob"), params);
 			}
 		}
@@ -499,67 +530,71 @@ void onRender(CSprite@ this)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
+	if (!isServer()) return;
+
 	if (cmd == this.getCommandID("rotateBlob"))
 	{
-		this.set_u16("build_angle", params.read_u16());
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+
+		if (caller !is this) return;
+
+		u16 angle;
+		if (!params.saferead_u16(angle)) return;
+
+		this.set_u16("build_angle", angle);
 		return;
 	}
-
-	if (!getNet().isServer())
+	else if (cmd == this.getCommandID("placeBlob"))
 	{
-		return;
-	}
+		u16 block_id;
+		if (!params.saferead_u16(block_id)) return;
+		CBlob @carryBlob = getBlobByNetworkID(block_id);
+		if (carryBlob is null) return;
 
-	if (cmd == this.getCommandID("placeBlob"))
-	{
-		CBlob @carryBlob = getBlobByNetworkID(params.read_u16());
-		if (carryBlob !is null)
-		{
-			Vec2f pos = params.read_Vec2f();
+		Vec2f aimpos;
+		if (!params.saferead_Vec2f(aimpos)) return;
 			
-			if (PlaceBlob(this, carryBlob, pos))
+		if (PlaceBlob(this, carryBlob, aimpos))
+		{
+			SendGameplayEvent(createBuiltBlobEvent(this.getPlayer(), carryBlob.getName()));
+		}
+
+	}
+	else if (cmd == this.getCommandID("repairBlob"))
+	{
+		u16 block_id;
+		if (!params.saferead_u16(block_id)) return;
+		CBlob @carryBlob = getBlobByNetworkID(block_id);
+		if (carryBlob is null) return;
+
+		Vec2f aimpos;
+		if (!params.saferead_Vec2f(aimpos)) return;
+
+		u16 repair_id;
+		if (!params.saferead_u16(repair_id)) return;
+		CBlob @repairBlob = getBlobByNetworkID(repair_id);
+		if (repairBlob is null) return;
+
+		// the getHealth() is here because apparently a blob isn't null for a tick (?) after being destroyed
+		bool repairing = (repairBlob !is null && repairBlob.getHealth() > 0);
+
+		if (repairing) // is there a blobtile here?
+		{
+			if (PlaceBlob(this, carryBlob, aimpos, true, repairBlob))
+			{
+				SendGameplayEvent(createBuiltBlobEvent(this.getPlayer(), repairBlob.getName()));
+			}
+		}
+		else // there's nothing here so we can place a new one
+		{
+			if (PlaceBlob(this, carryBlob, aimpos))
 			{
 				SendGameplayEvent(createBuiltBlobEvent(this.getPlayer(), carryBlob.getName()));
 			}
-		}
-	}
-	if (cmd == this.getCommandID("repairBlob"))
-	{
-		CBlob @carryBlob = getBlobByNetworkID(params.read_u16());
-		Vec2f pos = params.read_Vec2f();
-
-		CBlob @repairBlob = getBlobByNetworkID(params.read_u16());
-
-		if (carryBlob !is null)
-		{
-			// the getHealth() is here because apparently a blob isn't null for a tick (?) after being destroyed
-			bool repairing = (repairBlob !is null && repairBlob.getHealth() > 0);
-
-			if (repairing) // is there a blobtile here?
-			{
-				if (PlaceBlob(this, carryBlob, pos, true, repairBlob))
-				{
-					SendGameplayEvent(createBuiltBlobEvent(this.getPlayer(), repairBlob.getName()));
-				}
-			}
-			else // there's nothing here so we can place a new one
-			{
-				if (PlaceBlob(this, carryBlob, pos))
-				{
-					SendGameplayEvent(createBuiltBlobEvent(this.getPlayer(), carryBlob.getName()));
-				}
-			}
-		}
-	}
-	else if (cmd == this.getCommandID("settleLadder"))
-	{
-		CBlob @carryBlob = getBlobByNetworkID(params.read_u16());
-		Vec2f pos = params.read_Vec2f();
-		if (carryBlob !is null)
-		{
-			carryBlob.Tag("temp blob placed");
-			carryBlob.server_DetachFrom(this);
-			carryBlob.getShape().SetStatic(true);
 		}
 	}
 }

--- a/Entities/Common/Building/BlobPlacement.as
+++ b/Entities/Common/Building/BlobPlacement.as
@@ -43,7 +43,9 @@ bool PlaceBlob(CBlob@ this, CBlob@ blob, Vec2f cursorPos, bool repairing = false
 		if (!serverBlobCheck(this, blob, cursorPos, repairing, repairBlob))
 			return false;
 
-		u32 delay = getCurrentBuildDelay(this);
+		// one day we will reach an ideal world without latency, dumb edge cases and bad netcode
+		// that day is not today
+		u32 delay = 2 * getCurrentBuildDelay(this) - 1;
 		SetBuildDelay(this, delay);
 
 		CShape@ shape = blob.getShape();

--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -117,14 +117,6 @@ void onTick(CBlob@ this)
 		return;
 	}
 
-	if (isServer())
-	{
-		if (getGameTime() - this.get_u32("gametimeg") == 0)
-		{
-			printf("SERVER POS IN ONTICK" + this.getPosition());
-		}
-	}
-
 	//don't build with menus open
 	if (getHUD().hasMenus())
 	{

--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -37,7 +37,9 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 		server_TakeRequirements(inv, bc.reqs);
 		map.server_SetTile(cursorPos, bc.tile);
 
-		u32 delay = getCurrentBuildDelay(this);
+		// one day we will reach an ideal world without latency, dumb edge cases and bad netcode
+		// that day is not today
+		u32 delay = getCurrentBuildDelay(this) - 1;
 		SetBuildDelay(this, delay);
 
 		SendGameplayEvent(createBuiltBlockEvent(this.getPlayer(), bc.tile));


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

BlobPlacement.as
	"rotateBlob" - was client->server and client->client, is now client->server only. uses getActiveCommandPlayer(), added checks.
	"placeBlob" - was client->server but with majority of the checks done on client. the checks are now duplicated on server to ensure player is not building out of range.
	"repairBlob" - was client->server but with majority of the checks done on client. the checks are now duplicated on server to ensure player is not building out of range.
	"settleLadder" - unused, removed
BlockPlacement.as
	"placeBlock" - was client->server but with majority of the checks done on client. the checks are now duplicated on server to ensure player is not building out of range.
Deltas have to be updated before oncommand is run for this pr
