### PR TITLE
[added] "/team _" will also convert held items with script "SetTeamToCarrier.as"

### DIFF
--- a/Rules/CommonScripts/ChatCommands/PlayerCommands.as
+++ b/Rules/CommonScripts/ChatCommands/PlayerCommands.as
@@ -95,6 +95,16 @@ class TeamCommand : ChatCommand
 		}
 
 		blob.server_setTeamNum(team);
+		
+		if (blob.hasAttached())
+		{
+			CBlob@ heldblob = blob.getCarriedBlob();
+			
+			if (heldblob !is null && heldblob.hasScript("SetTeamToCarrier.as"))
+			{
+				heldblob.server_setTeamNum(team);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When switching team via `/team x`, held item will also switch to the new team if it has script `"SetTeamToCarrier.as"` (keg, drill, saw, boulder...)

This is a better solution than https://github.com/transhumandesign/kag-base/pull/1887

## Steps to Test or Reproduce

Go to Sandbox.
Have a drill in hand.
`/team 5` in chat.
Notice the drill will not have changed team.
**After this PR, held item will change to the new team**
