### PR TITLE
[fixed] Trampoline no longer bounces blobs slightly to the side

### DIFF
--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -136,6 +136,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 
 			Vec2f velocity = Vec2f(0, -Trampoline::SCALAR);
 			velocity.RotateBy(angle);
+			velocity = Vec2f(Maths::Round(velocity.x), Maths::Round(velocity.y));
 
 			blob.setVelocity(velocity);
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[fixed] Trampoline doesn't bounce blobs to the side slightly over time`

Fixes https://github.com/transhumandesign/kag-base/issues/1850

This PR fixes trampoline bouncing blobs to the side slightly, by applying `Maths::Round()` to the velocity vector that is applied to the blob to be bounced. This means that velocity x and velocity y will only change in steps of 1, and velocity lower than 1 won't get applied, therefore fixing the issue.

In testing, trampoline still behaves very normal when aimed in any direction and having blobs bounce off of it.