### PR TITLE
[added] Suicide chat command

### DIFF
--- a/Rules/CommonScripts/ChatCommands.cfg
+++ b/Rules/CommonScripts/ChatCommands.cfg
@@ -7,6 +7,7 @@ commands =
 	team; 0; 1;
 	coins; 0; 1;
 	heal; 0; 1;
+	suicide; 0; 1;
 	class; 0; 1;
 	wood; 0; 1;
 	stone; 0; 1;

--- a/Rules/CommonScripts/ChatCommands/PlayerCommands.as
+++ b/Rules/CommonScripts/ChatCommands/PlayerCommands.as
@@ -1,4 +1,6 @@
-#include "ChatCommand.as"
+
+#include "ChatCommand.as";
+#include "Hitters.as";
 
 class ClassCommand : ChatCommand
 {
@@ -205,5 +207,30 @@ class HealCommand : ChatCommand
 				}
 			}
 		}
+	}
+}
+
+class SuicideCommand : ChatCommand
+{
+	SuicideCommand()
+	{
+		super("suicide", "Kill yourself");
+		AddAlias("die");
+	}
+
+	void Execute(string[] args, CPlayer@ player)
+	{
+		CBlob@ blob = player.getBlob();
+		if (blob is null)
+		{
+			if (isServer())
+			{
+				server_AddToChat(getTranslatedString("You cannot kill yourself while dead or spectating"), ConsoleColour::ERROR, player);
+			}
+
+			return;
+		}
+
+		blob.server_Hit(blob, blob.getPosition(), blob.getVelocity(), 10.0f, Hitters::suicide);
 	}
 }

--- a/Rules/CommonScripts/DefaultChatCommands.as
+++ b/Rules/CommonScripts/DefaultChatCommands.as
@@ -25,6 +25,7 @@ void RegisterDefaultChatCommands(ChatCommandManager@ manager)
 	manager.RegisterCommand(TeamCommand());
 	manager.RegisterCommand(CoinsCommand());
 	manager.RegisterCommand(HealCommand());
+	manager.RegisterCommand(SuicideCommand());
 
 	//materials
 	manager.RegisterCommand(WoodCommand());


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[added] suicide chat command
```
Fixes https://github.com/transhumandesign/kag-base/issues/2032

This PR adds a suicide chat command.
The command works when typing in chat `/suicide` or `/die` and it kills you just like if you press the suicide button in menu.
I set it to not require `admin only` or `sv_test only`, so it can be used in any gamemode.

Tested in offline and online, no problems encountered.

## Steps to Test or Reproduce

Type in `/suicide` or `/die`, notice your character dies just like if you press the "Suicide" button in the menu.