### PR TITLE
[fixed] Exception in NoSwears

### DIFF
--- a/Rules/CommonScripts/NoSwears.as
+++ b/Rules/CommonScripts/NoSwears.as
@@ -42,7 +42,7 @@ string KidSafeText(const string &in textIn)
 			}
 
 			const string replacement = word_replacements[i + 1];
-			const uint endpos = pos + replacement.length;
+			const uint endpos = Maths::Min(pos + replacement.length, text.length);
 
 			if (isVital || // if !isVital check for the whole word
 			    ((pos == 0                    || text[pos - 1]    == charSpace) && // first part of the word?


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] Exception when typing non-vital word at the end of your chat message when its replacement word is longer. ("ass" and "cock")
```

Fixes https://github.com/transhumandesign/kag-base/issues/1863

The exception happens in offline and online when you write "ass" or "cock" at the end of your chat message.
Because their replacement word is 1 char longer, the code tries to access too far into `text` via `text[endpos - 1]` in line 49.
This causes no further problems except that the chat filter stops working.

It seems I fixed it by changing `endpos` from

`const uint endpos = pos + replacement.length;`

to

`const uint endpos = Maths::Min(pos + replacement.length, text.length);`

"cock" now gets replaced by "clown" properly in any position of the chat message.
Other messages get replaced as before, too.
I have not seen new issues arising from this change.

Issue https://github.com/transhumandesign/kag-base/issues/1871 is not touched upon and still present after applying this PR.

## Steps to Test or Reproduce

**Before this PR:**
"you ass" --> Exception
"cock" --> Exception

**After this PR:**
"you ass" --> "you butt"
"cock" --> "clown"
