### PR TITLE
[added] "/team _" will also convert held items with script "SetTeamToCarrier.as"

### DIFF
--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -86,18 +86,10 @@ void onChangeTeam(CBlob@ this, const int oldTeam)
 	if (!this.hasAttached())
 		return;
 
-	CAttachment@ att = this.getAttachments();
-	if (att !is null)
+	CBlob@ heldblob = this.getCarriedBlob();
+	
+	if (heldblob !is null && heldblob.hasScript("SetTeamToCarrier.as"))
 	{
-		AttachmentPoint@ ap = att.getAttachmentPoint("PICKUP");
-		if (ap !is null)
-		{
-			CBlob@ blob = ap.getOccupied();
-			if (blob !is null)
-			{
-				if (blob.hasScript("SetTeamToCarrier.as"))
-					blob.server_setTeamNum(this.getTeamNum());
-			}
-		}
+		heldblob.server_setTeamNum(this.getTeamNum());
 	}
 }

--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -77,3 +77,27 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		this.Untag("invincible");
 	return damage;
 }
+
+void onChangeTeam(CBlob@ this, const int oldTeam)
+{
+	if (!isServer())
+		return;
+
+	if (!this.hasAttached())
+		return;
+
+	CAttachment@ att = this.getAttachments();
+	if (att !is null)
+	{
+		AttachmentPoint@ ap = att.getAttachmentPoint("PICKUP");
+		if (ap !is null)
+		{
+			CBlob@ blob = ap.getOccupied();
+			if (blob !is null)
+			{
+				if (blob.hasScript("SetTeamToCarrier.as"))
+					blob.server_setTeamNum(this.getTeamNum());
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When switching team via `/team x` in Sandbox, held item will also switch to the new team if it has script `"SetTeamToCarrier.as"` (keg, drill, saw, boulder...)

Switching team via menu won't work. Tested online and offline successfully.

## Steps to Test or Reproduce

Go to Sandbox.
Have a drill in hand.
`/team 5` in chat.
Notice the drill will not have changed team.
**After this PR, held item will change to the new team**
