### PR TITLE
[fixed] Obstructor has proper minimap colors now

### DIFF
--- a/Scripts/MapLoaders/MinimapHook.as
+++ b/Scripts/MapLoaders/MinimapHook.as
@@ -55,23 +55,29 @@ void CalculateMinimapColour( CMap@ map, u32 offset, TileType tile, SColor &out c
 	{ 
 		col = color_castle;
 	} 
-	else if (map.isTileBackgroundNonEmpty(ctile) && !map.isTileGrass(tile)) {
-		
-		// TODO(hobey): maybe check if there's a door/platform on this backwall and make a custom color for them?
-		if (tile == CMap::tile_castle_back) 
-		{ 
-			col = color_castle_backwall;
-		} 
-		else if (tile == CMap::tile_wood_back)   
-		{ 
-			col = color_wood_backwall;
-		} 
-		else                                     
-		{ 
-			col = color_dirt_backwall;
-		}
-		
+	else if (tile == CMap::tile_castle_back) 
+	{ 
+		col = color_castle_backwall;
 	} 
+	else if (tile == CMap::tile_wood_back)   
+	{ 
+		col = color_wood_backwall;
+	} 
+	else if (tile == CMap::tile_ground_back)                                    
+	{ 
+		col = color_dirt_backwall;
+	} 
+	else if (tile != CMap::tile_empty && !map.isTileGrass(tile))
+	{
+		if (map.isTileBackground(ctile))
+		{
+			col = col.getInterpolated(color_castle_backwall, 0.5f);
+		}
+		else
+		{
+			col = color_castle_backwall;
+		}
+	}
 	else 
 	{
 		col = color_sky;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Obstructor has proper minimap tiles depending on its state
```
Fixes https://github.com/transhumandesign/kag-base/issues/1921

Obstructor had a minimap color `tile_castle_back` when it was non-solid, and had none, defaulting to sky color, when it was solid.

This PR changes `MinimapHook.as` to make Obstructor have a minimap tile `tile_castle_back` when it is solid and a brighter `tile_castle_back` color when it is non-solid.

I would like to make Obstructor show up as nothing when it is non-solid (i.e. sky color when it has nothing behind it, or dirt color when it has dirt backwall behind it). But there is no way to recognize such ( see: https://github.com/transhumandesign/kag-base/issues/1948 ) so this PR is the best solution for now.

I didn't see any regressions that arose from the changes.
