### PR TITLE
[changed] Sandbox will allow faster building and mining

### DIFF
--- a/Entities/Characters/Builder/Builder.cfg
+++ b/Entities/Characters/Builder/Builder.cfg
@@ -95,12 +95,24 @@ f32 sprite_offset_y                               = -4
   u16 sprite_animation_strike_time                = 2
   u8_sprite_animation_strike_loop                 = 1
   @u16 sprite_animation_strike_frames             = 21; 22; 23; 29; 30; 21;
+  
+   # strike_fast
+  $sprite_animation_strike_fast_name              = strike_fast
+  u16 sprite_animation_strike_fast_time           = 2
+  u8_sprite_animation_strike_fast_loop            = 1
+  @u16 sprite_animation_strike_fast_frames        = 21; 23; 30; 21;
 
   # chop
   $sprite_animation_chop_name                   = chop
   u16 sprite_animation_chop_time                = 2
   u8_sprite_animation_chop_loop                 = 1
   @u16 sprite_animation_chop_frames             = 37; 38; 39; 47; 46; 37;
+  
+   # chop_fast
+  $sprite_animation_chop_fast_name              = chop_fast
+  u16 sprite_animation_chop_fast_time           = 2
+  u8_sprite_animation_chop_fast_loop            = 1
+  @u16 sprite_animation_chop_fast_frames        = 37; 39; 47; 37;
   
   # build
   $sprite_animation_build_name                   = build

--- a/Entities/Characters/Builder/BuilderAnim.as
+++ b/Entities/Characters/Builder/BuilderAnim.as
@@ -19,7 +19,7 @@ void onInit(CSprite@ this)
 
 	this.getCurrentScript().runFlags |= Script::tick_not_infire;
 
-	this.getBlob().set_string("prev_attack_anim", "strike");
+	this.getBlob().set_string("prev_attack_anim", getRules().hasTag("faster mining") ? "strike_fast" : "strike");
 }
 
 void onPlayerInfoChanged(CSprite@ this)
@@ -93,7 +93,7 @@ void onTick(CSprite@ this)
 	// set attack animation back to default
 	if (blob.isKeyJustReleased(key_action2))
 	{
-		blob.set_string("prev_attack_anim", "strike");
+		blob.set_string("prev_attack_anim", getRules().hasTag("faster mining") ? "strike_fast" : "strike");
 
 	}
 
@@ -127,7 +127,8 @@ void onTick(CSprite@ this)
 		{
 			this.SetAnimation("crouch");
 		}
-		else if (action2 || ((this.isAnimation("strike") || this.isAnimation("chop")) && !this.isAnimationEnded()))
+		else if (action2 || ((this.isAnimation("strike") || this.isAnimation("chop") || this.isAnimation("strike_fast") 
+				|| this.isAnimation("chop_fast")) && !this.isAnimationEnded()))
 		{
 			string attack_anim = blob.get_string("prev_attack_anim");
 			HitData@ hitdata;
@@ -191,7 +192,14 @@ void onTick(CSprite@ this)
 
 				if (hitting_wood || hitting_stone)
 				{
-					attack_anim = hitting_wood ? "chop" : "strike";
+					if (getRules().hasTag("faster mining"))
+					{
+						attack_anim = hitting_wood ? "chop_fast" : "strike_fast";
+					}
+					else
+					{
+						attack_anim = hitting_wood ? "chop" : "strike";
+					}
 
 					Animation @anim = this.getAnimation(attack_anim);
 
@@ -328,7 +336,9 @@ void onRender(CSprite@ this)
 
 	// draw tile cursor
 
-	if (blob.isKeyPressed(key_action1) || this.isAnimation("strike") || this.isAnimation("chop"))
+	bool strikeAnim = this.isAnimation("strike") || this.isAnimation("strike_fast") || this.isAnimation("chop") || this.isAnimation("chop_fast");
+
+	if (blob.isKeyPressed(key_action1) || strikeAnim)
 	{
 		HitData@ hitdata;
 		blob.get("hitdata", @hitdata);

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -281,7 +281,9 @@ void SetTileAimpos(CBlob@ this, BlockCursor@ bc)
 
 u32 getCurrentBuildDelay(CBlob@ this)
 {
-	return (getRules().getCurrentState() != GAME ? this.get_u32("warmup build delay") : this.get_u32("build delay"));
+	CRules@ rules = getRules();
+	bool should_allow_faster_building = rules.getCurrentState() != GAME || rules.hasTag("faster building");
+	return should_allow_faster_building ? this.get_u32("warmup build delay") : this.get_u32("build delay");
 }
 
 f32 getMaxBuildDistance(CBlob@ this)

--- a/Rules/Sandbox/Scripts/Sandbox_Rules.as
+++ b/Rules/Sandbox/Scripts/Sandbox_Rules.as
@@ -393,6 +393,9 @@ void Reset(CRules@ this)
 
 	kegCount = 0;
 	mineCount = 0;
+	
+	this.Tag("faster building");
+	this.Tag("faster mining");
 }
 
 void onBlobCreated(CRules@ this, CBlob@ blob)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This PR makes changes to allow faster building and mining in Sandbox mode.
This makes sense to me because Sandbox mode should be all about building stuff.

Although `PlacementCommon.as` was changed to not check for rules tag `""faster building""` anymore, I added it back in and added the tag to `Sandbox_Rules.as`.

I noticed `BuilderLogic.as` would list animations `"chop_fast"` and `"strike_fast"` even though they aren't listed in `Builder.cfg`.
So I added them to `Builder.cfg`, reducing the animation time from 12 ticks to 8 ticks each.

If players would prefer the normal speed, maybe we can think about adding a setting to allow both.

Tested in offline and online, works as intended.