### PR TITLE
fix bomb/arrow cycle with item in hand

### DIFF
--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -280,21 +280,20 @@ void onTick(CBlob@ this)
 			if (isTap(this, minimum_ticks))     // tap - put thing in inventory
 			{
 				CBlob@ held = this.getCarriedBlob();
+
+				ControlsCycle@ onCycle;
+				if (this.get("onCycle handle", @onCycle))
+				{
+					CBitStream params;
+					params.write_u16(this.getNetworkID());
+					params.ResetBitIndex();
+
+					onCycle(params);
+				}
+
 				if (held !is null)
 				{
 					this.SendCommand(this.getCommandID("putinheld"));
-				}
-				else
-				{
-					ControlsCycle@ onCycle;
-					if (this.get("onCycle handle", @onCycle))
-					{
-						CBitStream params;
-						params.write_u16(this.getNetworkID());
-						params.ResetBitIndex();
-
-						onCycle(params);
-					}
 				}
 
 				this.ClearMenus();


### PR DESCRIPTION
## Status
- READY: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Before update, the player could hold an item in his hand and switch bomb/shot type at the same time, for now it's broken.
This fix just moving command putinheld to cycle clause, no problems were noticed during testing on localhost and Gruhsha CTF.

It related to issue #2059

## Steps to Test or Reproduce
1. Join in Sandbox/CTF server or host it
2. Change class to knight
3. Spawn via command `/s mat_bombs` four bombs and one water bomb via command `/s mat_waterbombs`
4. Pickup three normal bombs and one water
5. Put fourth bomb in hand
6. Try to press inventory button fast for item cycling
7. ...
8. Cycle is dont work.
