### PR TITLE
Optional spawn command count parameter for admins

### DIFF
--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -135,7 +135,7 @@ class SpawnCommand : BlobCommand
 		super("spawn", "Spawn a blob");
 		AddAlias("blob");
 		AddAlias("s");
-		SetUsage("<blob>");
+		SetUsage("<blob> (count)");
 	}
 
 	void SpawnBlobAt(Vec2f pos, string[] args, CPlayer@ player)
@@ -154,13 +154,32 @@ class SpawnCommand : BlobCommand
 			return;
 		}
 
-		u8 team = player.getBlob().getTeamNum();
-		CBlob@ newBlob = server_CreateBlob(blobName, team, pos + Vec2f(0, -5));
+		int count = args.size() >= 2 ? parseInt(args[1]) : 1;
 
-		//invalid blobs will have 'broken' names
-		if (newBlob is null || newBlob.getName() != blobName)
+		if (count <= 0 || count > 100)
 		{
-			server_AddToChat(getTranslatedString("Blob '{BLOB}' not found. See /help for details.").replace("{BLOB}", blobName), ConsoleColour::ERROR, player);
+			server_AddToChat(getTranslatedString("Invalid number of blobs to spawn: {COUNT}").replace("{COUNT}", ""+count), ConsoleColour::ERROR, player);
+			return;
+		}
+
+		if (count != 1 && (player is null || !player.isMod()))
+		{
+			server_AddToChat(getTranslatedString("You are not allowed to spawn more than one blob at once"), ConsoleColour::ERROR, player);
+			return;
+		}
+
+		u8 team = player.getBlob().getTeamNum();
+
+		for (int i = 0; i < count; ++i)
+		{
+			CBlob@ newBlob = server_CreateBlob(blobName, team, pos + Vec2f(0, -5));
+
+			//invalid blobs will have 'broken' names
+			if (newBlob is null || newBlob.getName() != blobName)
+			{
+				server_AddToChat(getTranslatedString("Blob '{BLOB}' not found. See /help for details.").replace("{BLOB}", blobName), ConsoleColour::ERROR, player);
+				return;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

cc @Vam-Jam 

It is now possible to do `/spawn keg 100`, for instance. Counts != 1 are admin-only to avoid abuse, it would mostly be useful for dev and testing.

Blobs are spawned in the same position, which would be particularly easy to abuse as it quickly gets very laggy.

## Steps to Test or Reproduce

```
/s keg 10
!keg 10
```