### PR TITLE
Cmd sanitization tunnels

### DIFF
--- a/Entities/Industry/Tunnel/Tunnel.as
+++ b/Entities/Industry/Tunnel/Tunnel.as
@@ -2,27 +2,9 @@
 
 #include "TunnelCommon.as"
 
-const bool CASUAL_MODE = false;
-
 void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
-}
-
-// destroy tunnel after enemly uses it
-void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
-{
-	//only casuals want this
-	if (!CASUAL_MODE) return;
-
-	if (cmd == this.getCommandID("travel"))
-	{
-		CBlob@ caller = getBlobByNetworkID(params.read_u16());
-		if (caller !is null && caller.getTeamNum() != this.getTeamNum())
-		{
-			this.server_Die();
-		}
-	}
 }
 
 void onInit(CSprite@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Tunnel.as
	removed unused casual mode code
TunnelTravel.as
	split Travel function into server_Travel and client_Travel, added additional checks
	"travel" - was client->server and client->client (cgenericbutton command). client->client is a func callback now (the yuck genericbutton callback), client->server is unnecessary, so removed
	"travel to" - was client->server and client->client (cgridbutton command). client->client is a func callback now. client->server uses getActiveCommandPlayer(), added some checks
	"travel none" - was client->client (cgridbutton cmd), is a func callback now
	"server travel to" - was server->client, still is server->client, renamed to "travel to client"
	needs #224 Crimson to work 
