### PR TITLE
[fixed] Keg sparkle sound was not playing on rejoin

### DIFF
--- a/Entities/Items/Explosives/KegVoodoo.as
+++ b/Entities/Items/Explosives/KegVoodoo.as
@@ -28,6 +28,11 @@ void onInit(CBlob@ this)
 
 	this.getCurrentScript().tickFrequency = 10;
 	this.getCurrentScript().tickIfTag = "exploding";
+	
+	this.getSprite().SetEmitSound("/Sparkle.ogg");
+	this.getSprite().SetEmitSoundSpeed(1.0f);
+	this.getSprite().SetEmitSoundVolume(1.0f);
+	this.getSprite().SetEmitSoundPaused(!this.hasTag("exploding"));
 }
 
 void onTick(CBlob@ this)
@@ -135,9 +140,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		this.SetLight(true);
 		this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-		this.getSprite().SetEmitSound("/Sparkle.ogg");
-		this.getSprite().SetEmitSoundSpeed(1.0f);
-		this.getSprite().SetEmitSoundVolume(1.0f);
 		this.getSprite().SetEmitSoundPaused(false);
 	}
 	else if (cmd == this.getCommandID("deactivate client") && isClient())


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2296

This fixes that Keg was not making a sparkle sound when activated when rejoining the server.

## Reproducing

Join server, light a Keg, leave and rejoin. Keg isn't making a sound. **After this PR, it will make a sound.**

For testing, I suggest that you increase the explosion timer in `Keg.as` 
`this.set_f32("keg_time", 180.0f);` --> `this.set_f32("keg_time", 1800.0f);`