### PR TITLE
[fix] Map loader now spawns bombs

### DIFF
--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -298,6 +298,8 @@ shared class TDMCore : RulesCore
 		sudden_death = false;
 
 		sv_mapautocycle = true;
+
+		SpawnBombs();
 	}
 
 	int gametime;
@@ -361,9 +363,6 @@ shared class TDMCore : RulesCore
 		//  SpawnPowerups();
 		RulesCore::Update(); //update respawns
 		CheckTeamWon();
-
-		if (getGameTime() % 2000 == 0)
-			SpawnBombs();
 	}
 
 	void updateHUD()
@@ -767,13 +766,15 @@ shared class TDMCore : RulesCore
 	void SpawnBombs()
 	{
 		Vec2f[] bombPlaces;
-		if (getMap().getMarkers("bombs", bombPlaces))
+		if (getMap().getMarkers("mat_bombs", bombPlaces))
 		{
 			for (uint i = 0; i < bombPlaces.length; i++)
 			{
 				server_CreateBlob("mat_bombs", -1, bombPlaces[i]);
 			}
 		}
+
+		getMap().RemoveMarkers("mat_bombs");
 	}
 
 

--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -298,8 +298,6 @@ shared class TDMCore : RulesCore
 		sudden_death = false;
 
 		sv_mapautocycle = true;
-
-		SpawnBombs();
 	}
 
 	int gametime;
@@ -762,21 +760,6 @@ shared class TDMCore : RulesCore
 	{
 		CBlob@ powerup = server_CreateBlob("powerup", -1, Vec2f(getMap().tilesize * 0.5f * getMap().tilemapwidth, 50.0f));
 	}
-
-	void SpawnBombs()
-	{
-		Vec2f[] bombPlaces;
-		if (getMap().getMarkers("mat_bombs", bombPlaces))
-		{
-			for (uint i = 0; i < bombPlaces.length; i++)
-			{
-				server_CreateBlob("mat_bombs", -1, bombPlaces[i]);
-			}
-		}
-
-		getMap().RemoveMarkers("mat_bombs");
-	}
-
 
 	void GiveSpawnResources(CBlob@ blob, CPlayer@ player)
 	{

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -379,7 +379,7 @@ class PNGLoader
 			case map_colors::bomber:      autotile(offset); spawnVehicle(map, "bomber",   offset); break;
 
 			// Ammo
-			case map_colors::bombs:       autotile(offset); AddMarker(map, offset, "mat_bombs"); break;
+			case map_colors::bombs:       autotile(offset); spawnBlob(map, "mat_bombs",       offset); break;
 			case map_colors::waterbombs:  autotile(offset); spawnBlob(map, "mat_waterbombs",  offset); break;
 			case map_colors::arrows:      autotile(offset); spawnBlob(map, "mat_arrows",      offset); break;
 			case map_colors::bombarrows:  autotile(offset); spawnBlob(map, "mat_bombarrows",  offset); break;


### PR DESCRIPTION
TDM will now spawn bombs when a map uses the bombs colour. It no longer spawns them every 2000 ticks, instead it just does it once.
