### PR TITLE
[added] Indicator that shows how much gold is in your team's inventories

### DIFF
--- a/Entities/Materials/Construction/MaterialGold.as
+++ b/Entities/Materials/Construction/MaterialGold.as
@@ -28,7 +28,10 @@ void onRender(CSprite@ this)
 	if (localBlob is null) return;
 
 	CBlob@ invBlob = blob.getInventoryBlob();
-	if (invBlob is null || localBlob.getTeamNum() != invBlob.getTeamNum() || localBlob is invBlob) return;
+	if (invBlob is null 
+		|| localBlob.getTeamNum() != invBlob.getTeamNum() 
+		|| localBlob is invBlob
+		|| invBlob.getName() == "storage") return;
 
 	Vec2f pos2d = blob.getScreenPos();
 
@@ -39,7 +42,12 @@ void onRender(CSprite@ this)
 		Vec2f textDim;
 		GUI::GetTextDimensions(goldCount, textDim);
 		
-		u16 offset_x = invBlob.getInitialHealth() * 2 * 12;
+		u16 offset_x = 0;
+		
+		if (invBlob.hasTag("player"))
+		{
+			offset_x = invBlob.getInitialHealth() * 2 * 12;
+		}
 		
 		Vec2f tl(pos2d.x - 6 + offset_x, pos2d.y + 4);
 		Vec2f textPos(pos2d.x + 18 + offset_x, pos2d.y + 8);

--- a/Entities/Materials/Construction/MaterialGold.as
+++ b/Entities/Materials/Construction/MaterialGold.as
@@ -14,4 +14,37 @@ void onInit(CBlob@ this)
   this.maxQuantity = 50;
 
   this.getCurrentScript().runFlags |= Script::remove_after_this;
+
+  AddIconToken("$Gold_Indicator$", "Materials.png", Vec2f(16, 16), 10);
+}
+
+void onRender(CSprite@ this)
+{
+	// show gold in friendly inventories
+	CBlob@ blob = this.getBlob();
+	if (blob is null || !blob.isOnScreen() || !blob.isInInventory()) return;
+
+	CBlob@ localBlob = getLocalPlayerBlob();
+	if (localBlob is null) return;
+
+	CBlob@ invBlob = blob.getInventoryBlob();
+	if (invBlob is null || localBlob.getTeamNum() != invBlob.getTeamNum() || localBlob is invBlob) return;
+
+	Vec2f pos2d = blob.getScreenPos();
+
+	if (!getHUD().hasButtons())
+	{
+		string goldCount = "" + invBlob.getBlobCount("mat_gold");
+		
+		Vec2f textDim;
+		GUI::GetTextDimensions(goldCount, textDim);
+		
+		u16 offset_x = invBlob.getInitialHealth() * 2 * 12;
+		
+		Vec2f tl(pos2d.x - 6 + offset_x, pos2d.y + 4);
+		Vec2f textPos(pos2d.x + 18 + offset_x, pos2d.y + 8);
+	
+		GUI::DrawText("$Gold_Indicator$", tl, tl, color_white, true, true, false);
+		GUI::DrawText(goldCount, textPos, textPos, color_white, true, true, false);
+	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[added] Indicator that shows how much gold is in friendly inventories
```

Fixes https://github.com/transhumandesign/kag-base/issues/2066

This PR adds a feature to indicate gold in your teammates' inventories as well as friendly Crates, Dinghies, Outposts, etc.

The blobs not showing gold are:
- you
- any blob that isn't from your team
- storage (because it already indicates if it has gold)

This is so you quickly know where your team's gold is and people can't grief by hiding gold in their inventory.

The gold indicator will be shown to the right of the health bar. It looks like this:


<img src="https://github.com/user-attachments/assets/80e62b5f-0d99-415a-bc6b-1f520f09d98d" width=85% height=85%>
<img src="https://github.com/user-attachments/assets/73c2c1c9-fc8a-4db5-87b9-0d6b37e336d0" width=50% height=50%>

For players, the indicator will shift to the right the more hearts they have.


<img src="https://github.com/user-attachments/assets/1547e8ed-e6c8-47c4-b75c-31040eff8f90" width=85% height=85%>

I have tested it in offline mostly, only a little in online but it looks to be working the same.