### PR TITLE
[changed] "/spawn" will spawn blobs with caller's facing direction

### DIFF
--- a/Entities/Industry/CTFShops/Quarry/Quarry.as
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.as
@@ -201,9 +201,11 @@ void spawnOre(CBlob@ this)
 	int remainder = amountToSpawn % 5;
 	amountToSpawn += (remainder < 3 ? -remainder : (5 - remainder));
 	//setup res
+	Vec2f ore_offset 			= this.isFacingLeft() ? Vec2f(8.0f, 0.0f) : Vec2f(-8.0f, 0.0f);
+	
 	_ore.Tag("custom quantity");
 	_ore.Init();
-	_ore.setPosition(this.getPosition() + Vec2f(-8.0f, 0.0f));
+	_ore.setPosition(this.getPosition() + ore_offset);
 	_ore.server_SetQuantity(!rare ? amountToSpawn : rare_output);
 
 	this.set_s16(fuel_prop, blobCount - actual_input); //burn wood

--- a/Entities/Industry/CTFShops/Quarters/Quarters.as
+++ b/Entities/Industry/CTFShops/Quarters/Quarters.as
@@ -295,10 +295,12 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint@ attachedPoint)
 
 	bed_head_animation.AddFrame(head_animation.getFrame(2));
 
+	uint rotation = !this.isFacingLeft() ? 80 : 280;
+
 	bed_head.SetAnimation(bed_head_animation);
-	bed_head.RotateBy(80, Vec2f_zero);
+	bed_head.RotateBy(rotation, Vec2f_zero);
 	bed_head.SetOffset(Vec2f(1, 2));
-	bed_head.SetFacingLeft(true);
+	bed_head.SetFacingLeft(!this.isFacingLeft());
 	bed_head.SetVisible(true);
 	bed_head.SetRelativeZ(2);
 }

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -115,8 +115,13 @@ class SpawnCommand : BlobCommand
 			return;
 		}
 
-		u8 team = player.getBlob().getTeamNum();
+		CBlob@ playerBlob = player.getBlob();
+		u8 team = playerBlob.getTeamNum();
 		CBlob@ newBlob = server_CreateBlob(blobName, team, pos + Vec2f(0, -5));
+		if (newBlob !is null)
+		{
+			newBlob.SetFacingLeft(playerBlob.isFacingLeft());
+		}
 
 		//invalid blobs will have 'broken' names
 		if (newBlob is null || newBlob.getName() != blobName)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

[changed] Blobs spawned with "/spawn" will assume the caller's facing direction

Fixes https://github.com/transhumandesign/kag-base/issues/1876

This PR will make blobs spawned via "/spawn" assume the facing direction of the player who used the chat command.
Quarters getting mirrored will show the player's head rotated correctly.
Quarry will spawn mat_stone in the correct position.
Making buildings "mirror proof" is probably a good thing.

And allowing blobs to get spawned not just "always facing left" but also being able to face right would add more variety to Sandbox.

## Steps to Test or Reproduce

Face left and use `/spawn <blob>`.
The spawned blob will face left.

Then face right and use `/spawn <blob>`.
The spawned blob will face left.

**After this PR, the first blob faces left and the second blob faces right.**