### PR TITLE
Command Quality of Life

### DIFF
--- a/Rules/CommonScripts/ChatCommandCommon.as
+++ b/Rules/CommonScripts/ChatCommandCommon.as
@@ -1,3 +1,5 @@
+const string[] prefixes = {"/", "!"};
+
 namespace ChatCommands
 {
 	ChatCommandManager@ getManager()
@@ -16,9 +18,9 @@ namespace ChatCommands
 		ChatCommands::getManager().RegisterCommand(command);
 	}
 
-	string getPrefix()
+	string[] getPrefixes()
 	{
-		return "/";
+		return prefixes;
 	}
 }
 
@@ -102,6 +104,6 @@ void CommandNotImplemented(string name, CPlayer@ player)
 	}
 	else
 	{
-		print("Unable to execute " + ChatCommands::getPrefix() + name + " command because it is not implemented", ConsoleColour::ERROR);
+		print("Unable to execute " + ChatCommands::getPrefixes()[0] + name + " command because it is not implemented", ConsoleColour::ERROR);
 	}
 }

--- a/Rules/CommonScripts/ChatCommandManager.as
+++ b/Rules/CommonScripts/ChatCommandManager.as
@@ -61,7 +61,7 @@ class ChatCommandManager
 
 		if (commandNames.size() > 0)
 		{
-			string prefix = ChatCommands::getPrefix();
+			string prefix = ChatCommands::getPrefixes()[0];
 			print("Loaded chat commands: " + prefix + join(commandNames, ", " + prefix), ConsoleColour::CRAZY);
 		}
 		else
@@ -106,13 +106,24 @@ class ChatCommandManager
 
 	bool processCommand(string text, ChatCommand@ &out command, string[] &out args)
 	{
-		text = text.toLower();  // Ignore case
+		// Match against known command prefixes
+		string prefixMatch;
+		const string[] prefixes = ChatCommands::getPrefixes();
+		for (uint i = 0; i < prefixes.size(); ++i)
+		{
+			if (text.substr(0, prefixes[i].size()) == prefixes[i])
+			{
+				prefixMatch = prefixes[i];
+				break;
+			}
+		}
 
-		string prefix = ChatCommands::getPrefix();
-		if (text.substr(0, prefix.size()) != prefix && text.substr(0, 1) != "!") return false;  // Allow ! instead of /
+		if (prefixMatch == "") { return false; }
 
-		string name = text.substr(1, 1);
-		if (name == "" || name == " ") return false;
+		string textNoPrefix = text.substr(1);
+
+		string firstLetter = textNoPrefix.substr(1, 1);
+		if (firstLetter == "" || firstLetter == " ") { return false; }
 
 		ChatCommand@[] commands = isServer() ? getEnabledCommands() : allCommands;
 		for (uint i = 0; i < commands.size(); i++)
@@ -122,7 +133,7 @@ class ChatCommandManager
 			for (uint j = 0; j < command.aliases.size(); j++)
 			{
 				string alias = command.aliases[j];
-				string aliasCandidate = text.substr(1, alias.size() + 1).toLower();
+				string aliasCandidate = textNoPrefix.substr(0, alias.size() + 1).toLower();
 				if (aliasCandidate == alias || aliasCandidate == alias + " ")
 				{
 					args = aliasCandidate == alias ? array<string>() : text.substr(alias.size() + 2).split(" ");

--- a/Rules/CommonScripts/ChatCommandManager.as
+++ b/Rules/CommonScripts/ChatCommandManager.as
@@ -106,9 +106,9 @@ class ChatCommandManager
 
 	bool processCommand(string text, ChatCommand@ &out command, string[] &out args)
 	{
-        text = text.toLower();  // Ignore case
+		text = text.toLower();  // Ignore case
 
-        string prefix = ChatCommands::getPrefix();
+		string prefix = ChatCommands::getPrefix();
 		if (text.substr(0, prefix.size()) != prefix && text.substr(0, 1) != "!") return false;  // Allow ! instead of /
 
 		string name = text.substr(1, 1);
@@ -131,6 +131,6 @@ class ChatCommandManager
 			}
 		}
 
-        return processCommand("/spawn " + text.substr(1), command, args);  // Default to spawn command
+		return processCommand("/spawn " + text.substr(1), command, args);  // Default to spawn command
 	}
 }

--- a/Rules/CommonScripts/ChatCommandManager.as
+++ b/Rules/CommonScripts/ChatCommandManager.as
@@ -106,8 +106,10 @@ class ChatCommandManager
 
 	bool processCommand(string text, ChatCommand@ &out command, string[] &out args)
 	{
-		string prefix = ChatCommands::getPrefix();
-		if (text.substr(0, prefix.size()) != prefix) return false;
+        text = text.toLower();  // Ignore case
+
+        string prefix = ChatCommands::getPrefix();
+		if (text.substr(0, prefix.size()) != prefix && text.substr(0, 1) != "!") return false;  // Allow ! instead of /
 
 		string name = text.substr(1, 1);
 		if (name == "" || name == " ") return false;
@@ -129,6 +131,6 @@ class ChatCommandManager
 			}
 		}
 
-		return false;
+        return processCommand("/spawn " + text.substr(1), command, args);  // Default to spawn command
 	}
 }

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -160,7 +160,7 @@ class SpawnCommand : BlobCommand
 		//invalid blobs will have 'broken' names
 		if (newBlob is null || newBlob.getName() != blobName)
 		{
-			server_AddToChat(getTranslatedString("Blob '{BLOB}' not found").replace("{BLOB}", blobName), ConsoleColour::ERROR, player);
+			server_AddToChat(getTranslatedString("Blob '{BLOB}' not found. See /help for details.").replace("{BLOB}", blobName), ConsoleColour::ERROR, player);
 		}
 	}
 }

--- a/Rules/CommonScripts/ChatCommands/MiscCommands.as
+++ b/Rules/CommonScripts/ChatCommands/MiscCommands.as
@@ -23,7 +23,7 @@ class HelpCommand : ChatCommand
 			for (uint i = 0; i < command.aliases.size(); i++)
 			{
 				string alias = command.aliases[i];
-				string cmdName = ChatCommands::getPrefix() + alias;
+				string cmdName = ChatCommands::getPrefixes()[0] + alias;
 				if (command.usage != "")
 				{
 					cmdName += " " + command.usage;


### PR DESCRIPTION
Quality of life improvements for the new command system. Allow syntax prior to the command rework. Tested on my balance mod since the command rework was added.

## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Address some common issues when using commands. Makes the following changes:
- Ignore character case when using commands
- Allow ! instead of / when using commands
- Default to the spawn command if no other command matches

## Steps to Test or Reproduce

1. Enable commands by setting sv_test to 1
2. Type !Keg to spawn a keg

git branch used: https://github.com/mehwaffle10/kag-base/tree/command-qol
