### PR TITLE
[fixed] characters don't regain tag "player" on rejoin

### DIFF
--- a/Entities/Characters/Scripts/RunnerDeath.as
+++ b/Entities/Characters/Scripts/RunnerDeath.as
@@ -9,6 +9,9 @@ const f32 HEAVY_CARRIED_BLOB_VEL_SCALE = 0.6;
 
 void onInit(CBlob@ this)
 {
+	if (this.hasTag("dead"))
+		this.Untag("player");
+
 	this.set_f32("hit dmg modifier", 0.0f);
 	this.set_f32("hit dmg modifier", 0.0f);
 	this.getCurrentScript().tickFrequency = 0; // make it not run ticks until dead


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2293

For a character that dies, `"player"` gets untagged, and `"dead"` and `"dead player"` get tagged.

But when rejoining, the dead player will get `"player"` tag back because `onInit(CBlob@ this)` gets run for every character on rejoin which applies the tag. This causes a bug where a crate that has a dead character inside will - after rejoining - show a "get out" button instead of the normal inventory button.

I added 
```
	if (this.hasTag("dead"))
		this.Untag("player");
```
to `onInit()` in `RunnerDeath.as`.
Because `RunnerDeath.as` is at the bottom in the blob scripts list for all the runners, this code effectively removes the "player" tag on rejoin. This is the simplest solution. Alternatively, you could also not tag "player" if tag "dead" is present, in each runner's blob init function.

Tested on dedicated server, it works and the crate bug doesn't happen anymore.

I think there could be more bugs like this in the game. I will search for more.