### PR TITLE
[fixed] Saw didn't deactivate when killing a teammate in offline

### DIFF
--- a/Entities/Industry/Saw/Saw.as
+++ b/Entities/Industry/Saw/Saw.as
@@ -87,7 +87,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		CBitStream params;
 		this.SendCommand(this.getCommandID(toggle_id_client), params);
 	}
-	else if (cmd == this.getCommandID(toggle_id_client) && isClient())
+	else if (cmd == this.getCommandID(toggle_id_client) && isClient() && !isServer())
 	{
 		SetSawOn(this, !getSawOn(this));
 		UpdateSprite(this);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2194

This fixes that your Saw didn't deactive when you got killed by it (in offline).

When getting killed by your Saw, it would actually toggle twice. So I applied the same fix as here https://github.com/transhumandesign/kag-base/pull/2186 , checking for `!isServer()` on the client-side command.

Tested in offline and online, works correctly.
