### PR TITLE
[changed] Mounted Bow can be detached from other vehicles

### DIFF
--- a/Entities/Vehicles/Common/VehicleAttachment.as
+++ b/Entities/Vehicles/Common/VehicleAttachment.as
@@ -25,10 +25,12 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 				CBlob@ occBlob = ap.getOccupied();
 				if (occBlob !is null) //detach button
 				{
-					if (this.isOnGround() && occBlob.getName() != "mounted_bow")	  // HACK:
+					if (this.isOnGround() || occBlob.getName() == "mounted_bow")	  // HACK:
 					{
+						Vec2f button_offset = ap.offset/2;
+						button_offset.RotateByDegrees(occBlob.getAngleDegrees());
 						string text = getTranslatedString("Detach {ITEM}").replace("{ITEM}", getTranslatedString(occBlob.getInventoryName()));
-						caller.CreateGenericButton(1, ap.offset, this, this.getCommandID("detach vehicle"), text);
+						CButton@ button = caller.CreateGenericButton(1, button_offset, this, this.getCommandID("detach vehicle"), text);
 					}
 				}
 			}
@@ -60,7 +62,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 						// range check
 						if (this.getDistanceTo(b) > 64.0f) return;
 
-						if (this.isOnGround() && occBlob.getName() != "mounted_bow")
+						if (this.isOnGround() || occBlob.getName() == "mounted_bow")
 						{
 							occBlob.server_DetachFrom(this);
 						}

--- a/Entities/Vehicles/Common/VehicleAttachment.as
+++ b/Entities/Vehicles/Common/VehicleAttachment.as
@@ -30,7 +30,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 						Vec2f button_offset = ap.offset/2;
 						button_offset.RotateByDegrees(occBlob.getAngleDegrees());
 						string text = getTranslatedString("Detach {ITEM}").replace("{ITEM}", getTranslatedString(occBlob.getInventoryName()));
-						CButton@ button = caller.CreateGenericButton(1, button_offset, this, this.getCommandID("detach vehicle"), text);
+						caller.CreateGenericButton(1, button_offset, this, this.getCommandID("detach vehicle"), text);
 					}
 				}
 			}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2207

You are allowed to detach mounted bow that is attached to other vehicles (longboat, warboat, airship, bomber).
The button offset was misplaced for longboat and bomber and I fixed it by dividing the `ap.offset` by 2.
The mounted bow on warboat still cannot be detached after this change.

Tested in offline.