### PR TITLE
[fixed] Stone blobs will no longer take damage from fire

### DIFF
--- a/Entities/Structures/Common/StoneStructureHit.as
+++ b/Entities/Structures/Common/StoneStructureHit.as
@@ -1,6 +1,5 @@
 //scale the damage:
-//      knights cant damage
-//      arrows cant damage
+//      knights, arrows and fire doesn't deal damage
 
 #include "Hitters.as";
 
@@ -16,6 +15,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		case Hitters::sword:
 		case Hitters::arrow:
 		case Hitters::stab:
+		case Hitters::fire:
 			dmg = 0.0f;
 			break;
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2310

Stone doors, obstructors(solid, in the current dev build) and possibly other stone blobs could take fire damage, if an adjacent wood back tile starts burning.

This PR fixing it by changing `StoneStructorHit.as` to set fire damage to 0.
With the damage being 0, `Stone.as` won't do a stone hit sound either.

Tested in online, works.
