### PR TITLE
Fix tree segments being one-sided/having broken visual randomness

### DIFF
--- a/Entities/Natural/Trees/BushyTreeLogic.as
+++ b/Entities/Natural/Trees/BushyTreeLogic.as
@@ -59,7 +59,7 @@ void GrowSprite(CSprite@ this, TreeVars@ vars)
 		this.animation.frame = 1;
 	}
 
-	TreeSegment[]@ segments;
+	TreeSegment@[]@ segments;
 	blob.get("TreeSegments", @segments);
 	if (segments is null)
 		return;

--- a/Entities/Natural/Trees/LogsOnDeath.as
+++ b/Entities/Natural/Trees/LogsOnDeath.as
@@ -12,7 +12,7 @@ void onDie(CBlob@ this)
 		fall_angle = this.get_f32("tree_fall_angle");
 	}
 
-	TreeSegment[]@ segments;
+	TreeSegment@[]@ segments;
 	this.get("TreeSegments", @segments);
 	if (segments is null)
 		return;

--- a/Entities/Natural/Trees/PineTreeLogic.as
+++ b/Entities/Natural/Trees/PineTreeLogic.as
@@ -172,13 +172,13 @@ void GrowSprite(CSprite@ this, TreeVars@ vars)
 						newsegment.ResetTransform();
 						newsegment.SetRelativeZ(-550.0f - (vars.height * 10.0f));
 
-						bool flip = (segment.r.NextRanged(2) == 0);
+						flip = (segment.r.NextRanged(2) == 0);
 						newsegment.SetFacingLeft(flip);
 
-						newsegment.SetOffset(segment.start_pos + Vec2f(((vars.max_height - i * 2) + segment.r.NextRanged(8)) * 0.5 + 8.0f , 4.0f));
+						newsegment.SetOffset(segment.start_pos + Vec2f((float(vars.max_height) - i * 2) + segment.r.NextRanged(4) + 5.0f, 3.0f + segment.r.NextRanged(4)));
 					}
 
-					if (segment.r.NextRanged(2) == 0)
+					if (true) // always make 2nd segment for now
 					{
 						CSpriteLayer@ secondnewsegment = this.addSpriteLayer("leaves doubleside " + i, "Entities/Natural/Trees/Trees.png" , 32, 32, 0, 0);
 
@@ -191,10 +191,9 @@ void GrowSprite(CSprite@ this, TreeVars@ vars)
 							secondnewsegment.SetRelativeZ(-550.0f - (vars.height * 10.0f));
 
 							flip = !flip;
-
 							secondnewsegment.SetFacingLeft(flip);
 
-							secondnewsegment.SetOffset(segment.start_pos + Vec2f(((vars.max_height - i * 2) + segment.r.NextRanged(8)) * 0.5 + 8.0f , 4.0f));
+							secondnewsegment.SetOffset(segment.start_pos + Vec2f((float(vars.max_height) - i * 2) + segment.r.NextRanged(4) + 5.0f, 3.0f + segment.r.NextRanged(4)));
 						}
 					}
 				}

--- a/Entities/Natural/Trees/PineTreeLogic.as
+++ b/Entities/Natural/Trees/PineTreeLogic.as
@@ -59,7 +59,7 @@ void GrowSprite(CSprite@ this, TreeVars@ vars)
 		this.animation.frame = 1;
 	}
 
-	TreeSegment[]@ segments;
+	TreeSegment@[]@ segments;
 	blob.get("TreeSegments", @segments);
 	if (segments is null)
 		return;

--- a/Entities/Natural/Trees/TreeCommon.as
+++ b/Entities/Natural/Trees/TreeCommon.as
@@ -17,6 +17,10 @@ shared class TreeSegment
 
 	Random r;
 
+	TreeSegment(const TreeSegment &in other) {
+		print("BUG, we do not want copy constructor of TreeSegment!");
+	}
+
 };
 
 shared class TreeVars
@@ -34,7 +38,7 @@ shared class TreeVars
 
 TreeSegment@ getLastSegment(CBlob@ this)
 {
-	TreeSegment[]@ segments;
+	TreeSegment@[]@ segments;
 	this.get("TreeSegments", @segments);
 
 	if (segments is null || segments.length < 1)
@@ -47,7 +51,7 @@ TreeSegment@ getLastSegment(CBlob@ this)
 
 void GrowSegments(CBlob@ this, TreeVars@ vars)
 {
-	TreeSegment[]@ segments;
+	TreeSegment@[]@ segments;
 	this.get("TreeSegments", @segments);
 	if (segments is null)
 	{
@@ -84,7 +88,7 @@ bool CollapseToGround(CBlob@ this, f32 angle)
 	CMap@ map = getMap();
 	Vec2f pos = this.getPosition();
 
-	TreeSegment[]@ segments;
+	TreeSegment@[]@ segments;
 	this.get("TreeSegments", @segments);
 	if (segments is null)
 		return false;

--- a/Entities/Natural/Trees/TreeSync.as
+++ b/Entities/Natural/Trees/TreeSync.as
@@ -7,7 +7,7 @@ f32 segment_length = 14.0f;
 
 void InitVars(CBlob@ this)
 {
-	TreeSegment[] segments;
+	TreeSegment@[] segments;
 	this.set("TreeSegments", segments);
 
 	AddIconToken("$Tree$", "Entities/Common/GUI/HelpIcons.png", Vec2f(16, 16), 1);
@@ -235,7 +235,7 @@ void addSegment(CBlob@ this, TreeVars@ vars)
 	}
 
 	segment.end_pos = segment.start_pos + Vec2f(0, -segment.length).RotateBy(segment.angle, Vec2f(0, 0));
-	this.push("TreeSegments", segment);
+	this.push("TreeSegments", @segment);
 	this.server_Heal(0.666f);
 }
 


### PR DESCRIPTION
[dev] also made all references to TreeSegment[] into a TreeSegment@[] to avoid incorrect copy construction

## Status

- **IN DEVELOPMENT**: this PR is still in development, but you would like your changes reviewed.

## Description

## Steps to Test or Reproduce

Observe trees, before this PR all background leaves for the pine would be to the right.  
This is because the TreeSegment copy constructor is called but doesn't properly copy the random seed. Instead, make it so that the list is a list of handles, so the copy constructor doesn't need to get involved in the first place.

Should make sure trees are still synced between players.

There were visual tweaks to make it so that the leaves are always shown on both sides of the pine tree. The random offsets were edited for visual style reasons.

Need to test on vanilla too

Sample screenshot:

![image](https://github.com/user-attachments/assets/5d911e45-025e-4fe2-b8db-6602c6d37d30)
