### PR TITLE
[fixed] Sponge will not dry in water

### DIFF
--- a/Entities/Items/Sponge/SpongeDryInAir.as
+++ b/Entities/Items/Sponge/SpongeDryInAir.as
@@ -11,7 +11,10 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
-    if (not this.isInWater())
+	Vec2f bottom_pos = this.getPosition() + Vec2f(0, this.getHeight() / 2);
+	CMap@ map = getMap();
+
+	if (!map.isInWater(bottom_pos))
     {
         u8 absorbed = this.get_u8(ABSORBED_PROP);
         absorbed = Maths::Max(0, absorbed - slow_frequency);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2095

Fully soaked sponge could dry while floating in water if it ticks while its center is above water.
Logically a sponge that's on the water should not become dry.

This PR changes the check in `SpongeDryInAir.as` `onTick()` so it checks for the sponge's bottom position rather than using `this.isInWater()` (which seems equivalent to checking for its center position).

## Reproduction

When making a huge sea and placing a bunch of sponges inside, every few seconds a sponge would dry and drain some water for a short moment. After applying this PR, this doesn't happen.