### PR TITLE
[changed] wall climb state is reset if descending past slide speed or when bouncing on a trampoline

### DIFF
--- a/Entities/Structures/Trampoline/TrampolineLogic.as
+++ b/Entities/Structures/Trampoline/TrampolineLogic.as
@@ -1,4 +1,5 @@
 #include "Help.as";
+#include "RunnerCommon.as";
 
 namespace Trampoline
 {
@@ -138,6 +139,17 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			velocity.RotateBy(angle);
 
 			blob.setVelocity(velocity);
+			
+			// reset wall climb status
+			if (blob.hasTag("player"))
+			{
+				RunnerMoveVars@ moveVars;
+				if (blob.get("moveVars", @moveVars))
+				{
+					moveVars.wallrun_count = 0;
+					moveVars.walljumped_side = Walljump::NONE;
+				}
+			}
 
 			CSprite@ sprite = this.getSprite();
 			if (sprite !is null)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2254
Fixes https://github.com/transhumandesign/kag-base/issues/2118

This PR resets your character's wall climb state when descending down beyond the slide-speed threshold, reducing annoying situations where the game prevents you from wall climbing if you have descended but not touched the ground yet, and then have made your way back up via grapple or trampoline.

This was done by splitting up the if-else codeblocks in `RunnerMovement.as` into:
```
	if (!blob.isOnCeiling() && !isknocked && !blob.isOnLadder()) 
	{
		const f32 slidespeed = 2.45f;
		bool key_pressed = (up || left || right || down);

		if (key_pressed)
		{

		( . . . )

		}
		else if (vel.y > slidespeed)
		{
			moveVars.wallrun_count = 0;
			moveVars.walljumped_side = Walljump::NONE;
		}
	}
```

Since this alone didn't fix the last situation in the video in issue https://github.com/transhumandesign/kag-base/issues/2118 , I changed `TrampolineLogic.as` to reset the player's wallclimb state when bounced.

Tested in offline, works as intended. Tested situations are:
* Archer descending but not touching the ground, then grappling up on the same wall again.
* Player wallclimbing and walljumping, then falling down and bouncing up by trampoline, then wallclimbing the same wall again.
* Knight walljumping off a left wall, then bouncing up, then trying to wall climb another left wall before touching the ground.
* 
After this PR, you are allowed to wall climb again in these situations.



