### PR TITLE
[fixed] Heal chat command bug

### DIFF
--- a/Rules/CommonScripts/ChatCommands/PlayerCommands.as
+++ b/Rules/CommonScripts/ChatCommands/PlayerCommands.as
@@ -146,7 +146,7 @@ class HealCommand : ChatCommand
 		//health calculation and processing
 
 		// going in steps of 0.25
-		float orig_health = parseFloat(args[0]);
+		float orig_health = args.size() > 0 ? parseFloat(args[0]) : blob.getInitialHealth() * 2;
 		float health_to_heal = orig_health > 0 ? Maths::Floor(orig_health * 4) * 0.25 : Maths::Ceil(orig_health * 4) * 0.25; 
 		bool no_change = health_to_heal == 0;
 		bool healing = health_to_heal > 0;

--- a/Rules/CommonScripts/ChatCommands/PlayerCommands.as
+++ b/Rules/CommonScripts/ChatCommands/PlayerCommands.as
@@ -143,44 +143,32 @@ class HealCommand : ChatCommand
 			return;
 		}
 
-		//i hate this but it works
-		float health;
-		float healthClamped;
+		//health calculation and processing
 
-		if (args.size() > 0)
-		{
-			health = healthClamped = parseFloat(args[0]);
+		// going in steps of 0.25
+		float orig_health = parseFloat(args[0]);
+		float health_to_heal = orig_health > 0 ? Maths::Floor(orig_health * 4) * 0.25 : Maths::Ceil(orig_health * 4) * 0.25; 
+		bool no_change = health_to_heal == 0;
+		bool healing = health_to_heal > 0;
+		float possible_health_gap =  healing ? blob.getInitialHealth() * 2 - blob.getHealth() * 2 : blob.getHealth() * 2 - 0.25;
 
-			if (blob.getHealth() * 2 + health < 0.5f)
-			{
-				healthClamped = 0.125f - blob.getHealth() * 2;
-			}
-
-			if (blob.getHealth() * 2 + health > blob.getInitialHealth() * 2)
-			{
-				healthClamped = (blob.getInitialHealth() - blob.getHealth()) * 2;
-			}
-		}
-		else
-		{
-			health = blob.getInitialHealth() * 2;
-			healthClamped = (blob.getInitialHealth() - blob.getHealth()) * 2;
-		}
+		// don't go lower than 0.25 or higher than max health
+		health_to_heal = healing ? Maths::Min(health_to_heal, possible_health_gap) : Maths::Max(health_to_heal, -possible_health_gap);
 
 		if (isServer())
 		{
-			blob.server_Heal(healthClamped);
+			blob.server_Heal(health_to_heal);
 		}
 
 		if (player.isMyPlayer())
 		{
-			if (healthClamped == 0)
+			if (health_to_heal == 0)
 			{
-				if (health == 0)
+				if (no_change)
 				{
-					client_AddToChat(getTranslatedString("Specify a valid amount to heal"), ConsoleColour::ERROR);
+					client_AddToChat(getTranslatedString("Specify a valid amount (at least 0.25 or -0.25)"), ConsoleColour::ERROR);
 				}
-				else if (health > 0)
+				else if (healing)
 				{
 					client_AddToChat(getTranslatedString("You are already at full health"), ConsoleColour::ERROR);
 				}
@@ -194,7 +182,7 @@ class HealCommand : ChatCommand
 				CSprite@ sprite = blob.getSprite();
 				if (sprite !is null)
 				{
-					if (health > 0)
+					if (health_to_heal > 0)
 					{
 						sprite.PlaySound("Heart.ogg");
 					}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Heal chat command not working properly
```

Fixes https://github.com/transhumandesign/kag-base/issues/1933

I changed the heal amount calculation in `PlayerCommands.as`, it now works like this:
Inputted health is rounded to a multiple of 0.25 (i.e. a quarter heart).

To be valid, inputted health must be 0.25 or higher, or -0.25 or lower.
`Specify a valid amount to heal` was changed to `Specify a valid amount (at least 0.25 or -0.25)`

0.49 health will be rounded down to 0.25 health, 0.74 to 0.5 etc.
-0.49 health will be rounded up to -0.25 health, -0.74 to -0.5 etc.

The game will not say that you are at full health when trying to heal a very tiny value (see the linked issue above).

Your health will not be set to values that are not a multiple of 0.25 anymore.

Tested and no problems encountered.