### PR TITLE
[fixed] Bugs when spawning a music

### DIFF
--- a/Entities/Meta/CTFMusic.as
+++ b/Entities/Meta/CTFMusic.as
@@ -2,6 +2,8 @@
 
 #define CLIENT_ONLY
 
+#include "MusicCommon.as";
+
 const string[] classList = {"knight", "archer", "builder"};
 const string[] blobList = {"knight", "archer", "builder", "ballista", "tunnel", "keg"};
 
@@ -28,7 +30,12 @@ void onInit(CBlob@ this)
 	if (mixer is null)
 		return;
 
-	mixer.ResetMixer();
+	if (musicAlreadyExists(this))
+	{
+		this.server_Die();
+		this.getCurrentScript().runFlags |= Script::remove_after_this;
+	}
+
 	this.set_bool("initialized game", false);
 
 	this.getCurrentScript().tickFrequency = 10;

--- a/Entities/Meta/ChallengeMusic.as
+++ b/Entities/Meta/ChallengeMusic.as
@@ -2,6 +2,8 @@
 
 #define CLIENT_ONLY
 
+#include "MusicCommon.as";
+
 enum GameMusicTags
 {
 	world_ambient,
@@ -22,11 +24,19 @@ void onInit(CBlob@ this)
 	CMixer@ mixer = getMixer();
 	if (mixer is null) { return; } //prevents aids on server
 
+	if (musicAlreadyExists(this))
+	{
+		this.server_Die();
+		this.getCurrentScript().runFlags |= Script::remove_after_this;
+	}
+
 	this.set_bool("initialized game", false);
 }
 
 void onTick(CBlob@ this)
 {
+	print("tick");
+
 	CMixer@ mixer = getMixer();
 	if (mixer is null) { return; } //prevents aids on server
 

--- a/Entities/Meta/ChallengeMusic.as
+++ b/Entities/Meta/ChallengeMusic.as
@@ -35,8 +35,6 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
-	print("tick");
-
 	CMixer@ mixer = getMixer();
 	if (mixer is null) { return; } //prevents aids on server
 

--- a/Entities/Meta/MusicCommon.as
+++ b/Entities/Meta/MusicCommon.as
@@ -1,0 +1,21 @@
+
+#define CLIENT_ONLY
+
+bool musicAlreadyExists(CBlob@ this)
+{
+	CBlob@[] musics;
+	getBlobsByName("music", @musics);
+	getBlobsByName("ctf_music", @musics);
+	getBlobsByName("war_music", @musics);
+	getBlobsByName("challenge_music", @musics);
+	
+	for (uint i = 0; i < musics.length; i++)
+	{
+		CBlob@ music = musics[i];
+		if (music is null || music is this) continue;
+
+		return true;
+	}
+
+	return false;
+}

--- a/Entities/Meta/TDMMusic.as
+++ b/Entities/Meta/TDMMusic.as
@@ -2,6 +2,8 @@
 
 #define CLIENT_ONLY
 
+#include "MusicCommon.as";
+
 enum GameMusicTags
 {
 	world_intro,
@@ -18,6 +20,12 @@ void onInit(CBlob@ this)
 	CMixer@ mixer = getMixer();
 	if (mixer is null)
 		return;
+
+	if (musicAlreadyExists(this))
+	{
+		this.server_Die();
+		this.getCurrentScript().runFlags |= Script::remove_after_this;
+	}
 
 	this.set_bool("initialized game", false);
 }

--- a/Entities/Meta/WARMusic.as
+++ b/Entities/Meta/WARMusic.as
@@ -3,6 +3,7 @@
 #define CLIENT_ONLY
 
 #include "RulesCore.as";
+#include "MusicCommon.as";
 
 enum GameMusicTag
 {
@@ -33,10 +34,14 @@ string base_blob_name = "hall";
 void onInit(CBlob@ this)
 {
 	CMixer@ mixer = getMixer();
-	if (mixer is null)
-		return;
+	if (mixer is null) { return; } //prevents aids on server
 
-	mixer.ResetMixer();
+	if (musicAlreadyExists(this))
+	{
+		this.server_Die();
+		this.getCurrentScript().runFlags |= Script::remove_after_this;
+	}
+
 	this.set_bool("initialized game", false);
 
 	CRules@ rules = getRules();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/1309

After this PR, you cannot spawn a `ctf_music`, `music`, `war_music` or `challenge_music` if one of these already exists.

Fixes bugs that occur when multiple music blobs exist (music getting cut off over and over).

Tested in offline and online, found no problems. 
When a CTF match ends and the new map loads, music will correctly start playing again.

## Alternative Solutions

This Pr might not be a good solution but I only aimed to fix the issue. There could be other possible solutions.

a) Replacing the existing music
It might be possible to write logic for replacing the existing music but it requires more time and research.

b) Blacklisting
Alternative to this PR would be to just put music blobs on the server's black list.

c) Moving music code to a rules script
Why are we using blobs?

