### PR TITLE
[modified] power grid rendering moved to g_debug 6

### DIFF
--- a/Rules/CommonScripts/MechanismsServer.as
+++ b/Rules/CommonScripts/MechanismsServer.as
@@ -34,7 +34,7 @@ void onTick(CRules@ this)
 
 void onRender(CRules@ this)
 {
-	if(g_debug == 1)
+	if (g_debug == 6)
 	{
 		MapPowerGrid@ grid;
 		if(!this.get("power grid", @grid)) return;


### PR DESCRIPTION
## Status

- **READY**:

## Description

Moves the power grid debug render to slot 6 instead of 1.
The intention is so that g_debug 1 isn't so cluttered and debuggers wont have a red screen when they just want to look at shapes and such.
Slot 6 is unoccupied by anything else so it is perfect.
