### PR TITLE
[fixed] Builder Queued Hit Fix

### DIFF
--- a/Entities/Characters/Builder/BuilderLogic.as
+++ b/Entities/Characters/Builder/BuilderLogic.as
@@ -86,7 +86,7 @@ void onTick(CBlob@ this)
 	{
 		if (queued_hit !is null && getGameTime() >= queued_hit.scheduled_tick)
 		{
-			HandlePickaxeCommand(this, queued_hit.params);
+			HandlePickaxeCommand(this, queued_hit.blobID, queued_hit.tilepos);
 			this.set("queued pickaxe", null);
 		}
 	}
@@ -531,20 +531,15 @@ bool canHit(CBlob@ this, CBlob@ b, Vec2f tpos, bool extra = true)
 
 class QueuedHit
 {
-	CBitStream params;
+	u16 blobID;
+    Vec2f tilepos;
 	int scheduled_tick;
 }
 
-void HandlePickaxeCommand(CBlob@ this, CBitStream@ params)
+void HandlePickaxeCommand(CBlob@ this, u16 blobID, Vec2f tilepos)
 {
 	PickaxeInfo@ SPI;
 	if (!this.get("spi", @SPI)) return;
-
-	u16 blobID;
-	Vec2f tilepos;
-
-	if (!params.saferead_u16(blobID)) return;
-	if (!params.saferead_Vec2f(tilepos)) return;
 
 	Vec2f blobPos = this.getPosition();
 	Vec2f aimPos = this.getAimPos();
@@ -649,18 +644,24 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 		}
 
+        u16 blobID;
+        Vec2f tilepos;
+
+        if (!params.saferead_u16(blobID) || !params.saferead_Vec2f(tilepos)) return;
+
 		// allow for one queued hit in-flight; reject any incoming one in the
 		// mean time (would only happen with massive lag in legit scenarios)
 		if (getGameTime() - SPI.last_pickaxed < delay)
 		{
 			QueuedHit queued_hit;
-			queued_hit.params = params;
+			queued_hit.blobID = blobID;
+            queued_hit.tilepos = tilepos;
 			queued_hit.scheduled_tick = SPI.last_pickaxed + delay;
 			this.set("queued pickaxe", @queued_hit);
 			return;
 		}
 
-		HandlePickaxeCommand(this, @params);
+		HandlePickaxeCommand(this, blobID, tilepos);
 	}
 }
 

--- a/Entities/Characters/Builder/BuilderLogic.as
+++ b/Entities/Characters/Builder/BuilderLogic.as
@@ -532,7 +532,7 @@ bool canHit(CBlob@ this, CBlob@ b, Vec2f tpos, bool extra = true)
 class QueuedHit
 {
 	u16 blobID;
-    Vec2f tilepos;
+	Vec2f tilepos;
 	int scheduled_tick;
 }
 
@@ -644,10 +644,10 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 		}
 
-        u16 blobID;
-        Vec2f tilepos;
+		u16 blobID;
+		Vec2f tilepos;
 
-        if (!params.saferead_u16(blobID) || !params.saferead_Vec2f(tilepos)) return;
+		if (!params.saferead_u16(blobID) || !params.saferead_Vec2f(tilepos)) return;
 
 		// allow for one queued hit in-flight; reject any incoming one in the
 		// mean time (would only happen with massive lag in legit scenarios)
@@ -655,7 +655,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		{
 			QueuedHit queued_hit;
 			queued_hit.blobID = blobID;
-            queued_hit.tilepos = tilepos;
+			queued_hit.tilepos = tilepos;
 			queued_hit.scheduled_tick = SPI.last_pickaxed + delay;
 			this.set("queued pickaxe", @queued_hit);
 			return;


### PR DESCRIPTION

## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
New logic for queued hits in BuilderLogic.as does not function, causing builders to periodically not break blocks. 

Safe reading a CBitStream after the onCommand hook fails, always reading the values in onCommand and caching them instead of the CBitStream fixes the issue.

Mentioned in issue https://github.com/transhumandesign/kag-base/issues/2065

## Steps to Test or Reproduce
1. Swap to builder
2. Continually break blocks until a swing does not register
