### PR TITLE
[fixed] 7 bugs related to filled bucket

### DIFF
--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -61,8 +61,7 @@ void onTick(CBlob@ this)
 					!occupiedBlob.isKeyPressed(key_inventory)) // prevent splash when doing stuff with inventory
 				{
 					DoSplash(this);
-					if (!(isClient() && isServer()))
-						this.SendCommand(this.getCommandID("splash client"));
+					this.SendCommand(this.getCommandID("splash client"));
 					this.set_u8("water_delay", 30);
 				}
 			}
@@ -93,6 +92,11 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			int id = this.getNetworkID();
 			this.setVelocity(this.getVelocity() + Vec2f(1,0).RotateBy((id * 933) % 360));
 			DepleteWaterCount(this);
+			
+			if (isClient())
+			{
+				SetFrame(this, this.get_u8("filled") > 0);
+			}
 		}
 	}
 
@@ -129,7 +133,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("splash client") && isClient())
+	if (cmd == this.getCommandID("splash client") && isClient() && !isServer())
 	{
 		DoSplash(this);
 	}

--- a/Entities/Items/Bucket/Bucket.cfg
+++ b/Entities/Items/Bucket/Bucket.cfg
@@ -66,7 +66,9 @@ $name                                = bucket
 									   Bucket.as;
 									   Wooden.as;
 									   NoPlayerCollision.as;
-                     DecayIfSpammed;
+									   DecayIfSpammed;
+									   SetDamageToCarrier.as;
+									   SetTeamToCarrier.as
 f32 health                           = 1.0
 # looks & behaviour inside inventory
 $inventory_name                      = Bucket


### PR DESCRIPTION
## Status

- **READY**

## Description
```
[fixed] filled bucket will not splash when destroyed with 1 splash remaining
[fixed] Bucket could only splash once (offline)
[fixed] Bucket sprite did not update when used (online)
[fixed] Bucket sprite did not update when falling in water
[fixed] Bucket sprite did not update when hit by a splash hit
[fixed] Bucket sprite did not update after water count is depleted from spam decay hits
[fixed] Splashing a filled bucket applied force to the wrong team
```
Fixes https://github.com/transhumandesign/kag-base/issues/2068
Fixes https://github.com/transhumandesign/kag-base/issues/2143
Fixes https://github.com/transhumandesign/kag-base/issues/2142
Fixes https://github.com/transhumandesign/kag-base/issues/2164

This PR aims to fix bugs related to splashing a filled bucket.

|  | Current build 4762 | After this PR |
| -------------| -------------| -------------| 
| Using filled bucket in offline | Becomes empty after 1 use  | Can be correctly used 2 times  |
| Bucket collides and turns empty | Sprite doesn't update, still says it's full when it actually isn't | Sprite updates to empty |
| Using a filled bucket from the enemy team | Applies force to your team  | Correctly applies force to the enemy team |
| Destroying a filled bucket with 1 splash remaining  | Doesn't splash | Splashes  |

I renamed `TakeWaterCount()` to `DepleteWaterCount()` to make it clear what the function does.

The bug with destroying a filled bucket with 1 splash remaining happens because server depletes uses to 0 and syncs that to the client. So I check if health is equal to or less than 0 in `DepleteWaterCount()` to check if the bucket is being destroyed, then apply and Sync a new Tag `splash on destroy` so client can check for that and correctly splash. I couldn't come up with a different solution.

Some instances of `this.SendCommand(this.getCommandID("splash client"));` now check if we are playing in offline by checking for `if (!(isClient() && isServer()))`, so client doesn't splash twice at the same time.

Added
```
	   SetDamageToCarrier.as;
	   SetTeamToCarrier.as
```
to blob scripts in Bucket.cfg to fix the issue with applying force on the wrong team.

Setting the frame for the bucket after a splash is now done in `DoSplash()` instead of the now server-only `TakeWaterCount()` / `DepleteWaterCount()` function. As a result, only
```
	if (filled == 0)
	{
		filled = 0;
	}
```
remained, serving no purpose so I removed it.

Tested in offline and online, I witnessed no problems.