### PR TITLE
[fixed] Archer fake charging bug

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -429,6 +429,7 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		if ((just_action1 || this.wasKeyPressed(key_action2) || this.hasTag("redo charge") && !pressed_action2) &&
 		        (charge_state == ArcherParams::not_aiming || charge_state == ArcherParams::fired || charge_state == ArcherParams::stabbing))
 		{
+			this.Untag("redo charge");
 			charge_state = ArcherParams::readying;
 			hasarrow = hasArrows(this);
 

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -426,7 +426,7 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			just_action1 = true;
 		}
 
-		if ((just_action1 || this.wasKeyPressed(key_action2) && !pressed_action2) &&
+		if ((just_action1 || this.wasKeyPressed(key_action2) || this.hasTag("redo charge") && !pressed_action2) &&
 		        (charge_state == ArcherParams::not_aiming || charge_state == ArcherParams::fired || charge_state == ArcherParams::stabbing))
 		{
 			charge_state = ArcherParams::readying;
@@ -536,6 +536,12 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 			{
 				charge_time++;
 			}
+		}
+		else
+		{
+			charge_state = ArcherParams::not_aiming;
+			charge_time = 0;
+			this.Tag("redo charge");
 		}
 	}
 	else


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[fixed] Archer fake charging bug`

Fixes https://github.com/transhumandesign/kag-base/issues/1807

Video https://www.youtube.com/watch?v=HTrvW8kj3z4

When you charge up arrow and get jabbed by enemy Knight, you will be looking like you are charging arrow but you actually aren't; letting go of `action1` will do nothing.

I added an `else` code block so archer will charge up a new arrow after getting jabbed and when still holding action1, just like you would charge up a new arrow after getting knocked back and the knockback ends.

```
if ((just_action1 || this.wasKeyPressed(key_action2) || this.hasTag("redo charge") && !pressed_action2) &&
 (charge_state == ArcherParams::not_aiming || charge_state == ArcherParams::fired || charge_state == ArcherParams::stabbing))
{	// ...
}
else if (charge_state == ArcherParams::readying)
{	// ...
}
else if (charge_state == ArcherParams::charging)
{	// ... 
}
else if (charge_state == ArcherParams::no_arrows)
{	// ... 
}
else
{
	charge_state = ArcherParams::not_aiming;
	charge_time = 0;
	this.Tag("redo charge");
}
```

Tested in offline and online, no problems encountered.

## Steps to Test or Reproduce

Go to TDM and use `AddBot("");` in console.
(You might want to edit `KnightBrain.as` so the bot jabs more often.)
Be Archer and charge arrow. While charging, get jabbed by the enemy knight bot.
Notice you will still have your bow drawn as if charging an arrow but nothing will happen.
**After this PR, you will charge up a new arrow after getting jabbed.**
