### PR TITLE
[fixed] Autopicking from someone's hand

### DIFF
--- a/Entities/Characters/Archer/ArcherAutoPickup.as
+++ b/Entities/Characters/Archer/ArcherAutoPickup.as
@@ -9,7 +9,10 @@ void onInit(CBlob@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
-	if (blob is null || blob.getShape().vellen > 1.0f)
+	if (blob is null 
+		|| blob.isAttached()
+		|| !blob.canBePickedUp(this)
+		|| blob.getShape().vellen > 1.0f)
 	{
 		return;
 	}

--- a/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -43,7 +43,10 @@ bool pickupCriteria(CBlob@ this, CBlob@ blob, uint16 quantity)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
-	if (blob is null || blob.getShape().vellen > 1.0f)
+	if (blob is null 
+		|| blob.isAttached()
+		|| !blob.canBePickedUp(this)
+		|| blob.getShape().vellen > 1.0f)
 	{
 		return;
 	}

--- a/Entities/Characters/Knight/KnightAutoPickup.as
+++ b/Entities/Characters/Knight/KnightAutoPickup.as
@@ -9,7 +9,10 @@ void onInit(CBlob@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
-	if (blob is null || blob.getShape().vellen > 1.0f)
+	if (blob is null 
+		|| blob.isAttached()
+		|| !blob.canBePickedUp(this)
+		|| blob.getShape().vellen > 1.0f)
 	{
 		return;
 	}

--- a/Entities/Items/Crate/CrateAutoPickup.as
+++ b/Entities/Items/Crate/CrateAutoPickup.as
@@ -27,14 +27,17 @@ void onTick(CBlob@ this)
         for (uint i = 0; i < overlapping.length; i++)
         {
             CBlob@ blob = overlapping[i];
-            {
-                if (blob.getShape().vellen > 1.0f)
-                {
-                    continue;
-                }
 
-                crateTake(this, blob);
-            }
+			if (blob is null 
+				|| blob.isAttached() 
+				|| !blob.canBePickedUp(this)
+				|| blob.getShape().vellen > 1.0f
+				)
+			{
+				continue;
+			}
+
+			crateTake(this, blob);
         }
     }
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[fixed] Autopicking from someone's hand`

Fixes https://github.com/transhumandesign/kag-base/issues/1866

This PR adds return conditions to `ArcherAutoPickup.as`, `BuilderAutoPickup.as` and `KnightAutoPickup.as` to make it so an item will not be "auto-picked" if it has been picked up by someone else already. 

I added `blob.isAttached()` and `!blob.canBePickedUp(this)` as return conditions that also exist in `StandardControls.as` when regularly picking up an item.
However, I did not add `owner.isInInventory()` and `owner.isAttached()` therefore still allowing auto-picking items when e.g. driving over materials while in a catapult. Let me know if it's ok or not.

I couldn't test the issue itself but it is extremely likely it will work as intended. I tested for regressions and didn't see any. Crate auto picking still works.

## Steps to Test or Reproduce

Join a server with a laggy friend.
Have laggy friend be archer.
Spawn a mat_arrows.
Pick up the mat_arrows and have the laggy friend walk over it in quick succession.
Notice the mat_arrows will be picked up by you but then be grabbed from your hand.
**After this PR, it will stay in your hand**