### PR TITLE
[fixed] fix stun, when you jumping on trampoline

### DIFF
--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -35,12 +35,12 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 
 		// better check for trampolines
 		CBlob@[] blobs_around;
-		if (getMap().getBlobsInRadius(this.getPosition(), this.getRadius() * 4, blobs_around)) {
+		if (getMap().getBlobsInRadius(this.getPosition(), this.getRadius() * 4, blobs_around))
+		{
 			for (uint i = 0; i < blobs_around.length; i++)
 			{
 				CBlob@ b = blobs_around[i];
 
-				if (b is null) continue;
 				if (!b.hasTag("no falldamage")) continue;
 
 				Vec2f b_pos = b.getPosition();

--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -33,24 +33,29 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	{
 		bool doknockdown = true;
 
+		// better check for trampolines
+		CBlob@[] blobs_around;
+		if (getMap().getBlobsInRadius(this.getPosition(), this.getRadius() * 4, blobs_around)) {
+			for (uint i = 0; i < blobs_around.length; i++)
+			{
+				CBlob@ b = blobs_around[i];
+
+				if (b is null) continue;
+				if (!b.hasTag("no falldamage")) continue;
+
+				Vec2f b_pos = b.getPosition();
+				Vec2f pos = this.getPosition();
+
+				if (Maths::Abs(b_pos.x - pos.x) > b.getWidth()) continue;
+
+				if (Maths::Abs(b_pos.y - pos.y) > b.getWidth()) continue;
+
+				return;
+			}
+		}
+
 		if (damage > 0.0f)
 		{
-			// check if we aren't touching a trampoline
-			CBlob@[] overlapping;
-
-			if (this.getOverlapping(@overlapping))
-			{
-				for (uint i = 0; i < overlapping.length; i++)
-				{
-					CBlob@ b = overlapping[i];
-
-					if (b.hasTag("no falldamage"))
-					{
-						return;
-					}
-				}
-			}
-
 			if (damage > 0.1f)
 			{
 				this.server_Hit(this, point1, normal, damage, Hitters::fall);
@@ -65,7 +70,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			setKnocked(this, knockdown_time);
 
 		if (!this.hasTag("should be silent"))
-		{				
+		{
 			if (this.getHealth() > damage) //not dead
 				Sound::Play("/BreakBone", this.getPosition());
 			else


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

In the standard situation, when trying to jump on a trampoline for a while, the player gets a stun:
https://github.com/transhumandesign/kag-base/assets/64691722/5728a98d-23bc-4a13-99f9-62967c078928

With the fix, the player will no longer get stun from jumping on the trampoline (including from a lower height)
https://github.com/transhumandesign/kag-base/assets/64691722/22156bef-395f-4181-9d91-003d8e8e8a47

## Steps to Test or Reproduce
1. Build a small pillar of blocks upwards
2. Put the trampoline underneath
3. Climb the pole and jump from it onto the trampoline
4. ...
5. STUN!
