### PR TITLE
Cmd sanitization vehicles

### DIFF
--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -50,12 +50,23 @@ class CatapultInfo : VehicleInfo
 			{
 				if (isServer())
 				{
-					this.server_DetachFrom(occupied); //detach before sending the command to avoid velocity issues
-					CBitStream params;
-					params.write_netid(caller.getNetworkID());
-					params.write_netid(occupied.getNetworkID());
-					params.write_u8(charge);
-					this.SendCommand(this.getCommandID("fire mag blob"), params);
+					VehicleInfo@ v;
+					if (!this.get("VehicleInfo", @v)) return false;
+
+					if (!occupied.hasTag("player"))
+						occupied.SetDamageOwnerPlayer(caller.getPlayer());
+
+					this.server_DetachFrom(occupied);
+
+					if (!occupied.hasTag("player"))
+						occupied.SetDamageOwnerPlayer(caller.getPlayer());
+
+					v.onFire(this, occupied, v.charge);
+					v.SetFireDelay(v.getCurrentAmmo().fire_delay);
+
+					CBitStream bt;
+					bt.write_u16(occupied.getNetworkID());
+					this.SendCommand(this.getCommandID("fire mag blob client"), bt);
 				}
 				return false;
 			}
@@ -111,6 +122,32 @@ class CatapultInfo : VehicleInfo
 	}
 }
 
+void onReload(CBlob@ this)
+{
+	Vehicle_Setup(this,
+	              30.0f, // move speed
+	              0.31f,  // turn speed
+	              Vec2f(0.0f, 0.0f), // jump out velocity
+	              false,  // inventory access
+	              CatapultInfo()
+	             );
+	VehicleInfo@ v;
+	if (!this.get("VehicleInfo", @v)) return;
+
+	Vehicle_AddAmmo(this, v,
+	                    cooldown_time_ammo, // fire delay (ticks)
+	                    7, // fire bullets amount
+	                    3, // fire cost
+	                    "mat_stone", // bullet ammo config name
+	                    "Catapult Rocks", // name for ammo selection
+	                    "cata_rock", // bullet config name
+	                    "CatapultFire", // fire sound
+	                    "CatapultFire", // empty fire sound
+	                    Vec2f(0, -16), //fire position offset
+	                    90 // charge time
+	);
+}
+
 void onInit(CBlob@ this)
 {
 	Vehicle_Setup(this,
@@ -146,7 +183,7 @@ void onInit(CBlob@ this)
 	this.getShape().SetOffset(Vec2f(0, 6));
 	
 	this.addCommandID("putin_mag");
-	this.addCommandID("fire mag blob");
+	this.addCommandID("fire mag blob client");
 
 	string[] autograb_blobs = {"mat_stone"};
 	this.set("autograb blobs", autograb_blobs);
@@ -231,8 +268,6 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		if (carried !is null && !carried.hasTag("temp blob"))
 		{
 			CBitStream callerParams;
-			callerParams.write_netid(caller.getNetworkID());
-			callerParams.write_netid(carried.getNetworkID());
 
 			string name = carried.getInventoryName();
 			const string msg = getTranslatedString("Load {ITEM}").replace("{ITEM}", name);
@@ -257,36 +292,60 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	VehicleInfo@ v;
 	if (!this.get("VehicleInfo", @v)) return;
 	
-	if (cmd == this.getCommandID("fire"))
+	if (cmd == this.getCommandID("fire") && isServer())
 	{
 		v.charge = 0; //for empty shots
 	}
-	else if (cmd == this.getCommandID("fire mag blob"))
+	else if (cmd == this.getCommandID("fire client") && isClient())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
-		CBlob@ occupied = getBlobByNetworkID(params.read_netid());
-		const u8 charge = params.read_u8();
+		v.charge = 0;
+	}
+	else if (cmd == this.getCommandID("fire mag blob client") && isClient())
+	{
+		u16 id;
+		if (!params.saferead_u16(id)) return;
 
-		if (caller !is null && occupied !is null && !occupied.hasTag("player"))
-			occupied.SetDamageOwnerPlayer(caller.getPlayer());
+		CBlob@ occupied = getBlobByNetworkID(id);
+		if (occupied is null) return; 
 
 		this.getSprite().PlayRandomSound(v.getCurrentAmmo().fire_sound);
-		v.onFire(this, occupied, charge);
+		v.onFire(this, occupied, v.charge);
 		v.SetFireDelay(v.getCurrentAmmo().fire_delay);
 	}
-	else if (isServer() && cmd == this.getCommandID("putin_mag"))
+	else if (cmd == this.getCommandID("putin_mag") && isServer())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
-		CBlob@ blob = getBlobByNetworkID(params.read_netid());
-		if (caller !is null && blob !is null && blob.isAttachedTo(caller))
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+
+		CBlob@ carried = caller.getCarriedBlob();
+		if (carried is null) return;
+
+		AttachmentPoint@ mag = this.getAttachments().getAttachmentPoint("MAG");
+		// player in mag? don't replace
+		CBlob@ occupied = mag.getOccupied();
+		if (occupied !is null && occupied.hasTag("player")) return; 
+
+		// team check
+		if (this.getTeamNum() != caller.getTeamNum()) return;
+
+		// range check
+		if (this.getDistanceTo(caller) > this.getRadius()) return;
+
+		// attach check
+		if (caller.isAttached()) return;
+
+		if (caller !is null && carried !is null && carried.isAttachedTo(caller))
 		{
 			CBlob@ occupied = this.getAttachments().getAttachmentPoint("MAG").getOccupied();
 			if (occupied !is null)
 			{
 				occupied.server_DetachFromAll();
 			}
-			blob.server_DetachFromAll();
-			this.server_AttachTo(blob, "MAG");
+			carried.server_DetachFromAll();
+			this.server_AttachTo(carried, "MAG");
 		}
 	}
 }

