### PR TITLE
[fixed] Sandbox: Non-Builder classes won't receive Wood and Stone after respawning

### DIFF
--- a/Rules/CTF/Scripts/CTF_PickSpawn.as
+++ b/Rules/CTF/Scripts/CTF_PickSpawn.as
@@ -95,7 +95,7 @@ void onTick(CRules@ this)
 //hook after the change has been decided
 void onPlayerChangedTeam(CRules@ this, CPlayer@ player, u8 oldteam, u8 newteam)
 {
-	if (player !is null && player.isMyPlayer() && this.isMatchRunning())
+	if (player !is null && player.isMyPlayer() && this.isMatchRunning() && this.gamemode_name != "Sandbox")
 	{
 		SHOW_MENU = true;
 		RESPAWNS_COUNT = -1;

--- a/Rules/Sandbox/Scripts/Sandbox_Rules.as
+++ b/Rules/Sandbox/Scripts/Sandbox_Rules.as
@@ -163,10 +163,12 @@ shared class SandboxSpawns : RespawnSystem
 				blob.server_Die();
 			}
 
-			if (p_info.blob_name == "") // if user is new
+			// for newly joined player, hard-set blob to builder
+			if (p_info.blob_name == "")
 			{
-				p_info.blob_name = "builder"; //hard-set the respawn blob
+				p_info.blob_name = "builder";
 			}
+
 			CBlob@ playerBlob = SpawnPlayerIntoWorld(getSpawnLocation(p_info), p_info);
 
 			if (playerBlob !is null)
@@ -175,8 +177,15 @@ shared class SandboxSpawns : RespawnSystem
 				RemovePlayerFromSpawn(player);
 
 				// spawn resources
-				SetMaterials(playerBlob, "mat_wood", 500);
-				SetMaterials(playerBlob, "mat_stone", 250);
+				if (p_info.blob_name == "builder")
+				{
+					SetMaterials(playerBlob, "mat_wood", 500);
+					SetMaterials(playerBlob, "mat_stone", 250);
+				}
+				else if (p_info.blob_name == "archer")
+				{
+					SetMaterials(playerBlob, "mat_arrows", 30);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[changed] Sandbox mode hard-sets 500 wood, 250 stone to builder only, instead of all classes
[changed] Sandbox mode hard-sets 30 arrows to archer
[fixed] On first join offline & online, player could receive twice as many materials (1000 wood, 500 stone)
```
Fixes https://github.com/transhumandesign/kag-base/issues/1998

Sandbox mode uses script files `CTF_GiveSpawnItems.as` and `Sandbox_Rules.as`.
The former:
- sets builder to receive 100 wood and 30 stone (on first spawn and every few seconds at respawn locations)
- sets archer to receive 30 wood on every respawn (as an "out of pity" rule)
But the latter overwrites that so
- Player gets their wood and stone changed to 500 wood and 250 stone, regardless what class they are, so archer and knight would receive these materials, too

Because of `void onPlayerChangedTeam(CRules@ this, CPlayer@ player, u8 oldteam, u8 newteam)` in `CTF_PickSpawn.as`, the player could receive twice the amount of materials on their first join, both in online and offline. This is related to an old issue which was fixed by adding check `this.isMatchRunning()`. So it was fixed for all game modes except Sandbox because `this.isMatchRunning()` is already true.

This PR fixes these issues by adding a check `this.gamemode_name != "Sandbox"` to `CTF_PickSpawn.as`.
After applying this fix, I'm only receiving the regular 500 wood and 250 stone.

`Sandbox_Rules.as` now sets materials to 500 wood and 250 stone only for builder and now also sets 30 arrows for archer (so they receive it always in this game mode even if someday the "out of pity" rule in `CTF_GiveSpawnItems.as` were to be removed.

Archer and Knight no longer receive unwanted wood and stone materials.

Because I ran into unnecessary misunderstandings, I changed wording `// if user is new` and `//hard-set the respawn blob` to `// for newly joined player, hard-set blob to builder` and placed it above the lines of code so the programmer can easily see what this code section does.

Tested in offline and online.

## Steps to Test or Reproduce

Join Sandbox.
Receive 1000 wood and 250 stone
**After this PR, you receive the normal amount of 500 wood and 250 stone.**

Change class to Knight, then die and respawn.
Receive 500 wood and 250 stone.
Be annoyed that you have to spend time opening your inventory and throwing these unwanted materials away.
**After this PR, Knight receives nothing. Archer still always receives 30 arrows each respawn.**
