### PR TITLE
[fix] Icon offset for new engine PR

### DIFF
--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -109,11 +109,11 @@ void MakeBlocksMenu(CInventory@ this, const Vec2f &in INVENTORY_CE)
 			CBitStream missing;
 			if (hasRequirements(this, b.reqs, missing, not b.buildOnGround))
 			{
-				button.hoverText = block_desc + "\n" + getButtonRequirementsText(b.reqs, false);
+				button.hoverText = block_desc + "\n\n" + getButtonRequirementsText(b.reqs, false);
 			}
 			else
 			{
-				button.hoverText = block_desc + "\n" + getButtonRequirementsText(missing, true);
+				button.hoverText = block_desc + "\n\n" + getButtonRequirementsText(missing, true);
 				button.SetEnabled(false);
 			}
 

--- a/Scripts/Default/DefaultGUI.as
+++ b/Scripts/Default/DefaultGUI.as
@@ -13,7 +13,7 @@ void LoadDefaultGUI()
 		string interaction = "/GUI/InteractionIcons.png";
 		AddIconToken("$NONE$", interaction, Vec2f(32, 32), 9);
 		AddIconToken("$TIME$", interaction, Vec2f(32, 32), 0);
-		AddIconToken("$COIN$", "Sprites/coins.png", Vec2f(16, 16), 1);
+		AddIconToken("$COIN$", "Sprites/coins.png", Vec2f(16, 16), 1, Vec2f(0, -8));
 		AddIconToken("$HEART$", "GUI/HeartNBubble.png", Vec2f(12, 12), 1);
 		AddIconToken("$TEAMS$", "GUI/MenuItems.png", Vec2f(32, 32), 1);
 		AddIconToken("$SPECTATOR$", "GUI/MenuItems.png", Vec2f(32, 32), 19);


### PR DESCRIPTION
This pull request requires engine pr 236 to be merged.

Fixes coins offset
![](https://fs.vamist.dev/41ff04-2tNZ38BUDSNzJ0JF.png)

Add another new line to builder hover text so text does not get blocked by icons
![](https://fs.vamist.dev/ecdf4b-b0ti9hjrZOaSVJVJ.png)


Closes #594