--- a/Entities/Vehicles/Common/Vehicle.as
+++ b/Entities/Vehicles/Common/Vehicle.as
@@ -82,10 +82,19 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (!this.get("VehicleInfo", @v)) return;
 
 	/// LOAD AMMO
-	if (isServer() && cmd == this.getCommandID("load_ammo"))
+	if (cmd == this.getCommandID("load_ammo") && isServer())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
 		if (caller is null) return;
+
+		// range check
+		if (this.getDistanceTo(caller) > this.getRadius()) return;
+
+		// team check
+		if (this.getTeamNum() != caller.getTeamNum()) return;
 
 		CBlob@[] ammos;
 		string[] eligible_ammo_names;
@@ -125,7 +134,39 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		RecountAmmo(this, v);
 	}
 	/// SWAP AMMO
-	else if (cmd == this.getCommandID("swap_ammo"))
+	else if (cmd == this.getCommandID("swap_ammo") && isServer())
+	{
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ b = p.getBlob();
+		if (b is null) return;
+
+		// don't swap ammo if only 1 ammo type
+		if (v.ammo_types.size() <= 1) return;
+
+		// don't swap ammo mid-charge
+		if (v.charge > 0) return;
+
+		// attached checks
+		CAttachment@ ca = this.getAttachments();
+		if (ca is null) return;
+		AttachmentPoint@ ap = ca.getAttachmentPointByName("GUNNER");
+		if (ap is null) return;
+		CBlob@ attachedblob = ap.getOccupied();
+		if (attachedblob is null) return;
+		if (attachedblob !is b) return;
+
+		u8 ammoIndex = v.current_ammo_index + 1;
+		if (ammoIndex >= v.ammo_types.size())
+		{
+			ammoIndex = 0;
+		}
+		v.current_ammo_index = ammoIndex;
+
+		this.SendCommand(this.getCommandID("swap_ammo_client"));
+	}
+	else if (cmd == this.getCommandID("swap_ammo_client") && isClient())
 	{
 		u8 ammoIndex = v.current_ammo_index + 1;
 		if (ammoIndex >= v.ammo_types.size())
@@ -135,22 +176,58 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		v.current_ammo_index = ammoIndex;
 	}
 	/// FIRE
