### PR TITLE
[added] TDM shop can be destroyed

### DIFF
--- a/Entities/Industry/Trading/Trader.as
+++ b/Entities/Industry/Trading/Trader.as
@@ -2,9 +2,7 @@
 
 #include "RunnerCommon.as"
 #include "Help.as";
-
 #include "Hitters.as";
-
 #include "TraderWantedList.as";
 
 //trader methods
@@ -23,25 +21,6 @@ void onInit(CBlob@ this)
 	this.getCurrentScript().runFlags |= Script::tick_moving;
 
 	//EnsureWantedList();
-}
-
-void onReload(CSprite@ this)
-{
-	this.getConsts().filename = this.getBlob().getSexNum() == 0 ?
-	                            "Entities/Special/WAR/Trading/TraderMale.png" :
-	                            "Entities/Special/WAR/Trading/TraderFemale.png";
-}
-
-void onGib(CSprite@ this)
-{
-	CBlob@ blob = this.getBlob();
-	Vec2f pos = blob.getPosition();
-	Vec2f vel = blob.getVelocity();
-	vel.y -= 3.0f;
-	f32 hp = Maths::Min(Maths::Abs(blob.getHealth()), 2.0f) + 1.0;
-	CParticle@ Gib1     = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp , 80), 0, 0, Vec2f(16, 16), 2.0f, 20, "/BodyGibFall");
-	CParticle@ Gib2     = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp - 0.2 , 80), 1, 0, Vec2f(16, 16), 2.0f, 20, "/BodyGibFall");
-	CParticle@ Gib3     = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp , 80), 2, 0, Vec2f(16, 16), 2.0f, 0, "/BodyGibFall");
 }
 
 void onHealthChange(CBlob@ this, f32 oldHealth)
@@ -95,8 +74,18 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	return damage;
 }
 
-
 //sprite/anim update
+void onInit(CSprite@ this)
+{
+	//gender
+	CBlob@ blob = this.getBlob();
+	if (blob !is null && blob.exists("sex num"))
+	{
+		blob.setSexNum(blob.get_u8("sex num"));
+		SetFilename(this);
+		this.ReloadSprite(this.getConsts().filename);
+	}
+}
 
 void onTick(CSprite@ this)
 {
@@ -142,4 +131,28 @@ void onTick(CSprite@ this)
 	{
 		this.SetAnimation("default");
 	}
+}
+
+void onReload(CSprite@ this)
+{
+	SetFilename(this);
+}
+
+void onGib(CSprite@ this)
+{
+	CBlob@ blob = this.getBlob();
+	Vec2f pos = blob.getPosition();
+	Vec2f vel = blob.getVelocity();
+	vel.y -= 3.0f;
+	f32 hp = Maths::Min(Maths::Abs(blob.getHealth()), 2.0f) + 1.0;
+	CParticle@ Gib1     = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp , 80), 0, 0, Vec2f(16, 16), 2.0f, 20, "/BodyGibFall");
+	CParticle@ Gib2     = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp - 0.2 , 80), 1, 0, Vec2f(16, 16), 2.0f, 20, "/BodyGibFall");
+	CParticle@ Gib3     = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp , 80), 2, 0, Vec2f(16, 16), 2.0f, 0, "/BodyGibFall");
+}
+
+void SetFilename(CSprite@ this)
+{
+		this.getConsts().filename = this.getBlob().getSexNum() == 0 ?
+	                            "Entities/Special/WAR/Trading/TraderMale.png" :
+	                            "Entities/Special/WAR/Trading/TraderFemale.png";
 }

--- a/Entities/Industry/Trading/TradingPost.as
+++ b/Entities/Industry/Trading/TradingPost.as
@@ -13,7 +13,9 @@ void onInit(CBlob@ this)
 	if (sprite !is null)
 	{
 		sprite.SetZ(-50.0f);   // push to background
-		string sex = traderRandom.NextRanged(2) == 0 ? "TraderMale.png" : "TraderFemale.png";
+		u8 trader_sex_num = this.getNetworkID() % 2;
+		string sex = (trader_sex_num == 0) ? "TraderMale.png" : "TraderFemale.png";
+		this.set_u8("trader sex num", trader_sex_num);
 		CSpriteLayer@ trader = sprite.addSpriteLayer("trader", sex, 16, 16, 0, 0);
 		trader.SetRelativeZ(20);
 		Animation@ stop = trader.addAnimation("stop", 1, false);
@@ -30,12 +32,9 @@ void onInit(CBlob@ this)
 		this.set_bool("moving left", false);
 		this.set_u32("move timer", getGameTime() + (traderRandom.NextRanged(5) + 5)*getTicksASecond());
 		this.set_u32("next offset", traderRandom.NextRanged(16));
-
 	}
-
 	//TODO: set shop type and spawn trader based on some property
 }
-
 
 
 //Sprite updates
@@ -97,9 +96,7 @@ void onTick(CSprite@ this)
 			trader.SetAnimation("stop");
 
 		}
-
 	}
-
 }
 
 f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
@@ -110,18 +107,41 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	} //no griffing
 
 	this.Damage(damage, hitterBlob);
-
+	
 	return 0.0f;
 }
 
 
 void onHealthChange(CBlob@ this, f32 oldHealth)
 {
-	CSprite @sprite = this.getSprite();
-
-	if (oldHealth > 0.0f && this.getHealth() < 0.0f)
+	// destructible in TDM and Sandbox only
+	CRules@ rules = getRules();
+	bool TDM = rules.gamemode_name == "Team Deathmatch";
+	bool SBX = rules.gamemode_name == "Sandbox";
+	
+	if (!TDM && !SBX)
+		return;
+	
+	if (oldHealth > 0.0f && this.getHealth() <= 0.0f)
 	{
-		MakeDustParticle(this.getPosition(), "Smoke.png");
-		this.getSprite().PlaySound("/BuildingExplosion");
+		// spawn trader that can be killed
+		if (this.exists("trader sex num"))
+		{
+			CBlob@ trader = server_CreateBlobNoInit("trader");
+			trader.set_u8("sex num", this.get_u8("trader sex num"));
+			trader.setPosition(this.getPosition());
+		}
+	
+		// destroy building
+		this.server_Die();
 	}
+}
+
+void onDie(CBlob@ this)
+{
+	MakeDustParticle(this.getPosition(), "Smoke.png");
+		
+	CSprite@ sprite = this.getSprite();
+	sprite.PlaySound("/BuildingExplosion");
+	sprite.Gib();
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2027

This PR makes it so TradingPost of the other team can be destroyed (only in Sandbox and in TDM).
When destroyed, it spawns a trader of the same gender as the spritelayer that can be killed.

I made it so gender of the spritelayer depends on Network ID so it is the same for everyone and nobody will say 
"I killed the trader woman"
"Weird, it's a male trader for me"

Also fixed a check in `onHealthChange()`, from `if (oldHealth > 0.0f && this.getHealth() < 0.0f)` to `if (oldHealth > 0.0f && this.getHealth() <= 0.0f)`.

Tested in offline and online, no problems found.

https://github.com/user-attachments/assets/a3bf6c9d-39d8-4736-9ea2-9d4a8aaca3e2

## Remaining Issues

Some maps have blue trading post in the center, so only red team could damage it. Those maps would need to be changed to have a trading post that isn't team 0 or 1. Or we could allow hits to be processed regardless if it's the same team.
TDM shop might be destroyed too quickly, so health could be increased or attack's damage lowered.
Overall, I'm satisfied though.

