### PR TITLE
[fixed] Camera issues

### DIFF
--- a/Rules/CommonScripts/CinematicCommon.as
+++ b/Rules/CommonScripts/CinematicCommon.as
@@ -287,20 +287,6 @@ bool focusOnBlob(CBlob@[] blobs)
 	return false;
 }
 
-void ViewEntireMap()
-{
-	CMap@ map = getMap();
-
-	if (map !is null)
-	{
-		Vec2f mapDim = map.getMapDimensions();
-		posTarget = mapDim / 2.0f;
-		Vec2f zoomLevel = calculateZoomLevel(mapDim.x, mapDim.y);
-		zoomTarget = Maths::Min(zoomLevel.x, zoomLevel.y);
-		zoomTarget = Maths::Clamp(zoomTarget, 0.5f, 2.0f);
-	}
-}
-
 bool cinematicEnabled = true;
 bool cinematicForceDisabled = false;
 

--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -146,23 +146,30 @@ void SpecCamera(CRules@ this)
 {
 	//death effect
 	CCamera@ camera = getCamera();
-	if (camera !is null && getLocalPlayerBlob() is null && getLocalPlayer() !is null)
+	if (camera !is null && getLocalPlayer() !is null)
 	{
-		const int diffTime = deathTime - getGameTime();
-		// death effect
-		if (!spectatorTeam && diffTime > 0)
+		if (getLocalPlayerBlob() is null)
 		{
-			//lock camera
-			posActual = deathLock;
-			camera.setPosition(deathLock);
-			//zoom in for a bit
-			const float zoom_target = 2.0f;
-			const float zoom_speed = 5.0f;
-			camera.targetDistance = Maths::Min(zoom_target, camera.targetDistance + zoom_speed * getRenderDeltaTime());
+			const int diffTime = deathTime - getGameTime();
+			// death effect
+			if (!spectatorTeam && diffTime > 0)
+			{
+				//lock camera
+				posActual = deathLock;
+				camera.setPosition(deathLock);
+				//zoom in for a bit
+				const float zoom_target = 2.0f;
+				const float zoom_speed = 5.0f;
+				camera.targetDistance = Maths::Min(zoom_target, camera.targetDistance + zoom_speed * getRenderDeltaTime());
+			}
+			else
+			{
+				Spectator(this);
+			}
 		}
 		else
 		{
-			Spectator(this);
+			posActual = camera.getPosition();
 		}
 	}
 }

--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -24,9 +24,7 @@ void Reset(CRules@ this)
 
 	currentTarget = 0;
 	switchTarget = 0;
-
-	//initially position camera to view entire map
-	ViewEntireMap();
+	
 	// force lock camera position immediately, even if not cinematic
 	posActual = posTarget;
 
@@ -34,6 +32,21 @@ void Reset(CRules@ this)
 	zoomEaseModifier = 1.0f;
 
 	timeToCinematic = 0;
+	
+	// so map will call "onInit(CMap@ this)", fixes "ViewEntireMap()" not working in online
+	CMap@ map = getMap();
+	if (!map.hasScript("PlayerCamera.as"))
+	{	
+		print("map script added");
+		map.AddScript("PlayerCamera.as");
+	}
+}
+
+void onInit(CMap@ this)
+{
+	print("on init map");
+	//initially position camera to view entire map
+	ViewEntireMap();
 }
 
 void onRestart(CRules@ this)

--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -37,14 +37,12 @@ void Reset(CRules@ this)
 	CMap@ map = getMap();
 	if (!map.hasScript("PlayerCamera.as"))
 	{	
-		print("map script added");
 		map.AddScript("PlayerCamera.as");
 	}
 }
 
 void onInit(CMap@ this)
 {
-	print("on init map");
 	//initially position camera to view entire map
 	ViewEntireMap();
 }

--- a/Rules/CommonScripts/Spectator.as
+++ b/Rules/CommonScripts/Spectator.as
@@ -67,6 +67,20 @@ float ease(float current, float target, float factor)
 	return current + linearCorrection * cubicCorrectionMod;
 }
 
