### PR TITLE
[changed] Normal arrows will not damage Saw; slight balance change

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -196,6 +196,16 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 	}
 }
 
+f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
+{
+    if (isExplosionHitter(customData) || customData == Hitters::burn)
+	{
+		return damage * 1.5f;
+	}
+	
+	return damage;
+}
+
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
 	if (blob.hasTag("ignore_saw"))

--- a/Entities/Industry/Saw/Saw.cfg
+++ b/Entities/Industry/Saw/Saw.cfg
@@ -3,6 +3,7 @@
 $sprite_factory                                   = generic_sprite
 @$sprite_scripts                                  = Saw.as;
 													Wooden.as;
+													FireAnim.as;
 $sprite_texture                                   = Saw.png
 s32_sprite_frame_width                            = 24
 s32_sprite_frame_height                           = 16
@@ -76,7 +77,8 @@ $name                                             = saw
 													NoPlayerCollision.as;
 													SetTeamToCarrier.as;
 													SetDamageToCarrier.as;
-f32 health                                        = 5.0
+													IsFlammable.as;
+f32 health                                        = 6.0
 $inventory_name                                   = Mill Saw
 $inventory_icon                                   = VehicleIcons.png
 u8 inventory_icon_frame                           = 3

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -368,6 +368,12 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 	{
 		return true;
 	}
+	
+	//collide with saw only when arrow isn't normal type
+	if (blob.getName() == "saw" && this.get_u8("arrow type") != ArrowType::normal)
+	{
+		return true
+	}
 
 	//anything to always hit
 	if (specialArrowHit(blob))

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -372,7 +372,7 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 	//collide with saw only when arrow isn't normal type
 	if (blob.getName() == "saw" && this.get_u8("arrow type") != ArrowType::normal)
 	{
-		return true
+		return true;
 	}
 
 	//anything to always hit


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[changed] arrows will not damage enemy Saw
[changed] Saw health changed from 5.0 to 6.0
[changed] instead of not burning, Saw will now burn at 1.5 * burn damage
[changed] instead of taking 1.0 * explosion damage, Saw will now take 1.5 * explosion damage
```

Fixes https://github.com/transhumandesign/kag-base/issues/1749

Saw is a situational item and should not get destroyed so easily.
It is usually destroyed very quickly when brought to the battle field.
Therefore this PR changes Saw health from 5.0 to 6.0

It looked odd to me that a Saw could get destroyed by a dozen wood arrows.
This PR removes the possibility to destroy Saw by normal arrows but introduces and promotes other ways of destroying it, by making Saw flammable and by slightly amplifying explosion and fire damage done to Saw.
After this PR, Saw can be destroyed in 3 bomb arrows, 3 bombs or 3 fire arrows (assuming the full burn duration plays out each time) or 1 keg.

Let me know what you think.

----

I decided to add code to `doesCollideWithBlob()` in `Arrow.as`.
The other alternative is to use `Tag("ignore_saw")` to `Arrow.as`, but this has the disadvantage that you need to make sure it gets untagged when arrow ignites or is tagged when it is unignited.

## Steps to Test or Reproduce

Go to Sandbox.
Spawn a Saw.
Switch to other team.
Change class to Archer.
Shoot normal arrow, fire arrows, bomb arrows at Saw and see the effects.
Notice you cannot destroy Saw by shooting a dozen wood arrows anymore.