### PR TITLE
[added] You can't purchase items after match ended (TDM)

### DIFF
--- a/Entities/Common/Includes/Requirements.as
+++ b/Entities/Common/Includes/Requirements.as
@@ -213,7 +213,7 @@ bool hasRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &inout bs, C
 		{
 			CBlob@ blob = inv1 !is null ? inv1.getBlob() : null;
 			CRules@ rules = getRules();
-			if (rules !is null && rules.exists("no purchase post match") && rules.isGameOver())
+			if (rules !is null && rules.exists("no purchase post match") && rules.get_bool("no purchase post match") && rules.isGameOver())
 			{
 				AddMatchNotEndedRequirement(missingBs);
 				has = false;

--- a/Entities/Common/Includes/Requirements.as
+++ b/Entities/Common/Includes/Requirements.as
@@ -61,6 +61,10 @@ string getButtonRequirementsText(CBitStream& inout bs, bool missing)
 		{
 			text += getTranslatedString("$HEART$ Must be hurt\n");
 		}
+		else if (requiredType == "match not ended" && missing)
+		{
+			text += getTranslatedString("Match has ended.\n");
+		}
 		else if (requiredType == "no more" && missing)
 		{
 			text += quantityColor;
@@ -112,6 +116,11 @@ void AddHurtRequirement(CBitStream &inout bs)
 	bs.write_string("hurt");
 }
 
+void AddMatchNotEndedRequirement(CBitStream &inout bs)
+{
+	bs.write_string("match not ended");
+}
+
 bool ReadRequirement(CBitStream &inout bs, string &out req, string &out blobName, string &out friendlyName, u16 &out quantity)
 {
 	if (!bs.saferead_string(req))
@@ -120,6 +129,11 @@ bool ReadRequirement(CBitStream &inout bs, string &out req, string &out blobName
 	}
 
 	if (req == "hurt")
+	{
+		return true;
+	}
+	
+	if (req == "match not ended")
 	{
 		return true;
 	}
@@ -192,6 +206,16 @@ bool hasRequirements(CInventory@ inv1, CInventory@ inv2, CBitStream &inout bs, C
 			if (blob is null || blob.getHealth() >= blob.getInitialHealth())
 			{
 				AddHurtRequirement(missingBs);
+				has = false;
+			}
+		}
+		else if (req == "match not ended")
+		{
+			CBlob@ blob = inv1 !is null ? inv1.getBlob() : null;
+			CRules@ rules = getRules();
+			if (rules !is null && rules.exists("no purchase post match") && rules.isGameOver())
+			{
+				AddMatchNotEndedRequirement(missingBs);
 				has = false;
 			}
 		}

--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -836,6 +836,8 @@ void Reset(CRules@ this)
 	this.set("start_gametime", getGameTime() + core.warmUpTime);
 	this.set_u32("game_end_time", getGameTime() + core.gameDuration); //for TimeToEnd.as
 	this.set_s32("restart_rules_after_game_time", (core.spawnTime < 0 ? 5 : 10) * 30 );
+	
+	this.set_bool("no purchase post match", true);
 }
 
 void onRestart(CRules@ this)

--- a/Rules/TDM/Scripts/TDM_Trading.as
+++ b/Rules/TDM/Scripts/TDM_Trading.as
@@ -39,6 +39,7 @@ TradeItem@ addItemForCoin(CBlob@ this, const string &in name, int cost, const bo
 	if (item !is null)
 	{
 		AddRequirement(item.reqs, "coin", "", "Coins", cost);
+		AddMatchNotEndedRequirement(item.reqs);
 		item.buyIntoInventory = true;
 	}
 	return item;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[added] You can't purchase items after match ended in TDM
```
Fixes https://github.com/transhumandesign/kag-base/issues/1936

Bool `no purchase post match = true` is written to CRules@ in `TDM.as` in `Reset()`.

A new function `AddMatchNotEndedRequirement()` is added to `Requirements.as` which fires when the match is over and the above bool exists in CRules@.

`TDM_Trading.as` applies `AddMatchNotEndedRequirement()` for each item that is set up in trading post via `AddItemForCoin()`.

This means you cannot buy any items after a match is over in TDM, removing annoying and unnecessary situations where a player wastes his coins post match. Since the bool is only set in `TDM.as`, the requirement only exists in TDM. You can still buy items post match in other game modes, including Challenges - which also uses trading posts and `AddItemForCoin()`.

Tested in online and offline, works as intended.

## Steps to Test or Reproduce

Play TDM.
Buy items as usual in trading post.
Win a match.
Try to buy items in trading post, get told "Match has ended" and all item buttons are greyed out.