### PR TITLE
[added] changing class at base copies your current emote

### DIFF
--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -160,6 +160,16 @@ void onRespawnCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			{
 				setKnocked(newBlob, getKnockedRemaining(caller));
 			}
+			
+			//copy emote
+			if (caller.exists("emote"))
+			{
+				newBlob.set_string("emote", caller.get_string("emote"));
+				newBlob.set_u32("emotetime", caller.get_u32("emotetime"));
+				bool client = caller.getPlayer() !is null && caller.isMyPlayer();
+				newBlob.Sync("emote", !client);
+				newBlob.Sync("emotettime", !client);
+			}
 
 			// plug the soul
 			newBlob.server_SetPlayer(caller.getPlayer());

--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -166,9 +166,8 @@ void onRespawnCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			{
 				newBlob.set_string("emote", caller.get_string("emote"));
 				newBlob.set_u32("emotetime", caller.get_u32("emotetime"));
-				bool client = caller.getPlayer() !is null && caller.isMyPlayer();
-				newBlob.Sync("emote", !client);
-				newBlob.Sync("emotettime", !client);
+				newBlob.Sync("emote", true);
+				newBlob.Sync("emotetime", true);
 			}
 
 			// plug the soul


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

When changing class at a tent, your current emote will be copied.