### PR TITLE
[added] "/seed" chat command can now spawn grain plant, flowers and bush

### DIFF
--- a/Rules/CommonScripts/ChatCommands.cfg
+++ b/Rules/CommonScripts/ChatCommands.cfg
@@ -18,7 +18,7 @@ commands =
 	allarrows; 0; 1;
 	fishies; 0; 1;
 	chickens; 0; 1;
-	tree; 0; 1;
+	seed; 0; 1;
 	water; 1; 1;
 	crate; 0; 1;
 	scroll; 0; 1;

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -25,10 +25,8 @@ class SeedCommand : BlobCommand
 				server_AddToChat(getTranslatedString("Specify a valid seed type: " + join(seedTypes, ", ")), ConsoleColour::ERROR, player);
 				return;
 			}
-			else
-			{
-				seed = type;
-			}
+
+			seed = type;
 		}
 
 		server_MakeSeed(pos, seed);

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -3,34 +3,35 @@
 #include "MakeCrate.as";
 #include "MakeScroll.as"
 
-class TreeCommand : BlobCommand
+class SeedCommand : BlobCommand
 {
-	string[] treeTypes = { "pine", "bushy" };
+	string[] seedTypes = { "tree_pine", "tree_bushy", "grain_plant", "flowers", "bush"};
 
-	TreeCommand()
+	SeedCommand()
 	{
-		super("tree", "Spawn a tree seed");
-		AddAlias("seed");
+		super("seed", "Spawn a seed");
 		SetUsage("[type]");
 	}
 
 	void SpawnBlobAt(Vec2f pos, string[] args, CPlayer@ player)
 	{
-		string tree = "tree_" + treeTypes[0];
+		string seed = seedTypes[XORRandom(seedTypes.size())];
 
 		if (args.size() > 0)
 		{
 			string type = args[0].toLower();
-			if (treeTypes.find(type) == -1)
+			if (seedTypes.find(type) == -1)
 			{
-				server_AddToChat(getTranslatedString("Specify a valid tree type: " + join(treeTypes, ", ")), ConsoleColour::ERROR, player);
+				server_AddToChat(getTranslatedString("Specify a valid seed type: " + join(seedTypes, ", ")), ConsoleColour::ERROR, player);
 				return;
 			}
-
-			tree = "tree_" + type;
+			else
+			{
+				seed = type;
+			}
 		}
 
-		server_MakeSeed(pos, tree);
+		server_MakeSeed(pos, seed);
 	}
 }
 

--- a/Rules/CommonScripts/DefaultChatCommands.as
+++ b/Rules/CommonScripts/DefaultChatCommands.as
@@ -45,7 +45,7 @@ void RegisterDefaultChatCommands(ChatCommandManager@ manager)
 	manager.RegisterCommand(BisonCommand());
 
 	//other
-	manager.RegisterCommand(TreeCommand());
+	manager.RegisterCommand(SeedCommand());
 	manager.RegisterCommand(WaterCommand());
 	manager.RegisterCommand(CrateCommand());
 	manager.RegisterCommand(ScrollCommand());


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[changed] "/seed" can now be used to spawn grain_plant, bush and flowers, too. "/tree" removed.
[changed] When "/seed" is used without a type, it will spawn a random seed rather than a pine tree seed.
```
Fixes https://github.com/transhumandesign/kag-base/issues/1939

This PR makes changes to `BlobCommands.as` to allow `/seed` to be able to spawn `grain_plant`, `bush` and `flowers`.

When only `/seed` is used without an argument, it will spawn a random seed instead of always a pine seed.

Removed `/tree` since the command is now also for types of seeds that aren't trees. The user will have to type in `tree_pine` and `tree_bushy` instead of just `pine` and `bushy`, as a small side effect.

Tested in offline, works without problems.

## Steps to Test or Reproduce

Type `/seed`
Type `/seed test`
Type `/seed tree_pine`
Type `/seed tree_bushy`
Type `/seed grain_plant`
Type `/seed bush`
Type `/seed flowers`
