### PR TITLE
[fixed] You no longer can take fall damage twice on the same tick

### DIFF
--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -17,7 +17,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 	if (!solid 
 		|| this.isInInventory()
 		|| this.hasTag("invincible")
-		|| (this.exists("last fall hit") && this.get_u16("last fall hit") == getGameTime()))
+		|| (this.exists("last fall hit") && this.get_u32("last fall hit") == getGameTime()))
 	{
 		return;
 	}
@@ -57,7 +57,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			if (damage > 0.1f)
 			{
 				this.server_Hit(this, point1, normal, damage, Hitters::fall);
-				this.set_u16("last fall hit", getGameTime()); // fixes bug of this code running twice in the same tick
+				this.set_u32("last fall hit", getGameTime()); // fixes bug of this code running twice in the same tick
 			}
 			else
 			{

--- a/Entities/Common/Movement/FallDamage.as
+++ b/Entities/Common/Movement/FallDamage.as
@@ -14,7 +14,10 @@ void onInit(CBlob@ this)
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)
 {
-	if (!solid || this.isInInventory() || this.hasTag("invincible"))
+	if (!solid 
+		|| this.isInInventory()
+		|| this.hasTag("invincible")
+		|| (this.exists("last fall hit") && this.get_u16("last fall hit") == getGameTime()))
 	{
 		return;
 	}
@@ -54,11 +57,14 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			if (damage > 0.1f)
 			{
 				this.server_Hit(this, point1, normal, damage, Hitters::fall);
+				this.set_u16("last fall hit", getGameTime()); // fixes bug of this code running twice in the same tick
 			}
 			else
 			{
 				doknockdown = false;
 			}
+			
+			
 		}
 
 		if (doknockdown)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

```
[fixed] You no longer can take fall damage twice on the same tick
```

Fixes https://github.com/transhumandesign/kag-base/issues/2183

When applying the fall damage hit in `FallDamage.as`, the game time is saved to the blob.
At the beginning of `onCollision()` the code drops out if it detects that it's the same tick again so it doesn't apply the hit twice.

I'm not sure why it happens in the first place. This is just a simple fix I came up with. Of course it could be worth looking for the root of the problem.

Tested in offline and online, works correctly. 

## Reproduction
Build a construction like in the screenshot from the issue linked above.
You have to be standing on a corner with the block being on your left or right side of the character.
When getting bounced down, you are taking two hits for 1 heart of total damage. **After this PR, it is only one hit for a total of 0.5 hearts damage**

