### PR TITLE
[changed] Trampoline interaction with Saw & Arrows

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -188,8 +188,8 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 		return false;
 	}
 
-	//flesh blobs & mines have to be fed into the saw part
-	if (blob.hasTag("flesh") || (name == "mine"))
+	//flesh blobs, mines, trampolines and arrows have to be fed into the saw part
+	if (blob.hasTag("flesh") || (name == "mine") || (name == "trampoline") || (name == "arrow"))
 	{
 		Vec2f pos = this.getPosition();
 		Vec2f bpos = blob.getPosition();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[changed] Saw isn't destroyed by Trampoline unless if it falls into it from above
[changed] Own team arrows will not get eaten by Saw except if they are shot at it from above
```

Fixes https://github.com/transhumandesign/kag-base/issues/2161
Fixes https://github.com/transhumandesign/kag-base/issues/2162

This PR aims to open up more strategies by allowing same team Arrows to be shot through Saw from the side or below, and by allowing Saw to bounce on Trampoline without destroying the Trampoline. Enemy team arrows will still collide with and deal damage to Saw if shot from any side.

Unlike suggested in the issues linked above, I think it is ok to have Saw not destroy Trampoline regardless of the team.

Tested in offline and online, works as envisioned.

This PR is based on the current Build 4762.

## Comparison

**Before**
<img src="https://github.com/user-attachments/assets/ff61d35b-b833-4b67-a3ed-e6d6598a97f5" width=50% height=50%>
<img src="https://github.com/user-attachments/assets/ec333f77-fc61-47c9-950c-95ca70e9a05e" width=50% height=50%>
<img src="https://github.com/user-attachments/assets/11de6144-3ba9-43da-97ce-be0c5fe5cd06" width=50% height=50%>

**After**
<img src="https://github.com/user-attachments/assets/70190e56-f39e-47ac-a638-d499f1732d77" width=50% height=50%>
<img src="https://github.com/user-attachments/assets/83decbd5-4b72-40be-98ea-8b95d28e07fd" width=50% height=50%>
<img src="https://github.com/user-attachments/assets/491110e1-bf9c-4922-b4ab-cac89326be34" width=50% height=50%>


