### PR TITLE
[added] "/bot" now allows setting the bot's name

### DIFF
--- a/Rules/CommonScripts/ChatCommands/MiscCommands.as
+++ b/Rules/CommonScripts/ChatCommands/MiscCommands.as
@@ -44,14 +44,15 @@ class BotCommand : ChatCommand
 	BotCommand()
 	{
 		super("bot", "Spawn a bot");
-		AddAlias("henry");
+		SetUsage("[name]");
 	}
 
 	void Execute(string[] args, CPlayer@ player)
 	{
 		if (isServer())
 		{
-			AddBot("Henry");
+			string name = args.size() > 0 ? args[0] : "Henry";
+			AddBot(name);
 		}
 	}
 }

--- a/Rules/CommonScripts/ChatCommands/MiscCommands.as
+++ b/Rules/CommonScripts/ChatCommands/MiscCommands.as
@@ -51,7 +51,7 @@ class BotCommand : ChatCommand
 	{
 		if (isServer())
 		{
-			string name = args.size() > 0 ? args[0] : "Henry";
+			string name = args.size() > 0 ? join(args, " ") : "Henry";
 			AddBot(name);
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[changed] "/bot" is now "/bot [name]" to allow setting the bot's name. "/henry" removed.
```
Fixes https://github.com/transhumandesign/kag-base/issues/1938

This PR changes `MiscCommands.as` so `/bot` can now take a string to set the bot's name.
When no argument is given, `"Henry"` will be used.
When multiple arguments are given, they will be joined together separated by one space each time.

I tested in offline.
All special characters I tried were accepted.
It didn't make a blank name at any time.
When using very long names, the string will be cut short.

The alias `/henry` was removed.

## Steps to Test or Reproduce

Type `/bot 123test`, the bot will be named `123test`.
Type `/bot`, the bot will be named `Henry`.
Type `/bot     `, the bot will be named `Henry`.
Type `/bot a b c d e`, the bot will be named `a b c d e`.
Type `/bot aaa            bbb`, the bot will be named `aaa bbb`.

