### PR TITLE
[fixed] use correct ballista texture

### DIFF
--- a/Entities/Vehicles/Ballista/Ballista.cfg
+++ b/Entities/Vehicles/Ballista/Ballista.cfg
@@ -12,7 +12,7 @@ $sprite_factory                            = generic_sprite
 											 FireAnim.as;
 											 HealthBar.as;
 											 VehicleConvert.as;
-$sprite_texture                            = Ballista.png
+$sprite_texture                            = Entities/Vehicles/Ballista/Ballista.png
 s32_sprite_frame_width                     = 40
 s32_sprite_frame_height                    = 40
 f32 sprite_offset_x                        = 0


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Since the engine searches for textures by first match, in place of the correct texture of the ballista is set the texture of the head of one of the player's head. The pull-request fixes this.

Without fix:
![screenshot_2024-04-26_at_20:09:30](https://github.com/transhumandesign/kag-base/assets/64691722/02f32acb-922d-4810-bb2b-bf50ffdaae72)


With fix:
![screenshot_2024-04-26_at_20:10:34](https://github.com/transhumandesign/kag-base/assets/64691722/faefe32c-ba0f-4374-911a-9c39c26a43fc)
