### PR TITLE
[fixed/changed] Ladders placed next to waterfalls won't decay

### DIFF
--- a/Rules/CommonScripts/WaterDecaysDoors.as
+++ b/Rules/CommonScripts/WaterDecaysDoors.as
@@ -60,12 +60,25 @@ void onTick(CRules@ this)
 		}
 
 		Vec2f pos = b.getPosition();
-		Vec2f[] postocheck =
+		
+		CShape@ shape = b.getShape();
+		if (shape is null) continue;
+		
+		ShapeConsts@ consts = shape.getConsts();
+		if (consts is null) continue;
+
+		Vec2f[] postocheck;
+
+		postocheck.push_back(pos);
+
+		if (!consts.waterPasses)
 		{
-			pos + Vec2f(map.tilesize, 0),
-			pos + Vec2f(-map.tilesize, 0),
-			pos + Vec2f(0, -map.tilesize)
-		};
+			// check left, top and right
+			postocheck.push_back(pos + Vec2f(map.tilesize, 0));
+			postocheck.push_back(pos + Vec2f(-map.tilesize, 0));
+			postocheck.push_back(pos + Vec2f(0, -map.tilesize));
+		}
+
 		bool water = false;
 		for (uint j = 0; j < postocheck.length; j++)
 		{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed/changed] Ladder decays next to waterfalls even though it doesn't touch the water
[fixed] Ladder placed in a 1 tile water puddle didn't decay
```
Fixes https://github.com/transhumandesign/kag-base/issues/2096

`WaterDecaysDoors.as` says that water should be checked for the tile **above**, **left of** and **right of** ladders and wooden doors.

This PR changes that to check for water in the blob's tile position (**center**). This fixes that ladder placed inside in a 1 tile water puddle doesn't decay.
Also, **above**, **left** and **right** are only checked if shape consts `waterPasses` returns false, therefore allowing ladders to be placed to the left or right of waterfalls without decaying.

(It's worth noting that wooden doors cannot be placed next to waterfalls without water spreading on top of it.
Please consider these suggestions for improving the water behavior https://github.com/transhumandesign/kag-base/issues/2077 - the 2nd example suggests that placing anything solid (including a wooden door) shouldn't spread water on top of it if it's a waterfall leading into the void.)

Instead of fetching shape and shape consts, you could also simply tag Ladder blobs and check for that tag, but I didn't want to add clutter with tags when the problem could be solved without using tags.

