### PR TITLE
[changed] Pre-loaded Bombs don't despawn in Tutorial level 1

### DIFF
--- a/Rules/Tutorials/Tutorial01.as
+++ b/Rules/Tutorials/Tutorial01.as
@@ -24,9 +24,23 @@ void onInit(CMap@ this)
 	createSign(Vec2f(163, 45) * this.tilesize, "Run at wall and hold jump to WALL RUN.\n\nHOLD $KEY_D$$KEY_W$");
 	createSign(Vec2f(183, 47) * this.tilesize, "Knights can destroy wooden blocks, wooden doors and dig dirt. Point at the wall and jab it to get through $LMB$");
 	createSign(Vec2f(200, 48) * this.tilesize, "Automatically pickup things used by your class.");
-	server_CreateBlob("mat_bombs", 0, Vec2f(205, 43) * this.tilesize);
-	server_CreateBlob("mat_bombs", 0, Vec2f(207, 43) * this.tilesize);
-	server_CreateBlob("mat_bombs", 0, Vec2f(208, 43) * this.tilesize);
+
+	{
+		CBlob@ bomb = server_CreateBlob("mat_bombs", 0, Vec2f(205, 43) * this.tilesize);
+		if (isServer() && bomb !is null)
+			bomb.server_SetTimeToDie(-1.0f);
+	}
+	{
+		CBlob@ bomb = server_CreateBlob("mat_bombs", 0, Vec2f(207, 43) * this.tilesize);
+		if (isServer() && bomb !is null)
+			bomb.server_SetTimeToDie(-1.0f);
+	}
+	{
+		CBlob@ bomb = server_CreateBlob("mat_bombs", 0, Vec2f(208, 43) * this.tilesize);
+		if (isServer() && bomb !is null)
+			bomb.server_SetTimeToDie(-1.0f);
+	}
+
 	createSign(Vec2f(216, 47) * this.tilesize, "Press $KEY_SPACE$ to light bomb\n\nAim with mouse.\n\nAgain $KEY_SPACE$ throw it.");
 	createSign(Vec2f(247, 49) * this.tilesize, "Shield gliding$Tutorial_Glide$\n\n\nJump over the canyon and while in air:\nPoint your cursor upwards\nHOLD $RMB$ for shield.");
 }

--- a/Rules/Tutorials/Tutorial01.as
+++ b/Rules/Tutorials/Tutorial01.as
@@ -27,17 +27,17 @@ void onInit(CMap@ this)
 
 	{
 		CBlob@ bomb = server_CreateBlob("mat_bombs", 0, Vec2f(205, 43) * this.tilesize);
-		if (isServer() && bomb !is null)
+		if (bomb !is null)
 			bomb.server_SetTimeToDie(-1.0f);
 	}
 	{
 		CBlob@ bomb = server_CreateBlob("mat_bombs", 0, Vec2f(207, 43) * this.tilesize);
-		if (isServer() && bomb !is null)
+		if (bomb !is null)
 			bomb.server_SetTimeToDie(-1.0f);
 	}
 	{
 		CBlob@ bomb = server_CreateBlob("mat_bombs", 0, Vec2f(208, 43) * this.tilesize);
-		if (isServer() && bomb !is null)
+		if (bomb !is null)
 			bomb.server_SetTimeToDie(-1.0f);
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[changed] Material bombs don't despawn in tutorial level 1
```

This PR makes it so the three bomb materials in tutorial level 1 don't despawn after 5 minutes.

Because it is possible the player goes afk or spends time in the first half of the level, the bombs could despawn in the meantime and the nearby sign explaining to light and throw a bomb doesn't make sense anymore.

Tested in offline, it works.

----

For testing, you can add `MaterialBomb.as` as a sprite script to `MaterialBomb.cfg` and add this code to `MaterialBomb.as` to render the time until despawning:
```
void onRender(CSprite@ this)
{
	CBlob@ blob = this.getBlob();
	if (blob is null) return;

	GUI::DrawText(blob.getTimeToDie()+"", blob.getScreenPos(), SColor(255,1,255,1));
}
```