### PR TITLE
[added] Keg will gib

### DIFF
--- a/Entities/Items/Explosives/Keg.cfg
+++ b/Entities/Items/Explosives/Keg.cfg
@@ -75,6 +75,7 @@ $name                                             = keg
 													NoPlayerCollision.as;
 													BehindWhenAttached.as;
 													SetTeamToCarrier.as;
+													GenericHit.as;
 													ImportantPickup.as;
 f32 health                                        = 3.0
 $inventory_name                                   = Keg


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[added] Keg will gib and make a sound effect when getting destroyed`

In the live build, when keg is destroyed without exploding, it would just despawn without a sound effect and without gib particles.

This PR adds `GenericHit.as` to keg's blob scripts so when it dies, it will also gib. Because it gibs, it will also call `onGib()` in `Wooden.as`, causing a wood destroy sound effect.

I tested only in offline, Keg still explodes after 6 sec or when colliding at high velocity or when getting its health depleted to 0.

## Steps to Test or Reproduce

Be a knight.
Spawn a keg.
Change team to something else.
Jab at the keg until it is destroyed.
It will vanish without gibs and sound effect.
**After this PR, it will gib and make a sound effect.**