### PR TITLE
[fixed] Wood layer was missing when loading wood to a quarry in online

### DIFF
--- a/Entities/Industry/CTFShops/Quarry/Quarry.as
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.as
@@ -80,6 +80,8 @@ void onInit(CBlob@ this)
 
 	//commands
 	this.addCommandID("add fuel");
+	this.addCommandID("add fuel client");
+
 	string current_output = "current_quarry_output_" + this.getTeamNum();
 	CRules@ rules = getRules();
 
@@ -154,7 +156,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("add fuel"))
+	if (cmd == this.getCommandID("add fuel") && isServer())
 	{
 		CBlob@ caller = getBlobByNetworkID(params.read_u16());
 		if (caller is null) return;
@@ -175,9 +177,14 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		{
 			caller.TakeBlob(fuel, ammountToStore);
 			this.set_s16(fuel_prop, this.get_s16(fuel_prop) + ammountToStore);
-
-			updateWoodLayer(this.getSprite());
+			this.Sync(fuel_prop, true);
 		}
+		
+		this.SendCommand(this.getCommandID("add fuel client"));
+	}
+	else if (cmd == this.getCommandID("add fuel client") && isClient())
+	{
+		updateWoodLayer(this.getSprite());
 	}
 }
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2262

The command "add fuel" was only run on the server, so the spritelayer wasn't being set.

I added "add fuel client" command that is run client-side and synced `fuel_prop` in order to update the spritelayer.

In offline and online, it works correctly now. 
* Loading wood correctly set the spritelayer, the higher the amount, the more is shown visibly. 
* The wood will visibly decrease over time.