### PR TITLE
[added] Trap Block can be placed in Sandbox mode

### DIFF
--- a/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -85,11 +85,6 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int team_num = 0, const stri
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", BuilderCosts::wooden_door);
 		blocks[0].push_back(b);
 	}
-	/*{
-		BuildBlock b(0, "trap_block", getTeamIcon("trap_block", "TrapBlock.png", team_num), "Trap Block\nOnly enemies can pass");
-		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", BuilderCosts::trap_block);
-		blocks[0].push_back(b);
-	}*/
 	{
 		BuildBlock b(0, "bridge", getTeamIcon("bridge", "Bridge.png", team_num), "Trap Bridge\nOnly your team can stand on it");
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", BuilderCosts::bridge);
@@ -144,6 +139,12 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int team_num = 0, const stri
 			b.buildOnGround = true;
 			b.size.Set(40, 24);
 			blocks[0].insertAt(9, b);
+		}
+		
+		{
+			BuildBlock b(0, "trap_block", getTeamIcon("trap_block", "TrapBlock.png", team_num), "Trap Block\nOnly enemies can pass");
+			AddRequirement(b.reqs, "blob", "mat_stone", "Stone", BuilderCosts::trap_block);
+			blocks[0].push_back(b);
 		}
 
 		BuildBlock[] page_1;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[added] Trap block to Sandbox builder blocks
```
Fixes https://github.com/transhumandesign/kag-base/issues/1983

This PR changes `CommonBuilderBlocks.as` to make trap blocks placable once again, but only in Sandbox.
There was one free slot available on the first page of builder's block inventory, so it fits perfectly.
This might raise interest in someday adding it back to other gamemodes.