### PR TITLE
[fixed] Water Bomb name is singular

### DIFF
--- a/Entities/Materials/Explosive/MaterialWaterBomb.cfg
+++ b/Entities/Materials/Explosive/MaterialWaterBomb.cfg
@@ -64,7 +64,7 @@ $name                                  = mat_waterbombs
 f32_health                             = 1.0
 
 # Inside inventory
-$inventory_name                        = Water Bombs
+$inventory_name                        = Water Bomb
 $inventory_icon                        = Materials.png
 u8 inventory_icon_frame                = 21
 u8 inventory_icon_frame_width          = 16


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2088

Items that can be stacked to more than 1 will have their inventory name in plural e.g. "fire arrows", whereas items that can not be stacked will be in singular e.g. "bomb".

However, although water bomb cannot be stacked, its inventory name was in plual, so this PR fixes the name to be in singular.