### PR TITLE
[fixed] Archer shooting automatically when picking heavy objects

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -1246,4 +1246,12 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 		archer.grappling = false;
 		SyncGrapple(this);
 	}
+	
+	// make archer not shoot when picking up heavy objects
+	
+	if (attached.hasTag("medium weight") || attached.hasTag("heavy weight") && attachedPoint.name == "PICKUP")
+	{
+		archer.charge_state = 0;
+		archer.charge_time = 0;
+	}
 }

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -1249,7 +1249,7 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	
 	// make archer not shoot when picking up heavy objects
 	
-	if (attached.hasTag("medium weight") || attached.hasTag("heavy weight") && attachedPoint.name == "PICKUP")
+	if (attached.hasTag("no action while carrying") && attachedPoint.name == "PICKUP")
 	{
 		archer.charge_state = 0;
 		archer.charge_time = 0;

--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -41,6 +41,19 @@ void onAddToInventory(CBlob@ this, CBlob@ blob)
 
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
+	if (attached.hasTag("no action while carrying"))
+	{
+		CAttachment@ att = attached.getAttachments();
+		if (att !is null) 
+		{
+			AttachmentPoint@ ap = att.getAttachmentPointByName("PICKUP");
+			if (ap !is null)
+			{
+				ap.SetKeysToTake(key_action1 | key_action2);
+			}
+		}
+	}
+
 	this.getSprite().PlaySound("/Pickup.ogg");
 
 	this.ClearButtons();

--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -21,13 +21,11 @@ void onInit(CBlob@ this)
 	this.set(Trampoline::TIMER, cooldowns);
 	this.getShape().getConsts().collideWhenAttached = true;
 
+	this.Tag("no action while carrying");
 	this.Tag("no falldamage");
 	this.Tag("medium weight");
 	// Because BlobPlacement.as is *AMAZING*
 	this.Tag("place norotate");
-
-	AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
-	point.SetKeysToTake(key_action1 | key_action2);
 
 	this.getCurrentScript().runFlags |= Script::tick_attached;
 }

--- a/Entities/Vehicles/Common/BoatCommon.as
+++ b/Entities/Vehicles/Common/BoatCommon.as
@@ -1,5 +1,7 @@
 void onInit(CBlob@ this)
 {
+	this.Tag("no action while carrying");
+
 	// add oar sprites to ROWER attachment points
 	CSprite@ sprite = this.getSprite();
 	AttachmentPoint@[] aps;
@@ -30,12 +32,6 @@ void onInit(CBlob@ this)
 					oarSprite.SetVisible(false);
 					oarSprite.SetRelativeZ(oar_offset);
 				}
-			}
-
-			// disable acion keys when carrying this
-			if (oar.name == "PICKUP")
-			{
-				oar.SetKeysToTake(key_action1 | key_action2);
 			}
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[fixed] Archer shooting when picking heavy items`

Fixes https://github.com/transhumandesign/kag-base/issues/1757

Video https://www.youtube.com/watch?v=47ow54glGaQ

When archer is charging up an arrow and picks up ~a heavy object~ an object that uses `SetKeysToTake()` at the same time, he will shoot his arrow automatically.
This should never happen since you didn't let go of action1.

As you can see in the video, this could have side effects such as accidentally shooting bomb arrow in places you don't want them fired. Your team might think you are griefing.

This PR makes it so archer's state is reset and no arrow is shot when picking up items that apply `SetKeysToTake()`.

`SetKeysToTake()` was previously applied in `Trampoline.as` (affects Trampoline) and `BoatCommon.as` (affects Dinghy and Raft).
Those instances are now replaced by Tag `"no action while carrying"`.
`SetKeysToTake()` is now only applied in `RunnerDefault.as` if the picked blob has the aforementioned tag.

Tested in offline and online, no problems encountered.

----

I needed to use a new tag because `ap.GetKeysToTake()` didn't seem to work, in this case at least; it always returned 0.

## Steps to Test or Reproduce

Go to Sandbox.
Pick up Trampoline, Dinghy or Raft.
Notice you cannot use action1 and action2.
Be archer, charge up arrow and pick up one of those items at the same time, notice you will not shoot your arrow automatically anymore after this PR is applied.