+void ViewEntireMap()
+{
+	CMap@ map = getMap();
+
+	if (map !is null)
+	{
+		Vec2f mapDim = map.getMapDimensions();
+		posTarget = mapDim / 2.0f;
+		Vec2f zoomLevel = calculateZoomLevel(mapDim.x, mapDim.y);
+		zoomTarget = Maths::Min(zoomLevel.x, zoomLevel.y);
+		zoomTarget = Maths::Clamp(zoomTarget, 0.5f, 2.0f);
+	}
+}
+
 void SetTargetPlayer(CPlayer@ p)
 {
 	_targetPlayer = "";

--- a/Rules/CommonScripts/Spectator.as
+++ b/Rules/CommonScripts/Spectator.as
@@ -238,11 +238,11 @@ void Spectator(CRules@ this)
 
 	if (targetPlayer() !is null)
 	{
-		if (camera.getTarget() !is targetPlayer().getBlob())
+		if (camera.getTarget() !is targetPlayer().getBlob() && !targetPlayer().isBot())
 		{
 			camera.setTarget(targetPlayer().getBlob());
+			posActual = camera.getPosition();
 		}
-		posActual = camera.getPosition();
 	}
 	else
 	{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
- Needs testing

## Description

```
[fixed] Camera getting stuck when going spectator, a new match starts and then switching from spectator to team
[fixed] Camera couldn't scroll as spectator in a match with bots
[fixed] Camera would scroll to somewhere else when moving character forward and then going spectator
[fixed] Camera would initialize in position (0, 0) instead of center map (in online)
```

Fixes https://github.com/transhumandesign/kag-base/issues/1862
Fixes https://github.com/transhumandesign/kag-base/issues/1512

This PR does some changes to address some issues. 

The reason for camera initialising in position (0, 0) when a new match loads while spectator is with `ViewEntireMap()` being called in `Reset(CRules@ this)` at the time map is not initialised yet, so map dimension is still (0, 0). I changed the code so that `ViewEntireMap()` is called in `onInit(CMap@ this)` instead which allows the camera to initialize in center of map properly.

I moved `ViewEntireMap()` from `CinematicCommon.as` to `Spectator.as` for no particular reason. There is no consequence in having it in one or the other script.

There are many issues with bots but I addressed one I found annoying. When in a match with bots and you go spectator, camera would be stuck on one of the bots and you couldn't move the camera. This PR fixes that by adding a check for `!targetPlayer().isBot()` in `Spectator.as`. Right after that, I moved `posActual = camera.getPosition();` inside the previous code block which seems to make camera movable in situations where it previouslyn wasn't. This seems to fix camera getting stuck when switching from spectator to team and waiting the respawn timer, after a match has gone from build phase to battle phase.

Tested offline and online. However it should be tested with other human players in an online server to check for regressions.

## Steps to Test or Reproduce

I added this in `TipCommand` in `MiscCommands.as` for testing purposes:

```
		if (index == 1)
		{
			getRules().SetCurrentState(GAME);
		}
		else if (index == 2)
		{
			getRules().SetCurrentState(GAME_OVER);
		}
		else if (index == 3)
		{
			AddBot("");
		}
```

1) 
Join CTF online server.
`/tip 4` (add bot)
Go spectator.
Notice the camera is stuck on the bot.
**After this PR, you can freely move it around.**

2)
Join CTF online server.
`/tip 3` (game over)
Go spectator.
When the new map loads, camera will be in top left corner.
**After this PR, it will be centered on the map.**

3)
Join CTF online server.
Move a distance away.
Go spectator.
Notice the camera would scroll back to the tent for odd reasons.
**After this PR, the camera would stay where you despawned.**

4)
Join CTF online server.
Go spectator.
`/tip 3` (game over)
Wait for new map to load.
`/tip 2` (battle phase start)
Join a team.
Notice the camera will be stuck.
**After this PR, it is movable.**