### PR TITLE
[fixed] Bison's or vehicle's damage owner did not get unset when sitting player died

### DIFF
--- a/Entities/Vehicles/Common/Seats.as
+++ b/Entities/Vehicles/Common/Seats.as
@@ -67,7 +67,8 @@ void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
 			detached.setAngleDegrees(0.0f);
 		}
 
-		if (detached.getPlayer() is this.getDamageOwnerPlayer()) {
+		if (detached.hasTag("dead") || detached.getPlayer() is this.getDamageOwnerPlayer()) {
+			
 			this.SetDamageOwnerPlayer(null);
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Bison's or vehicle's damage owner did not get unset when sitting player died
```
Fixes https://github.com/transhumandesign/kag-base/issues/2037

When playing online and dying while sitting on a catapult or a bison, the game correctly runs `onDetach()` in `Seats.as`.

However, 
```
		print("detached is null ? " + (detached is null));
		print("detached player is null ? " + (detached.getPlayer() is null));
		print("detached tag dead ? " + (detached.hasTag("dead")));
```
will yield false, false, false on client and false, true, true on server.
Because the player was already null on server, the damage player didn't get unset.
To fix the issue, this PR adds a check if the detached blob has the tag `"dead"`. When this condition is true we know the player must have died and we need to unset the damage owner.

Tested in online, works.

## Steps to Test or Reproduce

Play CTF with bots in a server.
Spawn bison and tame it.
Spawn a bomb and place it in your inventory, then sit on the bison to die while sitting.
Notice how any kills the bison gets now will be attributed to you.
**After this PR, kills are not attributed to you anymore.**
