### PR TITLE
[fixed] Couldn't swap ballista ammo in offline

### DIFF
--- a/Entities/Vehicles/Common/Vehicle.as
+++ b/Entities/Vehicles/Common/Vehicle.as
@@ -166,7 +166,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		this.SendCommand(this.getCommandID("swap_ammo_client"));
 	}
-	else if (cmd == this.getCommandID("swap_ammo_client") && isClient())
+	else if (cmd == this.getCommandID("swap_ammo_client") && isClient() && !isServer())
 	{
 		u8 ammoIndex = v.current_ammo_index + 1;
 		if (ammoIndex >= v.ammo_types.size())


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Couldn't swap ballista ammo in offline
```

Fixes https://github.com/transhumandesign/kag-base/issues/2173

This PR fixes that you couldn't switch from regular ballista bolts to bomb bolts in offline.
In fact, although it visually looks like nothing happens when you press the inventory key, the game actually changes the ammo twice.

**Vehicle.as**
```
void onCommand(CBlob@ this, u8 cmd, CBitStream @params)

...

/// SWAP AMMO
	else if (cmd == this.getCommandID("swap_ammo") && isServer())
	{
		CPlayer@ p = getNet().getActiveCommandPlayer();
		if (p is null) return;

		CBlob@ b = p.getBlob();
		if (b is null) return;

		// don't swap ammo if only 1 ammo type
		if (v.ammo_types.size() <= 1) return;

		// don't swap ammo mid-charge
		if (v.charge > 0) return;

		// attached checks
		CAttachment@ ca = this.getAttachments();
		if (ca is null) return;
		AttachmentPoint@ ap = ca.getAttachmentPointByName("GUNNER");
		if (ap is null) return;
		CBlob@ attachedblob = ap.getOccupied();
		if (attachedblob is null) return;
		if (attachedblob !is b) return;

		u8 ammoIndex = v.current_ammo_index + 1;
		if (ammoIndex >= v.ammo_types.size())
		{
			ammoIndex = 0;
		}
		v.current_ammo_index = ammoIndex;

		this.SendCommand(this.getCommandID("swap_ammo_client"));
	}
	else if (cmd == this.getCommandID("swap_ammo_client") && isClient())
	{
		u8 ammoIndex = v.current_ammo_index + 1;
		if (ammoIndex >= v.ammo_types.size())
		{
			ammoIndex = 0;
		}
		v.current_ammo_index = ammoIndex;
	}

...
```

On a server, the command `swap_ammo` is run, some checks are done and if successful, it changes ammo on server and sends command for client to change ammo on client.
But in offline, `isServer()` and `isClient()` are both true so `swap_ammo` increments the index and `swap_ammo_client` increments it again, making it 0 again.
The problem is fixed by adding a check `&& !isServer()` to `swap_ammo_client`.

Tested in offline and online, the ammo gets swapped properly in both.
