### PR TITLE
[fixed] Text wasn't aligned properly in Builder's block inventory

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -110,7 +110,8 @@ void MakeBlocksMenu(CInventory@ this, const Vec2f &in INVENTORY_CE)
 			BuildBlock@ b = blocks[PAGE][i];
 			if (b is null) continue;
 			string block_desc = getTranslatedString(b.description);
-			CGridButton@ button = menu.AddButton(b.icon, "\n" + block_desc, Builder::make_block + i);
+			block_desc = block_desc.find("\n") != -1 ? "\n" + block_desc : block_desc;
+			CGridButton@ button = menu.AddButton(b.icon, block_desc, Builder::make_block + i);
 			if (button is null) continue;
 
 			button.selectOneOnClick = true;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Single line text in builder's block inventory had an unnecessary linebreak.

## Before

![before](https://github.com/transhumandesign/kag-base/assets/14877281/4d0081df-dd19-4bd9-be10-cb63a9571862)

## After
![after](https://github.com/transhumandesign/kag-base/assets/14877281/0ea3dc6a-db7a-470d-89b8-8e20237e13bd)