### PR TITLE
[changed] Plants don't make cut sfx when burning

### DIFF
--- a/Entities/Common/Attacks/PlantHitEffects.as
+++ b/Entities/Common/Attacks/PlantHitEffects.as
@@ -5,7 +5,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 {
 	if (damage > 0.05f) //sound for all damage
 	{
-		if (customData != Hitters::fire && customData != Hitters::burn) // not fire or burn
+		if (customData != Hitters::fire && customData != Hitters::burn)
 		{
 			Sound::Play("/cut_grass", this.getPosition());
 		}

--- a/Entities/Common/Attacks/PlantHitEffects.as
+++ b/Entities/Common/Attacks/PlantHitEffects.as
@@ -5,7 +5,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 {
 	if (damage > 0.05f) //sound for all damage
 	{
-		if (customData != 7 && customData != 8) // not fire or burn
+		if (customData != Hitters::fire && customData != Hitters::burn) // not fire or burn
 		{
 			Sound::Play("/cut_grass", this.getPosition());
 		}

--- a/Entities/Common/Attacks/PlantHitEffects.as
+++ b/Entities/Common/Attacks/PlantHitEffects.as
@@ -5,25 +5,16 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 {
 	if (damage > 0.05f) //sound for all damage
 	{
-		//read customdata for hitter
-		switch (customData)
+		if (customData != 7 && customData != 8) // not fire or burn
 		{
-			case 0: //in case we want more cases
-			default:
-				if (hitterBlob !is this)
-				{
-					Sound::Play("/cut_grass", this.getPosition());
-				}
-
-				for (int i = 0; i < (damage + 1); ++i)
-				{
-					makeGibParticle("GenericGibs",
-					                this.getPosition(), getRandomVelocity(-90, (Maths::Min(Maths::Max(0.5f, damage), 2.0f) * 4.0f) , 270),
-					                7, 3 + XORRandom(4), Vec2f(8, 8),
-					                1.0f, 0, "", 0);
-				}
-
-				break;
+			Sound::Play("/cut_grass", this.getPosition());
+		}
+		
+		for (int i = 0; i < (damage + 1); ++i)
+		{
+			makeGibParticle("GenericGibs",
+				this.getPosition(), getRandomVelocity(-90, (Maths::Min(Maths::Max(0.5f, damage), 2.0f) * 4.0f) , 270),
+				7, 3 + XORRandom(4), Vec2f(8, 8), 1.0f, 0, "", 0);
 		}
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[changed] Plants (Bush, flowers, grain...) don't make a cut sfx when taking burn or fire damage`

It looked odd to me that plants would make a cut sound when taking burn damage, so this PR makes it so a cut sound is played but only if the damage source isn't "fire" or "burn". Otherwise the plant will take damage without a sound.
