### PR TITLE
[fixed] Don't damage items held by teammates

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -300,7 +300,20 @@ void onTick(CBlob@ this)
 								{
 									continue;
 								}
-
+								
+								// don't hit if carried by teammate
+								if (b.isAttached())
+								{
+									AttachmentPoint@ ap = b.getAttachments().getAttachmentPointByName("PICKUP");
+									
+									if (ap !is null)
+									{
+										CBlob@ occ = ap.getOccupied();
+										
+										if (occ is null || occ.getTeamNum() == this.getTeamNum()) 
+											continue;
+									}
+								}
 
 								if (isServer())
 								{

--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -294,10 +294,23 @@ void Explode(CBlob@ this, f32 radius, f32 damage)
 			if (hit_blob is this)
 				continue;
 
+			// don't hit if carried by teammate
+			if (hit_blob.isAttached())
+			{
+				AttachmentPoint@ ap = hit_blob.getAttachments().getAttachmentPointByName("PICKUP");
+				
+				if (ap !is null)
+				{
+					CBlob@ occ = ap.getOccupied();
+					
+					if (occ is null || occ.getTeamNum() == this.getTeamNum()) 
+						continue;
+				}
+			}
+
 			HitBlob(this, m_pos, hit_blob, radius, damage, hitter, true, should_teamkill);
 		}
 	}
-
 }
 
 void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitBlob, u8 customData)

--- a/Entities/Items/Projectiles/BallistaBolt.as
+++ b/Entities/Items/Projectiles/BallistaBolt.as
@@ -85,13 +85,19 @@ void onTick(CBlob@ this)
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
-
-	CBlob@ carrier = blob.getCarriedBlob();
-
-	if (carrier !is null)
-		if (carrier.hasTag("player")
-		        && (this.getTeamNum() == carrier.getTeamNum() || blob.hasTag("temp blob")))
-			return false;
+	// don't hit if carried by teammate
+	if (blob.isAttached())
+	{
+		AttachmentPoint@ ap = blob.getAttachments().getAttachmentPointByName("PICKUP");
+		
+		if (ap !is null)
+		{
+			CBlob@ occ = ap.getOccupied();
+			
+			if (occ is null || occ.getTeamNum() == this.getTeamNum()) 
+				return false;
+		}
+	}
 
 	return (this.getTeamNum() != blob.getTeamNum() || blob.getShape().isStatic())
 	       && blob.isCollidable();

--- a/Entities/Vehicles/Catapult/Rock.as
+++ b/Entities/Vehicles/Catapult/Rock.as
@@ -24,7 +24,7 @@ Random _r(0xca7a);
 
 void onInit(CBlob@ this)
 {
-	if (getNet().isServer())
+	if (isServer())
 	{
 		this.server_SetTimeToDie(4 + _r.NextRanged(2));
 	}
@@ -97,13 +97,19 @@ void MakeRockDustParticle(Vec2f pos, string file, Vec2f vel=Vec2f(0.0, 0.0), int
 
 bool canHitBlob(CBlob@ this, CBlob@ blob)
 {
-
-	CBlob@ carrier = blob.getCarriedBlob();
-
-	if (carrier !is null)
-		if (carrier.hasTag("player")
-		        && (this.getTeamNum() == carrier.getTeamNum() || blob.hasTag("temp blob")))
-			return false;
+	// don't hit if carried by teammate
+	if (blob.isAttached())
+	{
+		AttachmentPoint@ ap = blob.getAttachments().getAttachmentPointByName("PICKUP");
+		
+		if (ap !is null)
+		{
+			CBlob@ occ = ap.getOccupied();
+			
+			if (occ is null || occ.getTeamNum() == this.getTeamNum()) 
+				return false;
+		}
+	}
 
 	return (this.getTeamNum() != blob.getTeamNum() || blob.getShape().isStatic())
 	       && !blob.hasTag("invincible");


### PR DESCRIPTION
## Status

- **ON HOLD**
- I have to test for keg and ballista bomb bolts.

## Description
```
[changed/fixed] Rocks from own catapult don't hurt item held by teammate
[changed/fixed] Ballista Bolt from own ballista doesn't hurt item held by teammate
[changed/fixed] Own Drill doesn't hurt item held by teammate
[changed/fixed] Own Bomb explosion doesn't hurt item held by teammate
```

Fixes https://github.com/transhumandesign/kag-base/issues/2170
Might fix some symptoms described here https://github.com/transhumandesign/kag-base/issues/1267

This PR makes it so own damage sources (bomb explosion, drill, ballista bolt, catapult rocks) don't hurt own held items (log, fishy, chicken, enemy corpse, enemy crate, etc.).

I removed this code from `Rock.as` and `BallistaBolt.as`:
```
	CBlob@ carrier = blob.getCarriedBlob();

	if (carrier !is null)
		if (carrier.hasTag("player")
		        && (this.getTeamNum() == carrier.getTeamNum() || blob.hasTag("temp blob")))
			return false;
```
This code doesn't seem to serve any purpose. It basicly means, if blue player A holds red player B, then player A doesn't take damage from red catapult rocks. The only time a player can hold another player is when they are dead, but then they get untagged `"player"` so this code never even runs. Let me know if it does serve any purpose, though.

Tested in offline, should work in online.

## Reproduction

You can put a chicken in your catapult, then try to drill it or place a bomb or shoot with another catapult at it.
Prior to this PR, it takes damage, after this PR it doesn't.