### PR TITLE
[fixed] "/crate" will spawn an initialized crate

### DIFF
--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -48,7 +48,7 @@ class CrateCommand : BlobCommand
 
 		if (args.size() == 0)
 		{
-			server_MakeCrate("", "", 0, team, pos);
+			server_CreateBlob("crate", team, pos);
 			return;
 		}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2178

`"/crate"` spawned a crate that was not initialized, via `server_MakeCrate("", "", 0, team, pos);`.
This means that if an enemy picks up the crate, it will change color and it does not pick materials from the ground.

For consistency reasons, I made this PR which changes the crate command logic so `"/crate"` will use `server_CreateBlob("crate", team, pos);`.
Now the crate command's default crate will behave like any other empty crate that you can buy, craft at a workbench or spawn in via `"/s crate"`. It will __not__ change color when picked by the enemy, and it __will__ pick materials from the ground.

Tested, works.