### PR TITLE
[fixed] Right mouse key failed to toggle cinematic camera after a new map loads

### DIFF
--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -34,6 +34,7 @@ void Reset(CRules@ this)
 	zoomEaseModifier = 1.0f;
 
 	timeToCinematic = 0;
+	deathTime = 0;
 }
 
 void onRestart(CRules@ this)


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2307

`deathTime` didn't change between maps so toggling would not work because of the condition `getGameTime() > deathTime` at line 371 in `PlayerCamera.as`.

Now, when a new map loads and rules script `PlayerCamera.as` restarts, the `Reset()` function now sets `deathTime` back to 0.

The bug itself and the bug fix were verifed on dedicated server.
