### PR TITLE
[fixed] wrong font being used on tips and queue button when game state banners are shown

### DIFF
--- a/Rules/CommonScripts/ShowTipOnDeath.as
+++ b/Rules/CommonScripts/ShowTipOnDeath.as
@@ -56,6 +56,7 @@ void RenderTip()
 	Vec2f br(scrw / 2 + w / 2, scrh - offset);
 
 	GUI::DrawButton(tl, br);
+	GUI::SetFont("menu");
 	GUI::DrawText(tip, tl + Vec2f(10, 10), br - Vec2f(10, 10), color_white, true, true, false);
 }
 

--- a/Rules/CommonScripts/SpectatorQueue.as
+++ b/Rules/CommonScripts/SpectatorQueue.as
@@ -83,6 +83,7 @@ class QueueGUIHidden
 		string text = "Queue Position: " + (client_queue_pos == -1 ? "None" : "" + (client_queue_pos + 1));
 		GUI::DrawPane(origin, origin+size, color);
 		Vec2f text_pos = Vec2f(origin.x + size.x / 2, origin.y + size.y / 2);
+		GUI::SetFont("menu");
 		GUI::DrawTextCentered(text, text_pos, color_white);
 	}
 

--- a/Rules/CommonScripts/VoteCore.as
+++ b/Rules/CommonScripts/VoteCore.as
@@ -49,6 +49,7 @@ void onRender(CRules@ this)
 		vote_title = vote_title.replace("{USER}", vote.user_to_kick);
 	}
 
+	GUI::SetFont("menu");
 	GUI::GetTextDimensions(vote_title, text_dim);
 
 	if (can_cancel || can_force_pass)
@@ -57,8 +58,6 @@ void onRender(CRules@ this)
 	}
 
 	GUI::DrawPane(tl, br, SColor(0x80ffffff));
-
-	GUI::SetFont("menu");
 	GUI::DrawText(vote_title, tl + Vec2f(Maths::Max(dim.x / 2 - text_dim.x / 2, 3.0), 3), color_white);
 
 	GUI::DrawText(getTranslatedString("Reason: {REASON}").replace("{REASON}", getTranslatedString(vote.reason)), tl + Vec2f(3, 3 + text_dim.y * 2), color_white);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] wrong font being used on tips and queue button when game state banners are shown
```
Fixes https://github.com/transhumandesign/kag-base/issues/1699

Tested online, works.

## Steps to Test or Reproduce

You can add
```
		if (index == 1)
		{
			getRules().SetCurrentState(GAME);
		}
		else if (index == 2)
		{
			getRules().SetCurrentState(GAME_OVER);
		}
```
in `TipCommand` in `MiscCommands.as`.

Go to CTF.
Place spikes.
Jump in the spikes so the next jump would kill you.
Still during build phase, type `/tip 2` = battle phase start, banner is shown. Then ...

... Quickly jump in the spikes again.
Notice the font on the tip is wrong.
**After this PR, it is correct.**

... Quickly go spectator.
Notice the font on the queue button is wrong.
**After this PR, it is correct.**