### PR TITLE
[modified & fixed] better bombs (bomb explosion force)

### DIFF
--- a/Entities/Characters/Archer/Archer.cfg
+++ b/Entities/Characters/Archer/Archer.cfg
@@ -178,6 +178,7 @@ $name                                             = archer
 													FleshHitEffects.as;
 													PainSounds.as;
 													KnockBack.as;
+													BombHit.as;
 													DropHeartOnDeath.as;
 													RunnerCollision.as;
 													FallDamage.as;

--- a/Entities/Characters/Builder/Builder.cfg
+++ b/Entities/Characters/Builder/Builder.cfg
@@ -236,6 +236,7 @@ $name                                             = builder
                                                     FleshHitEffects.as;
                                                     PainSounds.as;
                                                     KnockBack.as;
+                                                    BombHit.as;
                                                     DropHeartOnDeath.as;
                                                     RunnerCollision.as;
                                                     FallDamage.as;

--- a/Entities/Characters/Knight/Knight.cfg
+++ b/Entities/Characters/Knight/Knight.cfg
@@ -335,6 +335,7 @@ $name                                             = knight
                                                     IsFlammable.as;
                                                     EmoteHotkeys.as;
                                                     KnockBack.as; #before shieldhit so we still get knocked
+                                                    BombHit.as;
                                                     ShieldHit.as;
                                                     RunnerKnock.as;
                                                     FleshHitEffects.as;

--- a/Entities/Common/Attacks/BombHit.as
+++ b/Entities/Common/Attacks/BombHit.as
@@ -1,0 +1,14 @@
+#include "Hitters.as";
+
+f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
+{
+	if (customData == Hitters::bomb || customData == Hitters::water)
+	{
+		if (this !is null && this.hasTag("player") && isClient())
+		{
+			this.AddForce(velocity);
+		}
+	}
+
+	return damage; 
+}

--- a/Entities/Common/Includes/SplashWater.as
+++ b/Entities/Common/Includes/SplashWater.as
@@ -69,8 +69,8 @@ void Splash(CBlob@ this, const uint splash_halfwidth, const uint splash_halfheig
 				bool hitHard = blob.getTeamNum() != this.getTeamNum() || ownerBlob is blob;
 
 				Vec2f hit_blob_pos = blob.getPosition();
-				f32 scale;
-				Vec2f bombforce = getBombForce(this, radius, hit_blob_pos, pos, blob.getMass(), scale);
+
+				Vec2f bombforce = getBombForce(this, radius, hit_blob_pos, pos, blob.getMass());
 
 				if (shouldStun && (ownerBlob is blob || (this.isOverlapping(blob) && hitHard)))
 				{
@@ -90,7 +90,7 @@ void Splash(CBlob@ this, const uint splash_halfwidth, const uint splash_halfheig
 }
 
 // copied from Explosion.as ...... should be in bombcommon?
-Vec2f getBombForce(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 hit_blob_mass, f32 &out scale)
+Vec2f getBombForceLegacy(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 hit_blob_mass, f32 &out scale)
 {
 	Vec2f offset = hit_blob_pos - pos;
 	f32 distance = offset.Length();
@@ -105,5 +105,28 @@ Vec2f getBombForce(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 h
 	bombforce.y = Maths::Round(bombforce.y);
 	bombforce /= 2.0f;
 	bombforce *= hit_blob_mass * (3.0f) * scale;
+	return bombforce;
+}
+
+f32 getBombDamageScale(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos)
+{
+	Vec2f offset = hit_blob_pos - pos;
+	f32 distance = offset.Length();
+
+	f32 scale = (distance > (radius * 0.7)) ? 0.5f : 1.0f;
+	return scale;
+}
+
+Vec2f getBombForce(CBlob@ this, f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 hit_blob_mass)
+{
+	Vec2f offset = hit_blob_pos - pos;
+	f32 distance = offset.Length();
+	//the force, copy across
+	Vec2f bombforce = offset;
+	bombforce.Normalize();
+	bombforce *= 2.0f;
+	bombforce.y -= 0.2f;
+	bombforce /= 2.0f;
+	bombforce *= hit_blob_mass * (3.0f);
 	return bombforce;
 }

--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -304,7 +304,10 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 {
 	if (customData == Hitters::bomb || customData == Hitters::water)
 	{
-		hitBlob.AddForce(velocity);
+		if (!hitBlob.hasTag("player"))
+		{
+			hitBlob.AddForce(velocity);
+		}
 	}
 }
 
@@ -568,8 +571,8 @@ bool HitBlob(CBlob@ this, Vec2f mapPos, CBlob@ hit_blob, f32 radius, f32 damage,
 	}
 
 	f32 scale;
-	Vec2f bombforce = hit_blob.hasTag("invincible") ? Vec2f_zero : getBombForce(this, radius, hit_blob_pos, pos, hit_blob.getMass(), scale);
-	f32 dam = damage * scale;
+	Vec2f bombforce = hit_blob.hasTag("invincible") ? Vec2f_zero : getBombForce(this, radius, hit_blob_pos, pos, hit_blob.getMass());
+	f32 dam = damage * getBombDamageScale(this, radius, hit_blob_pos, pos);
 
 	//explosion particle
 	makeSmallExplosionParticle(hit_blob_pos);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

1) bomb knockback force is now independent of distance between bomb and player. tested on captains, feels significantly better than vanilla bomb jumps, less weird ping-based timing which can make your bomb jump feel worse 
2) fixed the issue that bomb jumps from right-to-left were on average weaker than from left-to-right due to Maths::Round being dumb 
![obraz](https://github.com/transhumandesign/kag-base/assets/39147836/a536c240-e074-4445-bf18-83369ea5692a)
3) fixed https://github.com/transhumandesign/kag-base/issues/1822 by adding BombHit script and applying velocity from bomb explosions there instead of Explosion.as onHitBlob

