### PR TITLE
[change] Bombs are not limited by the top of the map

### DIFF
--- a/Entities/Items/Explosives/Bomb.as
+++ b/Entities/Items/Explosives/Bomb.as
@@ -11,8 +11,12 @@ void onInit(CBlob@ this)
 	this.set_u16("explosive_parent", 0);
 	this.getShape().getConsts().net_threshold_multiplier = 2.0f;
 	SetupBomb(this, bomb_fuse, 48.0f, 3.0f, 24.0f, 0.4f, true);
-	//
-	this.Tag("activated"); // make it lit already and throwable
+
+	//dont collide with top of the map
+	this.SetMapEdgeFlags(CBlob::map_collide_left | CBlob::map_collide_right);
+	
+	// make it lit already and throwable
+	this.Tag("activated");
 }
 
 //start ugly bomb logic :)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] Bombs can fly over the top limit of the map

Fixes https://github.com/transhumandesign/kag-base/issues/1812

Bombs should be allowed to fly above the ceiling freely because
1) Arrows are allowed to fly above the ceiling, too
2) Bombs are commonly used as projectiles, being thrown to the enemy side. So as projectiles they should have the same privilege like arrows.
3) It looks odd when bombs are thrown to the enemy side and get pushed below the ceiling in the last moment. As a result it would make targeting easier.
4) Bombs explode and despawn anyway, so it's not like they will fly above the ceiling indefinitely.

Video demonstrating this: https://www.youtube.com/watch?v=NvXtCCtcELU