### PR TITLE
[changed] You won't get stomped by the blob that you recently stomped

### DIFF
--- a/Entities/Characters/Scripts/Stomp.as
+++ b/Entities/Characters/Scripts/Stomp.as
@@ -2,6 +2,8 @@
 #include "/Entities/Common/Attacks/Hitters.as";
 #include "KnockedCommon.as"
 
+const u8 STOMP_AGAIN_THRESHOLD = 15;
+
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
 	if (blob is null)   // map collision?
@@ -71,7 +73,7 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 
 	u16 stomped_time = this.get_u16("stomped_time");
 	CBlob@ stomper = getBlobByNetworkID(this.get_u16("stomped_by_id"));
-	bool recently_stomped_by_blob = (stomper !is null && stomper is blob && stomped_time + 60 > getGameTime());
+	bool recently_stomped_by_blob = (stomper !is null && stomper is blob && stomped_time + STOMP_AGAIN_THRESHOLD > getGameTime());
 	bool falling_faster_than_blob = this.getVelocity().y > blob.getVelocity().y;
 
 	return !(recently_stomped_by_blob && falling_faster_than_blob);

--- a/Entities/Characters/Scripts/Stomp.as
+++ b/Entities/Characters/Scripts/Stomp.as
@@ -40,6 +40,11 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 		if (enemydam > 0)
 		{
 			this.server_Hit(blob, this.getPosition(), Vec2f(0, 1) , enemydam, Hitters::stomp);
+
+			blob.set_u16("stomped_time", getGameTime());
+			blob.set_u16("stomped_by_id", this.getNetworkID());
+			blob.Sync("stomped_time", true);
+			blob.Sync("stomped_by_id", true);
 		}
 	}
 }
@@ -55,4 +60,19 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	}
 
 	return damage;
+}
+
+bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
+{
+	if (!this.exists("stomped_time"))
+	{
+		return true;
+	}
+
+	u16 stomped_time = this.get_u16("stomped_time");
+	CBlob@ stomper = getBlobByNetworkID(this.get_u16("stomped_by_id"));
+	bool recently_stomped_by_blob = (stomper !is null && stomper is blob && stomped_time + 60 > getGameTime());
+	bool falling_faster_than_blob = this.getVelocity().y > blob.getVelocity().y;
+
+	return !(recently_stomped_by_blob && falling_faster_than_blob);
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[changed] You won't get stomped by the blob that you recently stomped
```

Fixes https://github.com/transhumandesign/kag-base/issues/1408

This PR changes `Stomp.as`.
The blob that got stomped will have stomp timestamp and stomper netid set to it.

`doesCollideWithBlob()` hook is added to `Stomp.as` which checks if we have any timestamp and stomper info.
Collision doesn't happen if the blob we try to collide with is the blob that recently (within 60 ticks) stomped us and if we are traveling downward faster than that blob.

Tested in offline only. I suggest to test it in live matches.

## Steps to Test or Reproduce

1) Build something like this https://i.imgur.com/59IY7rn.png
2) Spawn knight on the ladder at the top tunnel.
3) Change team
4) Travel to the top and jump on the knight you spawned, try to tap the "use" key so you travel the tunnel.
5) If you successfully traveled, you will notice the knight you just stomped with fall through you and will not stomp you. On the next bounce after that, he will stomp you though.