### PR TITLE
[fixed] Converting a vehicle will also convert items in inventory

### DIFF
--- a/Entities/Vehicles/Common/VehicleConvert.as
+++ b/Entities/Vehicles/Common/VehicleConvert.as
@@ -147,6 +147,7 @@ void onTick(CBlob@ this)
 void onChangeTeam(CBlob@ this, const int oldTeam)
 {
 	ConvertAttachments(this);
+	ConvertItems(this);
 
 	if (this.getTeamNum() < 10)
 	{
@@ -175,6 +176,19 @@ void ConvertAttachments(CBlob@ this)
 		
 		if (convertPoints.find(point.name) == -1) continue;
 		
+		blob.server_setTeamNum(this.getTeamNum());
+	}
+}
+
+void ConvertItems(CBlob@ this)
+{
+	if (!isServer()) return;
+
+	CInventory@ inventory = this.getInventory();
+	for (uint i = 0; i < inventory.getItemsCount(); i++)
+	{
+		CBlob@ blob = inventory.getItem(i);
+		if (blob is null || blob.getTeamNum() == 255) continue;
 		blob.server_setTeamNum(this.getTeamNum());
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

This PR makes it so that converting a vehicle or outpost will also convert its inventory items (only if the item isn't neutral team, that means chickens or sharks will not change team).

Previously, drills and mines would stay in the previous team. This could lead to scenarios where a blue mine could fall out of a red outpost that was destroyed.

Tested in offline and online, works.

## Steps

1. Be in blue team
2. Spawn an outpost or dinghy
3. Put in a drill and a mine
4. Have the outpost or dinghy get converted to red team (spawn a few red builders near it)
5. After conversion, spawn a few bombs to destroy the outpost or dinghy.
6. Notice blue drill and blue mine coming out. **After this PR, the items will be converted so a red drill and red mine would come out.**

