### PR TITLE
[fixed] Dead trader won't do death scream again when rejoining

### DIFF
--- a/Entities/Industry/Trading/Trader.as
+++ b/Entities/Industry/Trading/Trader.as
@@ -50,6 +50,12 @@ void onHealthChange(CBlob@ this, f32 oldHealth)
 	{
 		this.Tag("dead");
 		this.server_SetTimeToDie(20);
+		
+		CSprite@ sprite = this.getSprite();
+		if (sprite !is null)
+		{
+			sprite.PlaySound("/TraderScream");
+		}
 	}
 
 	if (this.getHealth() < 0)
@@ -105,9 +111,6 @@ void onTick(CSprite@ this)
 
 	if (blob.hasTag("dead"))
 	{
-		if (!this.isAnimation("dead"))
-			this.PlaySound("/TraderScream");
-
 		this.SetAnimation("dead");
 
 		if (blob.isOnGround())


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/1977#issuecomment-2571427373

When there is a dead trader and you rejoin, he will make a death scream even though he has been dead for a while.

This changes that so the death scream on rejoin won't happen. It will only happen when the trader dies.

Tested on dedicated server, it works.