### PR TITLE
[fixed] Knight doubleslash bug

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -231,6 +231,7 @@ void onTick(CBlob@ this)
 		knight.doubleslash = false;
 		hud.SetCursorFrame(0);
 		this.set_s32("currentKnightState", 0);
+		this.set_s32("serverKnightState", -1);
 		return;
 	}
 
@@ -264,6 +265,7 @@ void onTick(CBlob@ this)
 		knight.slideTime = 0;
 		knight.doubleslash = false;
 		this.set_s32("currentKnightState", 0);
+		this.set_s32("serverKnightState", -1);
 
 		pressed_a1 = false;
 		pressed_a2 = false;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[fixed] Buffered slash bug after getting knockback`

Fixes https://github.com/transhumandesign/kag-base/issues/1361

As knight, when performing a double slash, 
* if you get interrupted by knockback on a certain tick at the end of the first slash
* and if you are pressing or holding the action1 key

then you will perform the second slash after the knockback ends.

This bug seems to happen because - despite all important values for knight such as swordtimer, knightstate, etc. being reset to 0 - the function that runs after the knockback ends, `RunStateMachine()` in `KnightLogic.as`, still performs `s32 serverStateIndex = this.get_s32("serverKnightState");`, a value that wasn't reset. I didn't look too much into it but this is the cause of the bug and after adding `this.set_s32("serverKnightState", -1);` to the code blocks that reset the other values the bug doesn't happen anymore.

## Steps to Test or Reproduce

In `KnightLogic.as` add this in `onTick()` after the line `const bool myplayer = this.isMyPlayer();`:

```
if (knight.swordTimer == 10 && knight.state == 10)
	{
		setKnocked(this, 30);
	}
```

This causes the bug to always happen when performing a double slash. After applying the above solution, you will not perform a second slash after the knockback anymore.


