### PR TITLE
[fixed] don't pick up your own shot arrows from mid air

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -851,7 +851,7 @@ CBlob@ getPickupArrow(CBlob@ this)
 		for (uint i = 0; i < blobsInRadius.length; i++)
 		{
 			CBlob @b = blobsInRadius[i];
-			if (b.getName() == "arrow")
+			if (b.getName() == "arrow" && b.getShape().isStatic())
 			{
 				return b;
 			}
@@ -1095,19 +1095,16 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		if (arrow !is null/* || spriteArrow*/)
 		{
-			if (arrow !is null)
+			ArcherInfo@ archer;
+			if (!this.get("archerInfo", @archer))
 			{
-				ArcherInfo@ archer;
-				if (!this.get("archerInfo", @archer))
-				{
-					return;
-				}
-				const u8 arrowType = archer.arrow_type;
-				if (arrowType == ArrowType::bomb)
-				{
-					arrow.setPosition(this.getPosition());
-					return;
-				}
+				return;
+			}
+			const u8 arrowType = archer.arrow_type;
+			if (arrowType == ArrowType::bomb)
+			{
+				arrow.setPosition(this.getPosition());
+				return;
 			}
 
 			CBlob@ mat_arrows = server_CreateBlobNoInit('mat_arrows');


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2074

This PR fixes a bug where you could harvest your own arrows in mid air, preventing you from shooting arrows at low charge while grappling from a ceiling. Arrows can now only be harvested if they are static.

This bug only happened in online. Tested and it doesn't happen anymore on a dedicated server.

Removed a duplicate `if (arrow !is null)` check.
