### PR TITLE
Cmd sanitization minimapsync

### DIFF
--- a/Scripts/MapLoaders/MinimapHook.as
+++ b/Scripts/MapLoaders/MinimapHook.as
@@ -129,11 +129,14 @@ namespace MiniMap
 		CMap@ map = getMap();
 
 		//add sync script
-		//done here to avoid needing to modify gamemode.cfg
+		//was done here to avoid needing to modify gamemode.cfg
+		//seems to be unnecessary
+
+		/*
 		if (!rules.hasScript("MinimapSync.as"))
 		{
 			rules.AddScript("MinimapSync.as");
-		}
+		}*/
 
 		//init appropriately
 		if (isServer())


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

MinimapSync.as
	The script overall feels unnecessary. The client requests sync on 1st tick after joining and after restart. The server then syncs 3 bools to all clients. There is no reason why the bools would not be synced automatically by the server. Commented the script out; if its removal causes any issues in the future, it should be added back.
