### PR TITLE
[fixed] Gold decaying would alert admin (TDM)

### DIFF
--- a/Entities/Common/Decaying/DecayQuantity.as
+++ b/Entities/Common/Decaying/DecayQuantity.as
@@ -27,6 +27,7 @@ void onTick(CBlob@ this)
 
 	if (step >= quantity)
 	{
+		this.Tag("AdminAlertIgnore");
 		this.server_Die();
 		return;
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] False admin alert when gold vanished by decaying
```

Fixes https://github.com/transhumandesign/kag-base/issues/1513

Pebble of gold could decay after 66 sec in TDM causing a false admin alert message.

Although @eps0003 suggested that blobs should be tagged by the way they are destroyed and letting `AlertAdminOnDie.as` decide which tags are getting reported, this would mean changing every script that has `server_Die()` or `server_Hit()` in it.

For now, I simply added `this.Tag("AdminAlertIgnore");` to `DecayQuantity.as` so the specific situation of gold decaying and alerting admin doesn't happen.

Admin alert message is for when players throw gold into the void, not for when materials decay by themselves.

Note: Tag `"AdminAlertIgnore"` is also used for when materials merge, which is a similar use-case.

## Steps to Test or Reproduce

Go to TDM.
Slash at a gold tile so a pebble of gold falls out.
Wait 66 sec so the gold pebble despawns.
Admin alert message can be read in console log.
**After this PR, there is no admin alert message.**