### PR TITLE
[fixed] Archer could continue stabbing or charging Arrow after getting attached

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -83,7 +83,8 @@ void ManageGrapple(CBlob@ this, ArcherInfo@ archer)
 		&& !archer.grappling
 		&& this.isOnGround()
 		&& !this.isKeyPressed(key_action1)
-		&& !this.wasKeyPressed(key_action1))
+		&& !this.wasKeyPressed(key_action1)
+		&& !this.isAttached())
 	{
 		Vec2f aimpos = this.getAimPos();
 		CBlob@[] blobs;
@@ -1214,7 +1215,7 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 void fletchArrow(CBlob@ this)
 {
 	// fletch arrow
-	if (getNet().isServer())
+	if (isServer())
 	{
 		CBlob@ mat_arrows = server_CreateBlobNoInit("mat_arrows");
 		if (mat_arrows !is null)
@@ -1239,6 +1240,16 @@ void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 	if (!this.get("archerInfo", @archer))
 	{
 		return;
+	}
+
+	archer.charge_state = ArcherParams::not_aiming;
+	archer.charge_time = 0;
+	getHUD().SetCursorFrame(0);
+	
+	CSprite@ sprite = this.getSprite();
+	if (sprite !is null)
+	{
+		sprite.SetEmitSoundPaused(true);
 	}
 
 	if (this.isAttached() && canSend(this))


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Archer continued to charge Arrow when sleeping in a quarters
[fixed] Archer's stabbing state could continue after sleeping in a quarters
[fixed] Archer's cursor frame didn't reset when Archer got attached
```

Fixes https://github.com/transhumandesign/kag-base/issues/2024

This PR makes fixes to `ArcherLogic.as` so Archer won't be able to charge Arrows "in their sleep".
It was also possible to press `Action_2` to start stabbing a log, quickly start sleeping, and then Archer would fletch an arrow even when not pressing any keys.

When getting attached while charging, the cursor frame kept the charging meter. After this PR it will reset to indicate there is no charging.

Tested in offline and online.
