### PR TITLE
Chicken Breeding Rework

### DIFF
--- a/Entities/Natural/Animals/Chicken/ChickenCommon.as
+++ b/Entities/Natural/Animals/Chicken/ChickenCommon.as
@@ -1,0 +1,2 @@
+const int MAX_CHICKENS = 4;
+const f32 CHICKEN_LIMIT_RADIUS = 80.0f;

--- a/Entities/Natural/Animals/Chicken/Egg.as
+++ b/Entities/Natural/Animals/Chicken/Egg.as
@@ -1,13 +1,15 @@
 
-const int grow_time = 50 * getTicksASecond();
+#include "ChickenCommon.as";
 
-const int MAX_CHICKENS_TO_HATCH = 5;
-const f32 CHICKEN_LIMIT_RADIUS = 120.0f;
+const int GROW_TIME = 20 * getTicksASecond();
+const string CAN_GROW_TIME = "can grow time";
 
 void onInit(CBlob@ this)
 {
 	this.getCurrentScript().tickFrequency = 120;
 	this.addCommandID("hatch client");
+	ResetGrowTime(this);
+	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 }
 
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
@@ -17,31 +19,58 @@ bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 
 void onTick(CBlob@ this)
 {
-	if (isServer() && this.getTickSinceCreated() > grow_time)
+	if (isServer() && getGameTime() > this.get_u32(CAN_GROW_TIME))
 	{
-		int chickenCount = 0;
+		int count = 0;
 		CBlob@[] blobs;
 		this.getMap().getBlobsInRadius(this.getPosition(), CHICKEN_LIMIT_RADIUS, @blobs);
 		for (uint step = 0; step < blobs.length; ++step)
 		{
 			CBlob@ other = blobs[step];
-			if (other.getName() == "chicken")
+			if (other.getName() == "chicken" && !other.isAttached() && !other.isInInventory())
 			{
-				chickenCount++;
+				count++;
 			}
 		}
 
-		if (chickenCount < MAX_CHICKENS_TO_HATCH)
-		{
-			this.server_SetHealth(-1);
-			this.server_Die();
-			server_CreateBlob("chicken", -1, this.getPosition() + Vec2f(0, -5.0f));
+		this.server_SetHealth(-1);
+		this.server_Die();
+		this.SendCommand(this.getCommandID("hatch client"));
 
-			this.SendCommand(this.getCommandID("hatch client"));
+		// Prevent chickens from spawning in blocks
+		CMap@ map = getMap();
+		if (map !is null && count < MAX_CHICKENS)
+		{
+			f32 chicken_radius = 5.0f;
+			Vec2f chicken_height_offset = Vec2f(0, -chicken_radius);
+			Vec2f spawn_pos = this.getPosition() + chicken_height_offset;
+			Vec2f tile_pos = map.getTileSpacePosition(spawn_pos);
+			
+			// Solids in or above our block, abort
+			if (hasSolid(map, tile_pos))
+			{
+				return;
+			}
+
+			bool tiles_left = hasSolid(map, tile_pos + Vec2f(-1, 0));
+			bool tiles_right = hasSolid(map, tile_pos + Vec2f(1, 0));
+
+			// 1 wide gap, abort
+			if (tiles_left && tiles_right)
+			{
+				return;
+			}
+
+			// Check if we need to shift
+			if (tiles_left ^^ tiles_right)
+			{
+				spawn_pos.x = map.getAlignedWorldPos(spawn_pos).x + (tiles_left ? chicken_radius : 2);  // Not sure why these offsets had to be so weird
+			}
+
+			server_CreateBlob("chicken", this.getTeamNum(), spawn_pos + chicken_height_offset);
 		}
 	}
 }
-
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
@@ -53,4 +82,21 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			s.Gib();
 		}
 	}
+}
+
+void onDetach(CBlob@ this, CBlob@ detached, AttachmentPoint@ attachedPoint)
+{
+	ResetGrowTime(this);
+}
+
+void ResetGrowTime(CBlob@ this)
+{
+	this.set_u32(CAN_GROW_TIME, getGameTime() + GROW_TIME);
+}
+
+bool hasSolid(CMap@ map, Vec2f tile_pos)
+{
+	Tile this_tile = map.getTileFromTileSpace(tile_pos);
+	Tile above_tile = map.getTileFromTileSpace(tile_pos + Vec2f(0, -1));
+	return map.isTileSolid(this_tile) || map.hasTileSolidBlobs(this_tile) || map.isTileSolid(above_tile) || map.hasTileSolidBlobs(above_tile);
 }


### PR DESCRIPTION
Chicken breeding changes stemming from discussion on https://github.com/transhumandesign/kag-base/pull/1910. These have been tested on US captains for the past few weeks.

## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

- Chickens no longer use a global variable for sound or egg laying, which led to chickens being unable to breed or make sounds if any chicken was making noise
- Moved shared variables to `ChickenCommon.as`
- Chickens now always breed even if there isn't a player nearby
- Chickens and eggs now ignore other chickens/eggs that are held or in inventories when counting nearby chickens/eggs
- Eggs now prevent hatched chickens from clipping into walls
- Eggs will not hatch a chicken inside of a static blob
- Eggs will not hatch a chicken in a 1-wide gap
- Eggs now reset their hatch time when detached
- Eggs no longer tick when held
- Eggs now always hatch even if they can't spawn a chicken
- Reduced egg hatch time to 20 seconds
- Reduced chicken/egg search radius to 10 blocks
- Chickens will not lay eggs if there are 3 other chickens/eggs nearby
- Eggs will not spawn a chicken when hatching if there are 4 chickens nearby

