### PR TITLE
[fixed] Obstructor and Sensor not getting destroyed properly

### DIFF
--- a/Entities/Structures/Common/DummyOnStatic.as
+++ b/Entities/Structures/Common/DummyOnStatic.as
@@ -18,7 +18,7 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 				map.server_SetTile(POSITION, this.get_TileType(Dummy::TILE));
 				server_setDummyGridNetworkID(map.getTileOffset(POSITION), this.getNetworkID());
 			}
-			else if (this.getHealth() == 0) //this check fixes Obstructor and Sensor breaking background
+			else if (this.getHealth() <= 0) //builder removing Obstructor and Sensor from hand won't break background
 			{
 				map.server_SetTile(POSITION, CMap::tile_empty);
 				server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] Obstructor and Sensor didn't get destroyed properly when their health depleted beyond 0 HP.
```

Fixes https://github.com/transhumandesign/kag-base/issues/1875
Fixes https://github.com/transhumandesign/kag-base/issues/1874

This PR changes the check for health in `DummyOnStatic.as` from `== 0` to `<= 0`.

I changed wording of the comment right after the health checking to make it clear _when_ Obstructor or Sensor would destroy background if it weren't for those 3 lines of code: `//builder removing Obstructor and Sensor from hand won't break background`

## Steps to Test or Reproduce

Place a buch of sensors and then `/spawn orb`.
It should look like this https://i.imgur.com/ByFIFcK.png

Place some obstructors and then either have 1 keg explode next to them or 6 bombs inside them.
You can also have 1 bomb explode inside a non-solid obstructor and then pickaxe the obstructor until destruction.
Notice the obstructor will not get destroyed properly as the sprite will remain on the map.

**After this PR, both issues are fixed. There will be no "black tiles" and obstructor will get destroyed properly.**
