### PR TITLE
[fixed] CTF Flag return arrow will point towards its flag base

### DIFF
--- a/Entities/Special/CTF/CTF_Flag.as
+++ b/Entities/Special/CTF/CTF_Flag.as
@@ -110,7 +110,7 @@ void onRender(CSprite@ this)
 		return;
 
 	CBlob@ blob = this.getBlob();
-	if (blob.isAttached())
+	if (blob is null || blob.isAttached())
 	{
 		//todo: render "go to here" gui
 		return;
@@ -152,14 +152,14 @@ void onRender(CSprite@ this)
 
 	if (getGameTime() % 15 > 10)
 	{
+		Vec2f base_position = blob.get_Vec2f("flag base position");
+		Vec2f flag_position = blob.getPosition();
+		s16 right_add = base_position.x > flag_position.x ? 1 : -1;
+
 		if (!shouldFastReturn(blob))
-		{
-			GUI::DrawIconByName("$return_indicator$", Vec2f(pos2d.x-8.0f, pos2d.y-41.0f));
-		}
+			GUI::DrawIconByName("$return_indicator$", Vec2f(pos2d.x+8*right_add, pos2d.y-41.0f), 1.0f * -right_add, 1.0f, 0, SColor(0xffffffff));
 		else
-		{
-			GUI::DrawIconByName("$fast_return_indicator$", Vec2f(pos2d.x-18.0f, pos2d.y-41.0f));
-		}
+			GUI::DrawIconByName("$fast_return_indicator$", Vec2f(pos2d.x+18*right_add, pos2d.y-41.0f), 1.0f * -right_add, 1.0f, 0, SColor(0xffffffff));
 	}
 }
 

--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -17,6 +17,8 @@ void onInit(CBlob@ this)
 		{
 			this.server_AttachTo(flag, "FLAG");
 			this.set_netid("flag id", flag.getNetworkID());
+			flag.set_Vec2f("flag base position", this.getPosition());
+			flag.Sync("flag base position", true);
 		}
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Fixes https://github.com/transhumandesign/kag-base/issues/2197

This PR makes the CTF Flag's return indicator point into the direction it was stolen from, rather than always pointing to the left.

Tested in offline and online, works as intended.
