### PR TITLE
[new] Start of voting to kick logging

### DIFF
--- a/Rules/CommonScripts/DefaultVotes.as
+++ b/Rules/CommonScripts/DefaultVotes.as
@@ -156,11 +156,9 @@ class VoteKickFunctor : VoteFunctor
 		{
 			string username = byplayer !is null ? byplayer.getUsername() : " unknown";
 			string voteResult = outcome ? " has successfully voted" : " attempted";
-			
-			string message = username + voteResult + " to kick " + kickplayer.getUsername() + " ("+ kick_reason_string[reasonid] +")";
 
-			// TODO: No way to get IP server side, needs engine change
-			string serverip = "unknown";
+			string message = username + voteResult + " to kick " + kickplayer.getUsername() + " ("+ kick_reason_string[reasonid] +")";
+			string serverip = getNet().sv_current_ip;			
 
 			tcpr("*LOG *MESSAGE=\"" + message + "\" *SERVERNAME=\"" + sv_name + "\" *SERVERIP=\"" + serverip + "\"");
 		}

--- a/Rules/CommonScripts/Report.as
+++ b/Rules/CommonScripts/Report.as
@@ -24,9 +24,6 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 		CPlayer@ baddie = getPlayerByNetworkId(id);
 		if (baddie is null) return;
 
-		string serverip;
-		if (!params.saferead_string(serverip)) return;
-
 		string reason;
 		if (!params.saferead_string(reason)) return;
 
@@ -69,7 +66,7 @@ void onCommand(CRules@ this, u8 cmd, CBitStream @params)
 			//*REPORT *PLAYER="SirSalami" *BADDIE="vik" *COUNT="1" *SERVER="arbitrary server name" *REASON="bullshit fuckery"
 
 			tcpr("*REPORT *PLAYER=\"" + p_name + "\" *BADDIE=\"" + b_name + "\" *COUNT=\"" + this.get_u8(b_name + "_report_count") +
-			"\" *SERVERNAME=\"" + sv_name + "\" *SERVERIP=\"" + serverip + "\" *REASON=\"" + reason + "\"");
+			"\" *SERVERNAME=\"" + sv_name + "\" *SERVERIP=\"" + getNet().sv_current_ip + "\" *REASON=\"" + reason + "\"");
 
 			CBitStream bt;
 			bt.write_u16(player.getNetworkID());

--- a/Rules/CommonScripts/ReportCommon.as
+++ b/Rules/CommonScripts/ReportCommon.as
@@ -45,13 +45,9 @@ bool reportAllowed(CRules@ this, CPlayer@ player, CPlayer@ baddie)
 
 void report(CRules@ this, CPlayer@ player, CPlayer@ baddie, string reason)
 {
-	// TODO: add a way to get this server-side...
-	string serverip = getNet().joined_ip;
-
 	// send report information to server
 	CBitStream report_params;
 	report_params.write_u16(baddie.getNetworkID());
-	report_params.write_string(serverip);
 	report_params.write_string(reason);
 	this.SendCommand(this.getCommandID("report"), report_params);
 }


### PR DESCRIPTION
Add's voting to kick logging that gets sent to bsion.

What the message looks like:
![](https://fs.vamist.dev/8b894c-p70S3YaVoSbaNx96.png)

Known issues:
- Admin forcing to cancel does not call Pass() whatsoever, but forcing to pass does