### PR TITLE
[fixed] Don't allow changing to non-existing class

### DIFF
--- a/Rules/CommonScripts/ChatCommands/PlayerCommands.as
+++ b/Rules/CommonScripts/ChatCommands/PlayerCommands.as
@@ -49,7 +49,7 @@ class ClassCommand : ChatCommand
 		}
 
 		CBlob@ newBlob = server_CreateBlob(className, blob.getTeamNum(), blob.getPosition());
-		if (newBlob is null)
+		if (newBlob is null || newBlob.getName() != className)
 		{
 			server_AddToChat(getTranslatedString("Unable to change class"), ConsoleColour::ERROR, player);
 			return;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes 5) in https://github.com/transhumandesign/kag-base/issues/1738 

`/class` will now check if the blob created matches the class name you entered, same method used as in the `/spawn` command, therefore preventing you from changing class to a blob that doesn't exist.