### PR TITLE
[fixed] Taunt Menu was not working in offline

### DIFF
--- a/Entities/Common/Taunts/TauntMenu.as
+++ b/Entities/Common/Taunts/TauntMenu.as
@@ -16,7 +16,7 @@ void onInit(CRules@ rules)
 	rules.addCommandID("display taunt");
 	rules.addCommandID("display taunt client");
 
-	if (isServer()) return;
+	if (isServer() && !isClient()) return;
 
 	string filename = "TauntEntries.cfg";
 	string cachefilename = "../Cache/" + filename;
@@ -81,7 +81,7 @@ void onInit(CRules@ rules)
 
 void onTick(CRules@ rules)
 {
-	if (isServer()) return;
+	if (isServer() && !isClient()) return;
 
 	CBlob@ blob = getLocalPlayerBlob();
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Fixes https://github.com/transhumandesign/kag-base/issues/2199

This PR makes a small adjustment to `TauntMenu.as` to make it work in offline.

It works in offline and online now, displaying the taunt in the chat.

I'm not sure what the code / command stuff is for, if `SHOW_IN_CHAT` is false.
I tried it out but nothing happens. So I'm not touching it.
Anyway, taunts as we know them are fixed in offline with this PR.