-	else if (cmd == this.getCommandID("fire"))
+	else if (cmd == this.getCommandID("fire") && isServer())
 	{
-		CBlob@ caller = getBlobByNetworkID(params.read_netid());
-		const u8 charge = params.read_u8();
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+
+		CBitStream bt;
+		bt.write_u16(caller.getNetworkID());
+		bt.write_u16(v.charge);
+		this.SendCommand(this.getCommandID("fire client"), bt);
+
+		Fire(this, v, caller, v.charge);
+	}
+	else if (cmd == this.getCommandID("fire client") && isClient())
+	{
+		u16 id;
+		if (!params.saferead_u16(id)) return;
+
+		u16 charge;
+		if (!params.saferead_u16(charge)) return;
+
+		CBlob@ caller = getBlobByNetworkID(id);
+		if (caller is null) return;
+
 		Fire(this, v, caller, charge);
 	}
 	/// POST FIRE
-	else if (cmd == this.getCommandID("fire blob"))
+	else if (cmd == this.getCommandID("fire blob client") && isClient())
 	{
-		CBlob@ blob = getBlobByNetworkID(params.read_netid());
-		const u8 charge = params.read_u8();
+		u16 id;
+		if (!params.saferead_u16(id)) return;
+
+		u16 charge;
+		if (!params.saferead_u16(charge)) return;
+
+		CBlob@ blob = getBlobByNetworkID(id);
 		v.onFire(this, blob, charge);
 	}
 	/// FLIP OVER
-	else if (cmd == this.getCommandID("flip_over"))
+	else if (cmd == this.getCommandID("flip_over") && isServer())
 	{
+		CPlayer@ p = getNet().getActiveCommandPlayer();
+		if (p is null) return;
+
+		CBlob@ b = p.getBlob();
+		if (b is null) return;
+
+		// range check
+		if (this.getDistanceTo(b) > 64.0f) return;
+
 		if (isFlipped(this))
 		{
 			this.getShape().SetStatic(false);
@@ -160,11 +237,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		}
 	}
 	/// SYNC AMMUNITION
-	else if (!isServer() && cmd == this.getCommandID("recount ammo"))
+	else if (cmd == this.getCommandID("recount ammo client") && isClient())
 	{
-		const u8 current_recounted = params.read_u8();
-		v.ammo_types[current_recounted].ammo_stocked = params.read_u16();
-		v.ammo_types[current_recounted].loaded_ammo = params.read_u8();
+		u8 current_recounted;
+		if (!params.saferead_u8(current_recounted)) return;
+		if (!params.saferead_u16(v.ammo_types[current_recounted].ammo_stocked)) return;
+		if (!params.saferead_u8(v.ammo_types[current_recounted].loaded_ammo)) return;
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Vehicle.as, VehicleCommon.as, Catapult.as
	"load ammo" - was and remains client->server command, uses getActiveCommandPlayer(), added range check, team check
	"fire" - was a client->server & server->client command. Is now client->server. uses getActiveCommandPlayer(). Firing uses server's VehicleInfo.charge now, rather than the one sent by client. Added "fire client", which does the same thing as server->client fire did.
	"fire blob" - was a server->server & server->client command. is now server->client. renamed to "fire blob client"
	"flip_over" - was client->server and server->client. server->client was unnecessary. uses getActiveCommandPlayer(), added range check
	"swap_ammo" - was client->server and server->client. is now client->server. uses getActiveCommandPlayer(), added server-side checks. added client-side "swap_ammo_client".
	"recount_ammo" - was and remains server->client, changed reads to safereads. renamed to "recount_ammo_client"
Catapult.as
	"putin_mag" - was and remains client->server command, uses getActiveCommandPlayer(), added checks
	"fire mag blob" - was server->server and server->client. moved server->server outside command, is now server->client only
VehicleAttachment.as
	"attach vehicle" - unused, removed
	"detach vehicle" - was and remains client->server commmand, uses getActiveCommandPlayer(), added checks
