### PR TITLE
[fixed] Airship & Bomber issues

### DIFF
--- a/Entities/Vehicles/Airships/Airship.cfg
+++ b/Entities/Vehicles/Airships/Airship.cfg
@@ -11,6 +11,8 @@ $sprite_factory                            = generic_sprite
 											 FireAnim.as;
 											 Airship.as;
 											 DynamicForegroundLayer.as;
+											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = Airship.png
 s32_sprite_frame_width                     = 96
 s32_sprite_frame_height                    = 56
@@ -106,7 +108,6 @@ $inventory_name                            = Boat Compartment
 
 $name                                      = airship
 @$scripts                              = Seats.as;
-										 DecayIfLeftAlone.as;
 										 DecayIfFlipped.as;
 										 WoodVehicleDamages.as;
 										 Wooden.as;

--- a/Entities/Vehicles/Airships/Bomber.cfg
+++ b/Entities/Vehicles/Airships/Bomber.cfg
@@ -10,6 +10,8 @@ $sprite_factory                            = generic_sprite
 											 Wooden.as;
 											 FireAnim.as;
 											 Bomber.as;
+											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = Balloon.png
 s32_sprite_frame_width                     = 48
 s32_sprite_frame_height                    = 16
@@ -99,7 +101,6 @@ $inventory_name                            = Bomber Compartment
 
 $name                                      = bomber
 @$scripts                              = Seats.as;
-										 DecayIfLeftAlone.as;
 										 DecayIfFlipped.as;
 										 WoodVehicleDamages.as;
 										 Wooden.as;


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Team conversion bar for Airship and Bomber wasn't shown
[changed] Airship and Bomber will not decay if left with an enemy
[changed] Show healthbar for Airship and Bomber
```

Fixes https://github.com/transhumandesign/kag-base/issues/2216
Fixes https://github.com/transhumandesign/kag-base/issues/2211
Fixes https://github.com/transhumandesign/kag-base/issues/2206

Although Airship and Bomber can be converted, the graphics for it weren't shown. Now they are.

Although Airship and Bomber can be converted, they will decay if left with an enemy. Converting and decaying at the same time is stupid. So I removed the decaying when left with an enemy.

Although other vehicles and boats have a healthbar, Bomber and Airship didn't have one. Now they do.
