### PR TITLE
[fixed] You can't use buttons while stunned anymore

### DIFF
--- a/Entities/Characters/Scripts/KnockedCommon.as
+++ b/Entities/Characters/Scripts/KnockedCommon.as
@@ -70,7 +70,7 @@ u8 getKnockedRemaining(CBlob@ this)
 bool isKnocked(CBlob@ this)
 {
 	if (this.getPlayer() !is null && this.getPlayer().freeze)
-	{	
+	{
 		return true;
 	}
 

--- a/Entities/Characters/Scripts/KnockedCommon.as
+++ b/Entities/Characters/Scripts/KnockedCommon.as
@@ -24,7 +24,7 @@ bool setKnocked(CBlob@ blob, int ticks, bool server_only = false)
 	u8 currentKnockedTime = blob.get_u8(knockedProp);
 	if (knockedTime > currentKnockedTime)
 	{
-		if (getNet().isServer())
+		if (isServer())
 		{
 			blob.set_u8(knockedProp, knockedTime);
 
@@ -32,7 +32,6 @@ bool setKnocked(CBlob@ blob, int ticks, bool server_only = false)
 			params.write_u8(knockedTime);
 
 			blob.SendCommand(blob.getCommandID("knocked"), params);
-
 		}
 
 		if(!server_only && blob.isMyPlayer())
@@ -42,13 +41,13 @@ bool setKnocked(CBlob@ blob, int ticks, bool server_only = false)
 
 		return true;
 	}
-	return false;
 
+	return false;
 }
 
 void KnockedCommands(CBlob@ this, u8 cmd, CBitStream@ params)
 {
-	if (cmd == this.getCommandID("knocked") && getNet().isClient())
+	if (cmd == this.getCommandID("knocked") && isClient())
 	{
 		u8 knockedTime = 0;
 		if (!params.saferead_u8(knockedTime))
@@ -71,9 +70,8 @@ u8 getKnockedRemaining(CBlob@ this)
 bool isKnocked(CBlob@ this)
 {
 	if (this.getPlayer() !is null && this.getPlayer().freeze)
-	{
+	{	
 		return true;
-
 	}
 
 	u8 knockedRemaining = getKnockedRemaining(this);
@@ -108,8 +106,12 @@ void DoKnockedUpdate(CBlob@ this)
 			knockedRemaining--;
 			this.set_u8(knockedProp, knockedRemaining);
 
+			if (this.isMyPlayer())
+			{
+				this.ClearButtons();
+				this.ClearMenus();
+			}
 		}
-
 
 		u16 takekeys;
 		if (knockedRemaining < 2 || (this.hasTag("dazzled") && knockedRemaining < 30))

--- a/Entities/Common/Scripts/GenericButtonCommon.as
+++ b/Entities/Common/Scripts/GenericButtonCommon.as
@@ -1,6 +1,12 @@
+
+#include "KnockedCommon.as";
+
 bool canSeeButtons(CBlob@ this, CBlob@ caller)
 {
-	if ((this is null || caller is null)) { return false; }
+	if (this is null || caller is null || isKnocked(caller))
+	{ 
+		return false; 
+	}
 
 	CInventory@ inv = this.getInventory();
 	return (


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] that you could show "key_use" buttons while stunned
[fixed] that you could keep showing buttons, get stunned and then use them
```
Fixes https://github.com/transhumandesign/kag-base/issues/1951

### Preventing the player from showing new buttons

This PR adds a check to `canSeeButtons()` in `GenericButtonCommon.as` to see if the player is stunned (= knocked).
If the player is stunned, he won't be able to show any blob buttons by using "key_use".
Luckily this seems to work for inventory buttons, too. As far as I understand they are server-handled.
I wasn't able to access inventories after applying this fix.

### Removing already existing buttons

Inside `DoKnockedUpdate()` in `KnockedCommon.as`, I added:
```
if (this.isMyPlayer())
{
	this.ClearButtons();
	this.ClearMenus();
}
```
This causes buttons that already existed due to keeping "key_use" pressed to exit while the player is stunned.

Now the player can't manage inventories, change class or use tunnels while stunned anymore.

Tested in offline and online, works as intended. 

## Steps to Test or Reproduce

Be a knight, `/coins 999`, spawn a knightshop and buy a bunch of waterbombs.
Go to a chest, tent, storage or tunnel (when there are at least 2).
Throw a waterbomb above you.
Try to press or keep pressed the `key_use` key in order to show or keep showing buttons for above mentioned blobs, before or after getting hit by the waterbomb.
Notice you will be able to show and use buttons while stunned.
**After this PR, you won't be able to.**
