### PR TITLE
[fixed] Bucket will not fall through blobs you are standing on when throwing down

### DIFF
--- a/Entities/Items/Bucket/Bucket.cfg
+++ b/Entities/Items/Bucket/Bucket.cfg
@@ -54,7 +54,7 @@ $brain_factory                       =
 $attachment_factory                  = box2d_attachment
 @$attachment_scripts                 =
 # name; pixel offset (from center) X; offset Y; socket/plug 0/1; controller; radius
-@$attachment_points                  = PICKUP; -3; -2; 1; 0; 0;
+@$attachment_points                  = PICKUP; -3; -3; 1; 0; 0;
 
 $inventory_factory                   =
 

--- a/Entities/Items/Bucket/Bucket.cfg
+++ b/Entities/Items/Bucket/Bucket.cfg
@@ -54,7 +54,7 @@ $brain_factory                       =
 $attachment_factory                  = box2d_attachment
 @$attachment_scripts                 =
 # name; pixel offset (from center) X; offset Y; socket/plug 0/1; controller; radius
-@$attachment_points                  = PICKUP; -3; -4; 1; 0; 0;
+@$attachment_points                  = PICKUP; -3; -2; 1; 0; 0;
 
 $inventory_factory                   =
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
- Please see the notes below.

## Description

[fixed] bucket falling through door/platform when throwing down

Fixes https://github.com/transhumandesign/kag-base/issues/1809

Explanatory image: https://i.imgur.com/xIgDBd5.png

Bucket is held lower than other items to give the impression the character is holding it from the top but this caused the problem that bucket could fall down through doors when aiming downward and throwing down from a standing position. This PR adjusts the bucket pickup attachment 1 pixel higher.

## Notes 

I'm not entirely happy with this because we can't see the player characters face now.
Maybe there are other solutions?
I have not found a shape function that resolves collisions to make the bucket get pushed out of the door upwards.
Should we make bucket smaller (1 px less height)?
