### PR TITLE
[fixed] camera zoom in spectator doesnt using action keys 

### DIFF
--- a/Rules/CommonScripts/Spectator.as
+++ b/Rules/CommonScripts/Spectator.as
@@ -103,7 +103,7 @@ void Spectator(CRules@ this)
 	//scroll to zoom
 	if (timeToScroll <= 0)
 	{
-		if (controls.mouseScrollUp)
+		if (controls.isKeyJustPressed(controls.getActionKeyKey(AK_ZOOMIN)))
 		{
 			timeToScroll = 7;
 			setCinematicEnabled(false);
@@ -117,7 +117,7 @@ void Spectator(CRules@ this)
 				zoomTarget = 2.0f;
 			}
 		}
-		else if (controls.mouseScrollDown)
+		else if (controls.isKeyJustPressed(controls.getActionKeyKey(AK_ZOOMOUT)))
 		{
 			timeToScroll = 7;
 			setCinematicEnabled(false);


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Probably, after adding cinematic camera, while you rebinded keys **ZOOM IN** and **ZOOM OUT** in settings, in spectator team you can zoom in and out only with mouse scroll, because it using hardcoded `controls.mouseScrollUp` and `controls.mouseScrollDown` keys instead of `controls.getActionKeyKey(AK_ZOOMOUT)` and `controls.getActionKeyKey(AK_ZOOMIN)`.

This pull-request fixing it.

## Steps to Test or Reproduce
1. Join on server/single sandbox
2. Change team to spectator
3. Rebind keys ZOOM IN and ZOOM OUT
4. Try to use new binds