### PR TITLE
[fixed] Bombs couldn't damage same team wires (TDM)

### DIFF
--- a/Entities/Structures/Components/GenericComponent.as
+++ b/Entities/Structures/Components/GenericComponent.as
@@ -5,6 +5,7 @@
 void onInit(CBlob@ this)
 {
 	this.Tag("builder always hit");
+	this.Tag("is component");
 }
 
 void onSetStatic(CBlob@ this, const bool isStatic)

--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -831,3 +831,12 @@ void onInit(CRules@ this)
 {
 	Reset(this);
 }
+
+void onBlobCreated(CRules@ this, CBlob@ blob)
+{
+	if (blob is null)
+		return;
+
+	if (blob.hasTag("is component"))
+		blob.server_setTeamNum(255);
+}

--- a/Rules/TDM/Scripts/TDM.as
+++ b/Rules/TDM/Scripts/TDM.as
@@ -838,5 +838,14 @@ void onBlobCreated(CRules@ this, CBlob@ blob)
 		return;
 
 	if (blob.hasTag("is component"))
+	{	
+		u8 team = blob.getTeamNum();
 		blob.server_setTeamNum(255);
+
+		CSprite@ s = blob.getSprite();
+		if (s !is null)
+		{
+			spr.ReloadSprites(team, 0);
+		}
+	}
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2106

Components are given the tag "is component" and TDM gamemode checks for the tag in `onBlobCreated()` to change components' team to neutral team (255). 

I made it so the sprite is reloaded in the previous team color, so we could use any team color we want. Some existing TDM maps use blue wires and I didn't want to change that to grey.

By setting team to 255, wires and components are now always damaged by bombs.
Previously, bombs wouldn't hurt wires of the same team.

I think this is much better than having to edit any map png files directly.

Tested in offline, works.
