### PR TITLE
[fixed] "/scroll <name>" chat command not working

### DIFF
--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -85,8 +85,30 @@ class ScrollCommand : BlobCommand
 			SetupScrolls(getRules());
 		}
 
-		// no name specified, show all valid names in chat
+		// no name specified, spawn a random scroll
 		if (args.size() == 0)
+		{
+			ScrollSet@ allScrolls = getScrollSet("all scrolls");
+			
+			if (allScrolls !is null)
+			{
+				string[] scrolls_list = allScrolls.names;
+				int scrolls_list_size = scrolls_list.size();
+				
+				if (scrolls_list_size > 0)
+				{
+					server_MakePredefinedScroll(pos, scrolls_list[XORRandom(scrolls_list_size)]);
+				}
+			}
+			return;
+		}
+
+		// attempting to spawn scroll by name
+		string scrollName = join(args, " ");
+				
+		CBlob@ scroll = server_MakePredefinedScroll(pos, scrollName);
+		
+		if (scroll is null)
 		{
 			server_AddToChat(getTranslatedString("Specify the name of a scroll to spawn:"), ConsoleColour::ERROR, player);
 			
@@ -102,17 +124,6 @@ class ScrollCommand : BlobCommand
 				}
 			}
 			
-			return;
-		}
-
-		// attempting to spawn scroll
-		string scrollName = join(args, " ");
-				
-		CBlob@ scroll = server_MakePredefinedScroll(pos, scrollName);
-		
-		if (scroll is null)
-		{
-			server_AddToChat(getTranslatedString("Scroll '{SCROLL}' not found").replace("{SCROLL}", scrollName), ConsoleColour::ERROR, player);
 			return;
 		}
 	}

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -110,7 +110,7 @@ class ScrollCommand : BlobCommand
 		
 		if (scroll is null)
 		{
-			server_AddToChat(getTranslatedString("Specify the name of a scroll to spawn:"), ConsoleColour::ERROR, player);
+			server_AddToChat(getTranslatedString("Specify a valid scroll name:"), ConsoleColour::ERROR, player);
 			
 			ScrollSet@ allScrolls = getScrollSet("all scrolls");
 			

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -1,7 +1,8 @@
 #include "ChatCommand.as"
 #include "MakeSeed.as";
 #include "MakeCrate.as";
-#include "MakeScroll.as"
+#include "MakeScroll.as";
+#include "WAR_Technology.as";
 
 class TreeCommand : BlobCommand
 {
@@ -78,14 +79,42 @@ class ScrollCommand : BlobCommand
 
 	void SpawnBlobAt(Vec2f pos, string[] args, CPlayer@ player)
 	{
+		// setting up scrolls if necessary
+		if (!getRules().exists("all scrolls"))
+		{
+			SetupScrolls(getRules());
+		}
+
+		// no name specified, show all valid names in chat
 		if (args.size() == 0)
 		{
-			server_AddToChat(getTranslatedString("Specify the name of a scroll to spawn"), ConsoleColour::ERROR, player);
+			server_AddToChat(getTranslatedString("Specify the name of a scroll to spawn:"), ConsoleColour::ERROR, player);
+			
+			ScrollSet@ allScrolls = getScrollSet("all scrolls");
+			
+			if (allScrolls !is null)
+			{
+				string[] scrolls_list = allScrolls.names;
+				
+				if (scrolls_list.size() > 0)
+				{
+					server_AddToChat(join(scrolls_list, ", "), ConsoleColour::ERROR, player);
+				}
+			}
+			
 			return;
 		}
 
+		// attempting to spawn scroll
 		string scrollName = join(args, " ");
-		server_MakePredefinedScroll(pos, scrollName);
+				
+		CBlob@ scroll = server_MakePredefinedScroll(pos, scrollName);
+		
+		if (scroll is null)
+		{
+			server_AddToChat(getTranslatedString("Scroll '{SCROLL}' not found").replace("{SCROLL}", scrollName), ConsoleColour::ERROR, player);
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] "/scroll <name>" will now work in modes other than TTH
[changed] "/scroll <name>" with an invalid name will list all valid names in chat
```

Fixes https://github.com/transhumandesign/kag-base/issues/1937

This PR changes `BlobCommands.as`.

The command `/scroll <name>` didn't work outside of TTH mode.
I fixed it by executing `SetupScrolls()` if `"all scrolls"` doesn't exist in CRules@.
In testing, `SetupScrolls()` will only be executed once, the first time you try to use `/scroll <name>`.

When an invalid name is used, all valid names will be listed in chat.

When no name is used, a random scroll will be spawned.

This is the same behavior as `/seed <name>` from the seed PR here: https://github.com/transhumandesign/kag-base/pull/1941

## How to use

`/scroll ` --> a random scroll spawns
`/scroll abc` --> says in chat to specify a valid name and lists all valid names
`/scroll midas` --> spawns a midas scroll.

Notice scrolls will actually spawn in Sandbox rather than nothing happening.





