### PR TITLE
[fix] Tilepos on blob hits being set to 0,0 instead of an actual tilepos

### DIFF
--- a/Entities/Characters/Builder/BuilderLogic.as
+++ b/Entities/Characters/Builder/BuilderLogic.as
@@ -367,7 +367,7 @@ void Pickaxe(CBlob@ this)
 		{
 			CBitStream params;
 			params.write_u16(hitdata.blobID);
-			params.write_Vec2f(hitdata.tilepos);
+			params.write_Vec2f(tilepos);
 			this.SendCommand(this.getCommandID("pickaxe"), params);
 
 			// for smaller delay


### PR DESCRIPTION
Unsure what is actually going in the pickaxe code. Hitdata.tilepos only contains data when actually hitting a tile, but tilepos seems to contain the correct position when hitting a blob.

 Another fix could be editing line 610 and use b.getPosition() as suggested by Gingerbeard. 

Will do more testing later.

Credits to @Gingerbeard5773 

Closes #2082 
