### PR TITLE
[fixed] Greg not grabbing you if you previously got in a crate while grabbed

### DIFF
--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -249,7 +249,7 @@ bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
-	if (!canSeeButtons(this, caller)) return;
+	if (!canSeeButtons(this, caller) || caller.isAttached()) return;
 
 	Vec2f buttonpos(0, 0);
 
@@ -375,7 +375,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		}
 		CBlob@ caller = getBlobByNetworkID(params.read_netid());
 		CInventory@ inv = this.getInventory();
-		if (caller !is null && inv !is null) 
+		if (caller !is null && inv !is null && !caller.isAttached()) 
 		{
 			u8 itemcount = inv.getItemsCount();
 			// Boobytrap if crate has enemy mine

--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -240,9 +240,7 @@ void onTick(CBlob@ this)
             if (targetAttached && pickedPlayerBlob !is null)
             {
                 this.server_DetachAll();
-                pickedPlayerBlob.Untag("picked");
                 pickRandTargetPos(this);
-
             }
 
             return;

--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -583,6 +583,5 @@ void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
 {
 	detached.Untag("picked");
 	detached.Sync("picked", true);
-    
 	this.set_bool("no target", true);
 }

--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -215,8 +215,6 @@ void onTick(CBlob@ this)
             if (pickedPlayerBlob.get_s32("pickup time") + hold_time < getGameTime())
             {
                 this.server_DetachAll();
-                pickedPlayerBlob.Untag("picked");
-                pickedPlayerBlob.Sync("picked", true);
             }
         }
 
@@ -243,7 +241,6 @@ void onTick(CBlob@ this)
             {
                 this.server_DetachAll();
                 pickedPlayerBlob.Untag("picked");
-                pickedPlayerBlob.Sync("picked", true);
                 pickRandTargetPos(this);
 
             }
@@ -259,8 +256,6 @@ void onTick(CBlob@ this)
             if (targetAttached && pickedPlayerBlob !is null)
             {
                 this.server_DetachAll();
-                pickedPlayerBlob.Untag("picked");
-                pickedPlayerBlob.Sync("picked", true);
 
             }
 
@@ -387,9 +382,6 @@ void onTick(CBlob@ this)
                             //this.Chat("i lied.");
                         }
 
-                        pickedPlayerBlob.Untag("picked");
-                        pickedPlayerBlob.Sync("picked", true);
-
                         set_emote(this, "troll");
 
                     }
@@ -398,7 +390,6 @@ void onTick(CBlob@ this)
                     {
                         //detach and add some velocity so they hopefully die.
                         this.server_DetachAll();
-                        this.set_bool("no target", true);
                         //target.setVelocity(Vec2f(0, 8.0f));
 
                     }
@@ -431,8 +422,6 @@ void onTick(CBlob@ this)
             {
                 //detach and add some velocity so they hopefully die.
                 this.server_DetachAll();
-                pickedPlayerBlob.Untag("picked");
-                this.set_bool("no target", true);
                 target.setVelocity(Vec2f(0, 4.0f));
 
             }
@@ -493,12 +482,11 @@ void onDie( CBlob@ this )
     }
 }
 
-void onCollision( CBlob@ this, CBlob@ blob, bool solid )
+void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
     if (isKnocked(this) || blob is null)
     {
         return;
-
     }
 
     /*if (this.hasTag("statue"))
@@ -518,6 +506,7 @@ void onCollision( CBlob@ this, CBlob@ blob, bool solid )
     }*/
 
     CBlob@ target = getTarget(this);
+	
     if (target is blob && !target.hasTag("picked"))
     {
         target.Tag("picked");
@@ -590,5 +579,12 @@ f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hit
 bool doesCollideWithBlob( CBlob@ this, CBlob@ blob )
 {
     return blob.getName() != "greg";
+}
 
+void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
+{
+	detached.Untag("picked");
+	detached.Sync("picked", true);
+    
+	this.set_bool("no target", true);
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
- Needs testing

## Description

```
[fixed] Greg not grabbing you after you got in a crate while grabbed before
[changed] You will not see crate buttons when you are attached
```

Fixes https://github.com/transhumandesign/kag-base/issues/1736

The bug with Greg not grabbing you happened because tag `"picked"` on the targetblob  wasn't untagged after the game detached you from Greg as a result of getting in a crate.

Previously, tag `"picked"` was untagged after Greg.as detaches you.
This PR accounts for the fact that you could get detached outside of Greg.as, by adding `onDetach()` to Greg which untags `"picked"` and sets bool `"no target"`. As far as I tested, Greg now works correctly.

This PR also adds a second fix to make it so that you cannot see crate buttons or get in a crate in the first place, if you are attached to something. As far as I tested, this also works fine but it needs more testing to see if there are other gameplay scenarios that might be affected by this. You could get in a crate while sitting on a catapult's driver seat which wouldn't be possible after this PR goes live (this one is not a big deal).

## Reproduction Steps

Go in Sandbox.
Spawn Greg and crate.
Pick up a crate and wait for Greg to grab you.
While grabbed, get in the crate.
Wait for Greg to grab you again.
Notice he will try to grab you but you will not be grabbed.
**After this PR, you can't get in the crate, but even if you could Greg would properly grab you.**