### PR TITLE
[changed] Seed can be placed on non-static blobs

### DIFF
--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -163,7 +163,7 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 			}
 		}
 
-		if (!isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null)
+		if (!isSeed && !isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null)
 		{
 			return false;
 		}

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -186,7 +186,7 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 
 						Vec2f bpos = b.getPosition();
 
-						bool placingSeedOnNonStaticBlob = isSeed && !b.getShape().isStatic() && b.getName() != "seed";
+						bool placingSeedOnNonStaticBlob = isSeed && !b.getShape().isStatic();
 						bool replacingSeed = isSeed && b.getName() == "seed";
 						bool cantBuild = isBlocking(b);
 						bool buildingOnTeam = isDoor && (b.getTeamNum() == this.getTeamNum() || b.getTeamNum() == 255) && !b.getShape().isStatic() && this !is b;

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -163,7 +163,7 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 			}
 		}
 
-		if (!isSeed && !isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null)
+		if (!isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null)
 		{
 			return false;
 		}
@@ -186,17 +186,20 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 
 						Vec2f bpos = b.getPosition();
 
+						bool placingSeedOnNonStaticBlob = isSeed && !b.getShape().isStatic() && b.getName() != "seed";
+						bool replacingSeed = isSeed && b.getName() == "seed";
 						bool cantBuild = isBlocking(b);
 						bool buildingOnTeam = isDoor && (b.getTeamNum() == this.getTeamNum() || b.getTeamNum() == 255) && !b.getShape().isStatic() && this !is b;
 						bool ladderBuild = isLadder && !b.getShape().isStatic();
 
 						// cant place on any other blob
-						if (!ladderBuild &&
+						if ((!ladderBuild &&
 							!buildingOnTeam &&
-							cantBuild &&
+							(cantBuild && !(placingSeedOnNonStaticBlob)) &&
 							!b.hasTag("dead") &&
 							!b.hasTag("material") &&
 							!b.hasTag("projectile"))
+							|| replacingSeed)
 						{
 							f32 angle_decomp = Maths::FMod(Maths::Abs(b.getAngleDegrees()), 180.0f);
 							bool rotated = angle_decomp > 45.0f && angle_decomp < 135.0f;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
- But please look for odd cases.

## Description
```
[changed] Seed can now be placed on non-static blobs
[fixed] Seed can no longer be placed on another seed
```
Fixes https://github.com/transhumandesign/kag-base/issues/1996

Seed can now be placed on any blob unless it is static.
Therefore you can place seed on a Saw, Dinghy or other blobs that impose a no build area but not on a Building.
Also made it so you cannot place a Seed on another Seed.

Placing seed on a stuck arrow still works.

Briefly verified in offline.