### PR TITLE
[fixed] drill emitting steam when there's no heat

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -446,9 +446,13 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	if (customData == Hitters::water)
 	{
 		s16 current_heat = this.get_u8(heat_prop) - heat_max * heat_reduction_water;
-		if (current_heat < 0) current_heat = 0;
+		
+		if (current_heat <= 0) 
+			current_heat = 0;
+		else if (current_heat > 0)
+			makeSteamPuff(this);
+			
 		this.set_u8(heat_prop, current_heat);
-		makeSteamPuff(this);
 	}
 
 	return damage;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

`[fixed] Drill doesn't emit steam when getting hit by water and while having no heat`

Fixes https://github.com/transhumandesign/kag-base/issues/1882

## Steps to Test or Reproduce

Spawn a drill.
Shoot a water arrow at it.
Notice there is steam even though the drill had no heat.
**After this PR, there won't be steam.**