### PR TITLE
[changed] Untamed Bison will get mad when getting seated

### DIFF
--- a/Entities/Natural/Animals/Bison/Bison.as
+++ b/Entities/Natural/Animals/Bison/Bison.as
@@ -259,3 +259,14 @@ void onHitBlob(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@
 		hitBlob.AddForce(force);
 	}
 }
+
+void onAttach(CBlob@ this, CBlob@ blob, AttachmentPoint@ ap)
+{
+	const u16 friendId = this.get_netid(friend_property);
+	CBlob@ friend = getBlobByNetworkID(friendId);
+
+	if (!ap.socket || this is null || blob is null || !(friend !is null && blob is friend))
+		return;
+
+	MadAt(this, blob);
+}

--- a/Entities/Natural/Animals/Bison/Bison.as
+++ b/Entities/Natural/Animals/Bison/Bison.as
@@ -264,8 +264,9 @@ void onAttach(CBlob@ this, CBlob@ blob, AttachmentPoint@ ap)
 {
 	const u16 friendId = this.get_netid(friend_property);
 	CBlob@ friend = getBlobByNetworkID(friendId);
+	bool friend_wants_to_sit = (friend !is null && blob !is friend);
 
-	if (!ap.socket || this is null || blob is null || !(friend !is null && blob is friend))
+	if (!ap.socket || this is null || blob is null || !friend_wants_to_sit)
 		return;
 
 	MadAt(this, blob);

--- a/Entities/Natural/Animals/Bison/Bison.as
+++ b/Entities/Natural/Animals/Bison/Bison.as
@@ -264,9 +264,9 @@ void onAttach(CBlob@ this, CBlob@ blob, AttachmentPoint@ ap)
 {
 	const u16 friendId = this.get_netid(friend_property);
 	CBlob@ friend = getBlobByNetworkID(friendId);
-	bool friend_wants_to_sit = (friend !is null && blob !is friend);
+	bool is_friend = (friend !is null && friend is blob);
 
-	if (!ap.socket || this is null || blob is null || !friend_wants_to_sit)
+	if (!ap.socket || this is null || blob is null || is_friend)
 		return;
 
 	MadAt(this, blob);


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2198

This PR makes it so that taking a seat on Bison will enrage it. This fixes that you could sit on an untamed Bison and then de-seat to drop into the Bison, without it getting mad.

Bison will not get mad if the sitting player is the Bison's friend (the player who tamed it with a burger).

I added a check for `!ap.socket` just in case Bison could get attached to something in any future scenario or in any mods. We only want to do something if we attach something to Bison and not when Bison gets attached to something.

Tested in offline.

## Steps

Go near an untamed Bison. Try to take a seat without touching it. 
Notice Bison will stay calm and will not get mad. 
**After this PR, it will get mad if you are not the bison's friend.**
