### PR TITLE
[fixes] Wall running would override Trampoline bounce

### DIFF
--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -138,6 +138,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			velocity.RotateBy(angle);
 
 			blob.setVelocity(velocity);
+			blob.set_u16("trampoline last bounce time", getGameTime());
 
 			CSprite@ sprite = this.getSprite();
 			if (sprite !is null)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] Wall running doesn't override Trampoline bounce
```
Fixes https://github.com/transhumandesign/kag-base/issues/1724

I added a check if player recently bounced from a trampoline, in `RunnerMovement.as` near line 384.
Couldn't think of other solutions. Low effort PR.
