### PR TITLE
[fixed] Queue button doesn't turn grey when other player changes team

### DIFF
--- a/Rules/CommonScripts/SpectatorQueue.as
+++ b/Rules/CommonScripts/SpectatorQueue.as
@@ -438,14 +438,11 @@ void onPlayerLeave(CRules@ this, CPlayer@ player)
 
 void onPlayerChangedTeam(CRules@ this, CPlayer@ player, u8 oldteam, u8 newteam)
 {
-	if (newteam == this.getSpectatorTeamNum())
+	if (player.isMyPlayer() && newteam == this.getSpectatorTeamNum())
 	{
-		SetupQueueGUI(this);
-	}
-
-	if (oldteam != this.getSpectatorTeamNum() && player.isMyPlayer()) 
-	{
+		client_selected = -99;
 		hide = true;
+		SetupQueueGUI(this);
 		return;
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Queue button doesn't turn grey when other player changes team
```
Fixes https://github.com/transhumandesign/kag-base/issues/1528

This PR changes code in `SpectatorQueue.as` to fix a bug where the queue button in the top right corner turns grey whenever a different player changes teams. The culprit is the line `client_selected = -99;` in `onPlayerChangedTeam()`.

Since the `newteam == this.getSpectatorTeamNum()` check and the `oldteam != this.getSpectatorTeamNum() && player.isMyPlayer()` check are basicly the same (player changes from red/blue team to spectator), I mixed both code blocks and also moved the line `client_selected = -99;` inside it. `SetupQueueGUI(this);` also should only run if `player.isMyPlayer()` is true.

I tested in a dedicated CTF server with bots. Although the queue logic doesn't work well with bots, when there are enough bots it is possible to queue for one team without instantly entering it, allowing me to test the bug scenario. When queuing for a team and having a bot player change its team, my button previously turned grey but after applying the above fix it doesn't.

The sound for successfully getting entered into a team will still play at the correct time.
It plays only when switching from spectator to red/blue via the queue.

|                      | Current build | After this PR |
| ------------- | ------------- | ------------- |
| Switch from spectator to red/blue via queue  | Sound plays  | Sound plays  |
| Switch from spectator to red/blue via team button while queuing  | Sound doesn't play | Sound doesn't play |
| Switch from red/blue to red/blue   | Sound doesn't play  | Sound doesn't play |
| Switch from red/blue to spectator  | Sound doesn't play  | Sound doesn't play  |