### PR TITLE
Cmd sanitization taunts

### DIFF
--- a/Rules/CommonScripts/EmoteBinderMenu.as
+++ b/Rules/CommonScripts/EmoteBinderMenu.as
@@ -18,7 +18,6 @@ u8 selected_keybind = 0;
 void onInit(CRules@ this)
 {
 	this.addCommandID(EMOTE_CMD);
-	this.addCommandID("display taunt");
 }
 
 void NewEmotesMenu()


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

TauntMenu.as (moved "display taunt" init from EmoteBinderMenu.as)
	"display taunt" - was a command that relied on client->server->all clients. now it's just client->server, added "display taunt client" which does the server->client part
also changed volume of the loud ass noammo (all other files use it with 0.5)