## Steps to Test or Reproduce

Chickens no longer use a global variable for sound or egg laying, which led to chickens being unable to breed or make sounds if any chicken was making noise

-Set up a chicken coop on one side of the map. Collide repeatedly with a different chicken ~20 blocks away (to make sure there is no overlap). Chickens in coop can still make `Pluck` sound and will continue to lay eggs.

Chickens now always breed even if there isn't a player nearby

- Set up a chicken coop on one side of the map. Walk to other side of map. Chickens will still breed.

Chickens and eggs now ignore other chickens/eggs that are held or in inventories when counting nearby chickens/eggs

- Place 3 chickens on the ground. Have a chicken/egg in your hand/inventory. Chickens will stay lay an egg. Continue with chicken/egg in hand/inventory. Egg will still hatch

Eggs now prevent hatched chickens from clipping into walls

- Place an egg directly against the side of a block or static blob. The chicken will not clip into the wall when hatched
![image](https://github.com/user-attachments/assets/7a4aa719-bfab-4261-a7a5-feaf59d28b73)

Eggs will not hatch a chicken inside of a static blob

- Place an egg in a door or platform. It will not spawn a chicken when it hatches

Eggs will not hatch a chicken in a 1-wide gap

- Place an egg in a 1-wide gap. It will not spawn a chicken when it hatches
![image](https://github.com/user-attachments/assets/1504caf2-234e-445e-8de2-2345cfe17e31)

Eggs now reset their hatch time when detached

- Place an egg on the ground. Pick it up after 10 seconds. It will take ~20 seconds to hatch once dropped (delays occasionally due to tick timings. Egg only ticks every 4 seconds)

Eggs no longer tick when held

- Hold an egg. It will never hatch

Eggs now always hatch even if they can't spawn a chicken

- Place an egg in a 1-wide gap or in a coop with at least 4 chickens. It will not spawn a chicken when it hatches

Reduced egg hatch time to 20 seconds

- Place an egg on the ground. It will hatch in ~20 seconds (repeat of delay note above)

Reduced chicken/egg search radius to 10 blocks

- Create 2 chickens breeders at least 10 blocks apart, 1 that has 10 blocks between the chickens on the top and bottom and one that has 5. The former will continue to drop eggs while the latter will not once there are 2 chickens in the bottom (assuming you only put 2 chickens in the top)

Chickens will not lay eggs if there are 3 other chickens/eggs nearby

- Place 4 chickens in a coop. They will not lay eggs
- Place 2 chickens in a coop. They will lay 2 eggs total and no more

Eggs will not spawn a chicken when hatching if there are 4 chickens nearby

- Place 4 chickens and an egg in a coop. Wait until the egg hatches. There will still only be 4 chickens in the coop

If you added new features and want to explain how to use them, do so here.

Chicken coop:
- Will generate up to 4 chickens, but you need to keep 2 to continue production
![image](https://github.com/user-attachments/assets/d2667b19-3cdb-4746-879f-b3595c364e75)

Simple chicken breeder set up:
- 2 chickens in the top (optional 3rd for slightly faster production)
- Can take all 4 chickens from the collection chamber
![image](https://github.com/user-attachments/assets/1d06f255-8e1b-486b-83be-1ab18ee469c3)

Some useful information to include:

- git branch used: chicken-breeding-rework
- gamemode if relevant: N/A
- specific objects or behaviours affected: chickens, eggs

Follow-Up Recommended Changes:
- Prevent `RegrowPlants.as` from spawning chickens, flowers, and grain. Random full healing or chickens isn't great for competitive gameplay
- Lower chicken health. Chicken shields against archers are stronger than they should be, considering 90% of the time it's an accident. Increased chicken health was also likely a band-aid fix to the next problem
- Change chicken team on pick up and prevent dealing damage to friendly chickens. Prevents teammates from accidentally killing all of your chickens in the coop or when you are holding a chicken. I'd recommend some sort of indicator for team color, I have a rudimentary one that's supposed to be a leg tag. This is also an issue for a lot of team based objects (bombs, boulders, etc)
![image](https://github.com/user-attachments/assets/3500905c-f894-4b2c-8ee9-f9cf8123ccad)
- Potentially rework chickens further. Chickens being more accessible in their current state will exacerbate the trampoline sky tower meta that dominants EU CTF currently. In my mod, I've made chickens have a strong horizontal movement decay to nerf chicken and trampoline combo, and chickens will die if you take any damage while holding them so you can be shot down. On the flip side, I've made their hover stronger and added a double jump mechanic for them to give them more uses. I've also made chickens directly purchasable from the quarters for 50 coins instead of eggs. This incentivizes actually creating a breeder while also reducing the wait time (buying an egg and waiting 50 seconds is a horribly slow payoff when half the time a teammate kills the chicken)
