### PR TITLE
[fixed] Attached Keg collision issus

### DIFF
--- a/Entities/Items/Boulder/Boulder.as
+++ b/Entities/Items/Boulder/Boulder.as
@@ -13,6 +13,7 @@ void onInit(CBlob @ this)
 	this.set_u8("launch team", 255);
 	this.server_setTeamNum(-1);
 	this.Tag("medium weight");
+	this.Tag("projectile hits keg");
 
 	LimitedAttack_setup(this);
 

--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -242,3 +242,12 @@ void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)
 		this.doTickScripts = true;
 	}
 }
+
+bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
+{
+	if (blob is null)
+		return false;
+
+	bool should_collide = this.isAttached() ? (blob.hasTag("projectile hits keg") && blob.getShape().vellen > 0.01f) : true;
+	return should_collide;
+}

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -32,6 +32,7 @@ void onInit(CBlob@ this)
 	consts.bullet = false;
 	consts.net_threshold_multiplier = 4.0f;
 	this.Tag("projectile");
+	this.Tag("projectile hits keg");
 
 	//dont collide with top of the map
 	this.SetMapEdgeFlags(CBlob::map_collide_left | CBlob::map_collide_right);

--- a/Entities/Items/Projectiles/BallistaBolt.as
+++ b/Entities/Items/Projectiles/BallistaBolt.as
@@ -11,9 +11,10 @@ const f32 FAST_SPEED = 16.0f;
 
 void onInit(CBlob@ this)
 {
-
 	this.set_u8("blocks_pierced", 0);
 	this.set_bool("static", false);
+
+	this.Tag("projectile hits keg");
 
 	this.server_SetTimeToDie(20);
 

--- a/Entities/Vehicles/Catapult/Rock.as
+++ b/Entities/Vehicles/Catapult/Rock.as
@@ -37,6 +37,8 @@ void onInit(CBlob@ this)
 		this.getShape().getConsts().net_threshold_multiplier = 4.0f;
 		this.set_u32("last collided tile", -1);
 	}
+
+	this.Tag("projectile hits keg");
 }
 
 void onTick(CBlob@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
```
[fixed] Keg in hand will not push blobs on the ground (Saw, Heart, ...) around anymore
[fixed] Blobs thrown at an attached Keg will not collide with it anymore 
        except for Boulder, Arrow, BallistaBolt and Rock
```

Fixes https://github.com/transhumandesign/kag-base/issues/2214

First I tried setting `this.getShape().getConsts().collideWhenAttached = true;` to `false` but then nothing would collide with attached Keg anymore. So I used  

```
bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
{
	if (blob is null)
		return false;

	bool should_collide = this.isAttached() ? (blob.hasTag("projectile hits keg") && blob.getShape().vellen > 0.01f) : true;
	return should_collide;
}
```

If Keg is attached, only blobs that are moving and that have tag "projectile hits keg" can collide with Keg.
If Keg is not attached, then other blobs can collide with Keg as usual.

Boulder, Arrow, Ballista Bolt and catapult Rocks are given the new tag "projectile hits keg".
Other blobs that don't have this tag will not collide with an attached Keg.
So bucket or Saw thrown at Keg (which is loaded in a Catapult) will not collide with it anymore.

I considered using existing tag `"projectile"` but Rock and Boulder don't have this and blobs with that tag will set off mines so I couldn't just give Rock and Boulder that tag. So although I hate to do it I had to introduce the new tag "projectile hits keg".

I want only blobs to collide with an attached Keg that can actually hit it and therefore detach it.
Let me know if there are better approaches.

Tested in offline and online, works as envisioned.

For testing steps, see the linked issue above.

