### PR TITLE
[fix] Knight now calls RunStateMachine sooner

### DIFF
--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -241,6 +241,11 @@ void onTick(CBlob@ this)
 		return;
 	}
 
+	if (!knocked)
+	{
+		RunStateMachine(this, knight, moveVars);
+	}
+
 	Vec2f pos = this.getPosition();
 	Vec2f vel = this.getVelocity();
 	Vec2f aimpos = this.getAimPos();
@@ -275,12 +280,6 @@ void onTick(CBlob@ this)
 		pressed_a1 = false;
 		pressed_a2 = false;
 		walking = false;
-
-	}
-	else
-	{
-		RunStateMachine(this, knight, moveVars);
-
 	}
 
 	//throwing bombs


### PR DESCRIPTION
Knight no longer processes an older state, this *should* not change anything aside from fixing a 1 tick delay with shields.

This also means `knight_clear_actor_limits` does not get called on the first tick you jab/hold sword, not entirely sure if this could result in anything different.

Needs testing in mp.

