### PR TITLE
[changed] Greg will not take fire damage

### DIFF
--- a/Entities/Zombies/Greg/Greg.cfg
+++ b/Entities/Zombies/Greg/Greg.cfg
@@ -4,8 +4,7 @@
 
 $sprite_factory                                   = generic_sprite
 
-@$sprite_scripts                                  = DazzleAnimation.as;	
-                                                    FireAnim.as;									
+@$sprite_scripts                                  = DazzleAnimation.as;									
 													
 $sprite_texture                                   = Greg.png
 s32_sprite_frame_width                            = 32
@@ -84,8 +83,7 @@ $inventory_factory                                =
 $name                                             = greg
 @$scripts                                         =	Greg.as;
                                                     EmoteBubble.as;
-                                                    RunnerKnock.as;
-                                                    IsFlammable.as;		
+                                                    RunnerKnock.as;	
                                                     GenericHit.as;
 					
 f32 health                                        = 2.0


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] Greg will not take fire damage

Fixes https://github.com/transhumandesign/kag-base/issues/1737

`FireAnim.as` (sprite script) and `IsFlammable.as` (blob script) was removed from `Greg.cfg`.
It was odd that a stone statue enemy could be burning.
It will still take damage from the arrow hit itself.

## Steps to Test or Reproduce

Spawn greg.
Shoot arrows and fire arrows on it.
Notice it will take damage from the arrow hit but it will not take fire damage.