### PR TITLE
[fixed] TDM_spawn and tent won't be floating above ground or be one tile too deep

### DIFF
--- a/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
+++ b/Entities/Special/TDM/TDM_Ruins/TDM_Ruins.as
@@ -20,6 +20,12 @@ void onInit(CBlob@ this)
 	this.Tag("change class drop inventory");
 
 	this.getSprite().SetZ(-50.0f);   // push to background
+	
+	CShape@ shape = this.getShape();
+	if (shape !is null)
+	{
+		shape.PutOnGround();
+	}
 }
 
 void onTick(CBlob@ this)

--- a/Entities/Special/Tent/TentLogic.as
+++ b/Entities/Special/Tent/TentLogic.as
@@ -21,6 +21,12 @@ void onInit(CBlob@ this)
 
 	// defaultnobuild
 	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 8.0f));
+	
+	CShape@ shape = this.getShape();
+	if (shape !is null)
+	{
+		shape.PutOnGround();
+	}
 }
 
 void onTick(CBlob@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] TDM_spawn and tent will have the correct position
```
Fixes https://github.com/transhumandesign/kag-base/issues/1960

This PR adds `shape.PutOnGround()` to `Init(CBlob@ this)` for tdm_spawn and tent.
So if the pixel for the "main spawn" in a png file is too low or too high, it will not matter as the blob will automatically place itself on the ground.

During testing I have not seen it misbehave. The only condition for this to work is that there is enough empty space (64x64 for tdm_ruins and 40x40 for tent).

The alternative would have been to change like 30 png files which is much painful work. And map makers will mess up pixels in the future so this generic solution should be good.

When spawning tdm_ruin or tent in Sandbox, naturally they will warp down to the next nearby ground. Good enough, since tents and ruins aren't supposed to be floating anyway.

## Steps

Load a map with the correct pixel position for tdm_spawn, e.g. `RattleCage`
Load a map with the pixel being too deep by 1 pixel, e.g. `Vault`
Notice that Vault's tdm_spawns are one pixel deep in the ground.
**After this PR, tdm_spawn is placed on the ground correctly on both maps.**
