### PR TITLE
[fix] Material duping

### DIFF
--- a/Entities/Materials/MaterialCommon.as
+++ b/Entities/Materials/MaterialCommon.as
@@ -54,6 +54,8 @@ namespace Material
 			this.server_SetQuantity(sum);
 			blob.Tag("AdminAlertIgnore");
 			blob.Sync("AdminAlertIgnore", true);
+
+			blob.server_SetQuantity(0);
 			blob.server_Die();
 		}
 		else
@@ -70,6 +72,8 @@ namespace Material
 		if (this.getName() != blob.getName()) return false;
 
 		if (this is blob) return false;
+
+		if (blob.getQuantity() == 0) return false;
 
 		// Materials in-use are supposed
 		// to have a fixed quantity


### PR DESCRIPTION
Should close #2315

When two (or more) materials on the floor tick at the same time with different qty's, it could result in the lower quantity being duplicated.

The reason for this is if both the lower qty and higher qty item call `merge` at the same tick, the lower qty item would be added twice & killed twice.

This patch just set's the lower qty item to 0 and checks if quantity is not 0 before merging.  