### PR TITLE
[changed] You don't lose coins in TDM before a match or after a match when killing yourself

### DIFF
--- a/Rules/TDM/Scripts/TDM_Trading.as
+++ b/Rules/TDM/Scripts/TDM_Trading.as
@@ -182,7 +182,11 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customData)
 			}
 		}
 
-		victim.server_setCoins(victim.getCoins() - coinsOnDeathLose);
+		if (this.isMatchRunning() || (killer !is null && killer !is victim))
+		{
+			// subtract coins after a match only when someone killed us
+			victim.server_setCoins(victim.getCoins() - coinsOnDeathLose);
+		}
 	}
 }
 

--- a/Rules/TDM/Scripts/TDM_Trading.as
+++ b/Rules/TDM/Scripts/TDM_Trading.as
@@ -182,9 +182,9 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ killer, u8 customData)
 			}
 		}
 
-		if (this.isMatchRunning() || (killer !is null && killer !is victim))
+		if (this.isMatchRunning() || (killer !is null && killer.getTeamNum() != victim.getTeamNum()))
 		{
-			// subtract coins after a match only when someone killed us
+			// subtract coins after a match only when opponent team player killed us
 			victim.server_setCoins(victim.getCoins() - coinsOnDeathLose);
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[changed] You won't lose coins in TDM before a match starts or after a match ends when killing yourself
```
Fixes https://github.com/transhumandesign/kag-base/issues/1922
Fixes https://github.com/transhumandesign/kag-base/issues/1961

Players in TDM like to drop into the void for fun after match is over.
This PR changes `TDM_Trading.as` so coins are not subtracted in this case.
Coins are subtracted if the match is ongoing or if a killer exists and isn't from our team.

Tested in offline, should work in online the same way.

## Reproduction

No coins lost when 
* match is over and you kill yourself by suicide, void, map spikes, drowning etc. (if you didn't take enemy damage in the previous 10 seconds)

Coins lost when
* You die while match is running
* match is over and you die by enemy bomb / keg / arrow / boulder
* match is over and you die after taking enemy damage in the previous 10 seconds

## Suggestions

If people want, we can also make it so you lose coins after match ended and by enemy attack only if the enemy attack is within 1-2 seconds rather than within 10 seconds. Because 1-2 seconds after match ended will be the point where everyone has realized the match is over and if anyone dies after that, it was probably their deliberate choice.
But I opted for not doing this for now.