### PR TITLE
[changed] Allow 1 seed to grow when 2 or more are overlapping

### DIFF
--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -9,7 +9,7 @@ bool isNotBlockedByOthers(CBlob@ this)
 	{
 		u16 lowest_net_id = this.getNetworkID();
 		bool found_seed = false;
-	
+
 		for (uint i = 0; i < blobsInRadius.length; i++)
 		{
 			CBlob@ blob = blobsInRadius[i];
@@ -29,7 +29,8 @@ bool isNotBlockedByOthers(CBlob@ this)
 				return false;
 			}
 		}
-		
+
+		// if there are 2 or more seeds, allow the seed with the lowest net id to grow
 		if (found_seed)
 		{
 			CBlob@ seed_to_grow = getBlobByNetworkID(lowest_net_id);

--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -49,7 +49,7 @@ bool canGrowAt(CBlob@ this, Vec2f pos)
 {
 	if (!this.getShape().isStatic()) // they can be static from grid placement
 	{
-		if (!this.isOnGround() || this.isInWater() || this.isAttached() || this.isInInventory() || !isNotBlockedByOthers(this))
+		if (!this.isOnGround() || this.isInWater() || this.isAttached() || !isNotBlockedByOthers(this))
 		{
 			return false;
 		}

--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -2,17 +2,19 @@
 
 bool isNotBlockedByOthers(CBlob@ this)
 {
-	CBlob@[] blobsInRadius;
+	CBlob@[] overlapping;
 	CMap@ map = getMap();
 
-	if (map.getBlobsInRadius(this.getPosition(), map.tilesize / 4, @blobsInRadius))
+	if (this.getOverlapping(@overlapping))
 	{
 		u16 lowest_net_id = this.getNetworkID();
 		bool found_seed = false;
 
-		for (uint i = 0; i < blobsInRadius.length; i++)
+		for (uint i = 0; i < overlapping.length; i++)
 		{
-			CBlob@ blob = blobsInRadius[i];
+			CBlob@ blob = overlapping[i];
+
+			if (blob is null) continue;
 
 			if (blob.getName() == "seed")
 			{
@@ -24,7 +26,7 @@ bool isNotBlockedByOthers(CBlob@ this)
 					lowest_net_id = blob_net_id;
 				}
 			}
-			else if (blob.getName().find("tree") == -1)
+			else if (blob.getName().find("tree") != -1)
 			{
 				return false;
 			}
@@ -48,7 +50,7 @@ bool canGrowAt(CBlob@ this, Vec2f pos)
 {
 	if (!this.getShape().isStatic()) // they can be static from grid placement
 	{
-		if (!this.isOnGround() || this.isInWater() || this.isAttached() || !isNotBlockedByOthers(this))
+		if (!this.isOnGround() || this.isInWater() || this.isAttached() || this.isInInventory() || !isNotBlockedByOthers(this))
 		{
 			return false;
 		}

--- a/Entities/Natural/Scripts/canGrow.as
+++ b/Entities/Natural/Scripts/canGrow.as
@@ -3,7 +3,6 @@
 bool isNotBlockedByOthers(CBlob@ this)
 {
 	CBlob@[] overlapping;
-	CMap@ map = getMap();
 
 	if (this.getOverlapping(@overlapping))
 	{


### PR DESCRIPTION
## Status

- **IN DEVELOPMENT**
- Still issues with several seeds growing on the same tile.

## Description

Fixes [Issue #2283](https://github.com/transhumandesign/kag-base/issues/2283)

When two or more seeds are on the ground at the same tile position, no seeds would grow.
This PR changes that so the seed with the lowest net id can grow.

`this.getOverlapping(@overlapping)` was replaced by `map.getBlobsInRadius()` due to the previous logic sometimes failing, see [PR #2238](https://github.com/transhumandesign/kag-base/issues/2238) .

<s>Tested in offline, works as intended.</s>
After further testing, I found that several seeds could grow on the same tile. Will fix soon.

