### PR TITLE
[fixed] No flesh gibs when kidssafe is turned on

### DIFF
--- a/Entities/Common/Attacks/FleshHit.as
+++ b/Entities/Common/Attacks/FleshHit.as
@@ -23,7 +23,9 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	//printf("gibHealth " + gibHealth + " health " + this.getHealth() );
 	if (this.getHealth() <= gibHealth)
 	{
-		this.getSprite().Gib();
+		if (!g_kidssafe)
+			this.getSprite().Gib();
+
 		this.server_Die();
 	}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/1753

This PR changes `FleshHit.as` to not produce flesh gibs when `g_kidssafe` is on.

Originally addressed in https://github.com/transhumandesign/kag-base/pull/1854

Tested in offline, works.
