### PR TITLE
Build Height Changes

### DIFF
--- a/Entities/Characters/Archer/ArcherAnim.as
+++ b/Entities/Characters/Archer/ArcherAnim.as
@@ -536,7 +536,9 @@ void doRopeUpdate(CSprite@ this, CBlob@ blob, ArcherInfo@ archer)
 		return;
 	}
 
-	Vec2f adjusted_pos = Vec2f(archer.grapple_pos.x, Maths::Max(0.0, archer.grapple_pos.y));
+	// Only limit grapple to top of map if it's a cave map
+	CRules@ rules = getRules();
+	Vec2f adjusted_pos = rules is null || rules.get_bool("collide with ceiling") ? Vec2f(archer.grapple_pos.x, Maths::Max(0.0, archer.grapple_pos.y)) : archer.grapple_pos;
 	Vec2f off = adjusted_pos - blob.getPosition();
 
 	f32 ropelen = Maths::Max(0.1f, off.Length() / 32.0f);

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -765,7 +765,10 @@ bool checkGrappleStep(CBlob@ this, ArcherInfo@ archer, CMap@ map, const f32 dist
 
 		archer.grapple_ratio = Maths::Max(0.2, Maths::Min(archer.grapple_ratio, dist / archer_grapple_length));
 
-		archer.grapple_pos.y = Maths::Max(0.0, archer.grapple_pos.y);
+		// Only limit grapple to top of map if it's a cave map
+		CRules@ rules = getRules();
+		archer.grapple_pos.y = rules is null || rules.get_bool("collide with ceiling") ? Maths::Max(0.0, archer.grapple_pos.y) : archer.grapple_pos.y;
+
 
 		if (canSend(this) || isServer()) SyncGrapple(this);
 

--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -473,8 +473,8 @@ void onRender(CSprite@ this)
 								@sector = map.getSectorAtPosition(middle, "no blobs");
 							}
 							if (sector is null && bc.blockActive && map.isTileSolid(bc.blockType))
-								{
-							@sector = map.getSectorAtPosition(middle, "no solids");  
+							{
+								@sector = map.getSectorAtPosition(middle, "no solids");  
 							}
 							if (sector is null)
 							{

--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -466,8 +466,20 @@ void onRender(CSprite@ this)
 						if (!bc.buildableAtPos && !bc.sameTileOnBack) //no build indicator drawing
 						{
 							CMap@ map = getMap();
-							Vec2f middle = blob.getAimPos() + Vec2f(map.tilesize*0.5f, map.tilesize*0.5f);
-							CMap::Sector@ sector = map.getSectorAtPosition( middle, "no build");
+							Vec2f middle = map.getAlignedWorldPos(blob.getAimPos());
+						CMap::Sector@ sector;
+						if (bc.blobActive)
+						{
+							@sector = map.getSectorAtPosition(middle, "no blobs");
+						}
+						if (sector is null && bc.blockActive && map.isTileSolid(bc.blockType))
+							{
+							@sector = map.getSectorAtPosition(middle, "no solids");  
+						}
+						if (sector is null)
+						{
+							@sector = map.getSectorAtPosition( middle, "no build");
+						}
 							if (sector !is null)
 							{
 								GUI::DrawRectangle( getDriver().getScreenPosFromWorldPos(sector.upperleft), getDriver().getScreenPosFromWorldPos(sector.lowerright), SColor(0x65ed1202) );

--- a/Entities/Characters/Builder/BuilderInventory.as
+++ b/Entities/Characters/Builder/BuilderInventory.as
@@ -467,19 +467,19 @@ void onRender(CSprite@ this)
 						{
 							CMap@ map = getMap();
 							Vec2f middle = map.getAlignedWorldPos(blob.getAimPos());
-						CMap::Sector@ sector;
-						if (bc.blobActive)
-						{
-							@sector = map.getSectorAtPosition(middle, "no blobs");
-						}
-						if (sector is null && bc.blockActive && map.isTileSolid(bc.blockType))
+							CMap::Sector@ sector;
+							if (bc.blobActive)
 							{
+								@sector = map.getSectorAtPosition(middle, "no blobs");
+							}
+							if (sector is null && bc.blockActive && map.isTileSolid(bc.blockType))
+								{
 							@sector = map.getSectorAtPosition(middle, "no solids");  
-						}
-						if (sector is null)
-						{
-							@sector = map.getSectorAtPosition( middle, "no build");
-						}
+							}
+							if (sector is null)
+							{
+								@sector = map.getSectorAtPosition( middle, "no build");
+							}
 							if (sector !is null)
 							{
 								GUI::DrawRectangle( getDriver().getScreenPosFromWorldPos(sector.upperleft), getDriver().getScreenPosFromWorldPos(sector.lowerright), SColor(0x65ed1202) );

--- a/Entities/Common/Building/BlobPlacement.as
+++ b/Entities/Common/Building/BlobPlacement.as
@@ -91,7 +91,7 @@ bool serverBlobCheck(CBlob@ blob, CBlob@ blobToPlace, Vec2f cursorPos, bool repa
 
 	if (pos.Length() > 30)
 		return false;
-    
+	
 	// Are we still on cooldown?
 	if (isBuildDelayed(blob)) 
 		return true;
@@ -111,41 +111,41 @@ bool serverBlobCheck(CBlob@ blob, CBlob@ blobToPlace, Vec2f cursorPos, bool repa
 	if (map.isTileCollapsing(cursorPos))
 		return false;
 
+	// Prevent building in no build, no solids, and no blobs sectors
 	pos = cursorPos + Vec2f(map.tilesize * 0.2f, map.tilesize * 0.2f);
-    CMap::Sector@[] sectors;
-    map.getSectorsAtPosition(pos, sectors);
-    for (u8 i = 0; i < sectors.length; i++)
-    {
-        if (sectors[i] is null)
-        {
-            continue;
-        }
+	CMap::Sector@[] sectors;
+	map.getSectorsAtPosition(pos, sectors);
+	for (u8 i = 0; i < sectors.length; i++)
+	{
+		if (sectors[i] is null)
+		{
+			continue;
+		}
 
-		CBlob@ owner = getBlobByNetworkID(sectors[i].ownerID);
+		const bool no_build = sectors[i].name == "no build";
+		const bool no_solids = sectors[i].name == "no solids";
+		const bool no_blobs = sectors[i].name == "no blobs";
 
-        const bool no_build = sectors[i].name == "no build";
-        const bool no_solids = sectors[i].name == "no solids";
-        const bool no_blobs = sectors[i].name == "no blobs";
 		// Allow spike dropping at the top of the map
-        if (blobToPlace.getName() == "spikes")
-        {
-            const bool has_adjacent = (// Can't place next to something it'd stick to
-                map.isTileSolid(pos + Vec2f(0,             map.tilesize))  ||
-                map.isTileSolid(pos + Vec2f(0,             -map.tilesize)) ||
-                map.isTileSolid(pos + Vec2f(map.tilesize,  0))             ||
-                map.isTileSolid(pos + Vec2f(-map.tilesize, 0))
-            );
-            if (no_build || (no_solids || no_blobs) && has_adjacent)
-            {
-                return false;
-            }
-        }
+		if (blobToPlace.getName() == "spikes")
+		{
+			const bool has_adjacent = (// Can't place next to something it'd stick to
+				map.isTileSolid(pos + Vec2f(0,             map.tilesize))  ||
+				map.isTileSolid(pos + Vec2f(0,             -map.tilesize)) ||
+				map.isTileSolid(pos + Vec2f(map.tilesize,  0))             ||
+				map.isTileSolid(pos + Vec2f(-map.tilesize, 0))
+			);
+			if (no_build || (no_solids || no_blobs) && has_adjacent)
+			{
+				return false;
+			}
+		}
 		// Is our blob not a ladder and are we trying to place it into a no build, solids, or blobs area
-        else if (no_build && blobToPlace.getName() != "ladder" || no_solids || no_blobs)
-        {
+		else if (no_build && blobToPlace.getName() != "ladder" || no_solids || no_blobs)
+		{
 			return false;
-        }
-    }
+		}
+	}
 	
 	// Are we trying to place a blob on a door/ladder/platform/bridge (usually due to lag)?
 	if (fakeHasTileSolidBlobs(cursorPos) && !repairing)
@@ -590,10 +590,10 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (PlaceBlob(this, carryBlob, aimpos))
 		{
 			CPlayer@ p = this.getPlayer();
-            if (p !is null)
-            {
-                GE_BuildBlob(p.getNetworkID(), carryBlob.getName()); // gameplay event for coins
-            }
+			if (p !is null)
+			{
+				GE_BuildBlob(p.getNetworkID(), carryBlob.getName()); // gameplay event for coins
+			}
 		}
 
 	}
@@ -623,7 +623,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				if (p !is null)
 				{
 					GE_BuildBlob(p.getNetworkID(), carryBlob.getName()); // gameplay event for coins
-                }
+				}
 			}
 		}
 		else // there's nothing here so we can place a new one

--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -77,16 +77,16 @@ bool serverTileCheck(CBlob@ blob, u8 tileIndex, Vec2f cursorPos)
 	if (map.isTileCollapsing(cursorPos))
 		return false;
 
-	// Is our tile solid and are we trying to place it into a no build area
-	if (map.isTileSolid(tileIndex))
+	// Is our tile solid and are we trying to place it into a no build or no solids sectors
+	BuildBlock @blockToPlace = getBlockByIndex(blob, tileIndex);
+	if (map.isTileSolid(blockToPlace.tile))
 	{
 		pos = cursorPos + Vec2f(map.tilesize * 0.5f, map.tilesize * 0.5f);
 
-		if (map.getSectorAtPosition(pos, "no build") !is null)
+		if (map.getSectorAtPosition(pos, "no build") !is null || map.getSectorAtPosition(pos, "no solids") !is null)
 			return false;
 	}
 
-	BuildBlock @blockToPlace = getBlockByIndex(blob, tileIndex);
 	// Are we trying to place a tile on the same tile (usually due to lag)?
 	if (backtile.type == blockToPlace.tile)
 	{
@@ -153,6 +153,7 @@ void onTick(CBlob@ this)
 
 	if (buildtile > 0)
 	{
+		bc.blockType = buildtile;
 		bc.blockActive = true;
 		bc.blobActive = false;
 		CMap@ map = this.getMap();

--- a/Entities/Common/Building/BlockPlacement.as
+++ b/Entities/Common/Building/BlockPlacement.as
@@ -79,7 +79,7 @@ bool serverTileCheck(CBlob@ blob, u8 tileIndex, Vec2f cursorPos)
 
 	// Is our tile solid and are we trying to place it into a no build or no solids sectors
 	BuildBlock @blockToPlace = getBlockByIndex(blob, tileIndex);
-	if (map.isTileSolid(blockToPlace.tile))
+	if (map.isTileSolid(blockToPlace.tile) || cursorPos.y < map.tilesize * 3.0f)
 	{
 		pos = cursorPos + Vec2f(map.tilesize * 0.5f, map.tilesize * 0.5f);
 

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -16,6 +16,7 @@ shared class BlockCursor
 	bool blobActive;
 	bool sameTileOnBack;
 	CBitStream missing;
+	u16 blockType;
 
 	BlockCursor()
 	{
@@ -163,7 +164,12 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 			}
 		}
 
-		if (!isSeed && !isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null)
+		// Prevent placing in no build, no solids, and no blobs sectors
+		const bool no_build  = !isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null;
+        const bool no_solids = buildSolid && map.getSectorAtPosition(middle, "no solids") !is null;
+        const bool no_blobs  = blob !is null && map.getSectorAtPosition(middle, "no blobs") !is null;
+        const bool has_adjacent = map.isTileSolid(up) || map.isTileSolid(down) || map.isTileSolid(left) || map.isTileSolid(right);
+		if (!isSeed && (no_build || (!isSpikes || has_adjacent) && (no_solids || no_blobs)))
 		{
 			return false;
 		}

--- a/Entities/Common/Building/PlacementCommon.as
+++ b/Entities/Common/Building/PlacementCommon.as
@@ -21,6 +21,7 @@ shared class BlockCursor
 	BlockCursor()
 	{
 		blobActive = blockActive = buildableAtPos = rayBlocked = hasReqs = supported = buildable = cursorClose = sameTileOnBack = false;
+		blockType = 0;
 	}
 };
 
@@ -165,10 +166,10 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 		}
 
 		// Prevent placing in no build, no solids, and no blobs sectors
-		const bool no_build  = !isLadder && (buildSolid || isSpikes || isDoor || isPlatform) && map.getSectorAtPosition(middle, "no build") !is null;
-        const bool no_solids = buildSolid && map.getSectorAtPosition(middle, "no solids") !is null;
-        const bool no_blobs  = blob !is null && map.getSectorAtPosition(middle, "no blobs") !is null;
-        const bool has_adjacent = map.isTileSolid(up) || map.isTileSolid(down) || map.isTileSolid(left) || map.isTileSolid(right);
+		const bool no_build  = !isLadder && (buildSolid || isSpikes || isDoor || isPlatform || y < 3) && map.getSectorAtPosition(middle, "no build") !is null;
+		const bool no_solids = buildSolid && map.getSectorAtPosition(middle, "no solids") !is null;
+		const bool no_blobs  = blob !is null && map.getSectorAtPosition(middle, "no blobs") !is null;
+		const bool has_adjacent = map.isTileSolid(up) || map.isTileSolid(down) || map.isTileSolid(left) || map.isTileSolid(right);
 		if (!isSeed && (no_build || (!isSpikes || has_adjacent) && (no_solids || no_blobs)))
 		{
 			return false;
@@ -176,49 +177,50 @@ bool isBuildableAtPos(CBlob@ this, Vec2f p, TileType buildTile, CBlob @blob, boo
 
 		//if (blob is null)
 		//middle += Vec2f(map.tilesize*0.5f, map.tilesize*0.5f);
-
-		const string name = blob !is null ? blob.getName() : "";
-		CBlob@[] blobsInRadius;
-		if (map.getBlobsInRadius(middle, buildSolid ? map.tilesize : 0.0f, @blobsInRadius))
+		if (!isLadder)
 		{
-			for (uint i = 0; i < blobsInRadius.length; i++)
+			const string name = blob !is null ? blob.getName() : "";
+			CBlob@[] blobsInRadius;
+			if (map.getBlobsInRadius(middle, buildSolid ? map.tilesize : 0.0f, @blobsInRadius))
 			{
-				CBlob @b = blobsInRadius[i];
-				if (!b.isAttached() && b !is blob)
+				for (uint i = 0; i < blobsInRadius.length; i++)
 				{
-					if (blob !is null || buildSolid)
+					CBlob @b = blobsInRadius[i];
+					if (!b.isAttached() && b !is blob)
 					{
-						if (b is this && b.getName() == "spikes") continue;
-
-						Vec2f bpos = b.getPosition();
-
-						bool cantBuild = isBlocking(b);
-						bool buildingOnTeam = isDoor && (b.getTeamNum() == this.getTeamNum() || b.getTeamNum() == 255) && !b.getShape().isStatic() && this !is b;
-						bool ladderBuild = isLadder && !b.getShape().isStatic();
-
-						// cant place on any other blob
-						if (!ladderBuild &&
-							!buildingOnTeam &&
-							cantBuild &&
-							!b.hasTag("dead") &&
-							!b.hasTag("material") &&
-							!b.hasTag("projectile"))
+						if (blob !is null || buildSolid)
 						{
-							f32 angle_decomp = Maths::FMod(Maths::Abs(b.getAngleDegrees()), 180.0f);
-							bool rotated = angle_decomp > 45.0f && angle_decomp < 135.0f;
-							f32 width = rotated ? b.getHeight() : b.getWidth();
-							f32 height = rotated ? b.getWidth() : b.getHeight();
-							if ((middle.x > bpos.x - width * 0.5f) && (middle.x < bpos.x + width * 0.5f)
-								&& (middle.y > bpos.y - height * 0.5f) && (middle.y < bpos.y + height * 0.5f))
+							if (b is this && b.getName() == "spikes") continue;
+
+							Vec2f bpos = b.getPosition();
+
+							bool cantBuild = isBlocking(b);
+							bool buildingOnTeam = isDoor && (b.getTeamNum() == this.getTeamNum() || b.getTeamNum() == 255) && !b.getShape().isStatic() && this !is b;
+							bool ladderBuild = isLadder && !b.getShape().isStatic();
+
+							// cant place on any other blob
+							if (!ladderBuild &&
+								!buildingOnTeam &&
+								cantBuild &&
+								!b.hasTag("dead") &&
+								!b.hasTag("material") &&
+								!b.hasTag("projectile"))
 							{
-								return false;
+								f32 angle_decomp = Maths::FMod(Maths::Abs(b.getAngleDegrees()), 180.0f);
+								bool rotated = angle_decomp > 45.0f && angle_decomp < 135.0f;
+								f32 width = rotated ? b.getHeight() : b.getWidth();
+								f32 height = rotated ? b.getWidth() : b.getHeight();
+								if ((middle.x > bpos.x - width * 0.5f) && (middle.x < bpos.x + width * 0.5f)
+									&& (middle.y > bpos.y - height * 0.5f) && (middle.y < bpos.y + height * 0.5f))
+								{
+									return false;
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-
 
 		if (isSeed)
 		{

--- a/Entities/Items/Crate/Crate.as
+++ b/Entities/Items/Crate/Crate.as
@@ -804,12 +804,6 @@ bool canUnpackHere(CBlob@ this)
 		}
 	}
 
-	//no unpacking at map ceiling
-	if (pos.y + 4 < (space.y + 2) * map.tilesize)
-	{
-		return false;
-	}
-
 	const bool water = this.hasTag("unpack_only_water");
 	bool inwater = this.isInWater() || map.isInWater(pos + Vec2f(0.0f, map.tilesize));
 	if (this.isAttached())

--- a/Entities/Structures/Ladder/Ladder.as
+++ b/Entities/Structures/Ladder/Ladder.as
@@ -4,8 +4,6 @@
 
 void onInit(CBlob@ this)
 {
-	this.Tag("ignore blocking actors");
-
 	CShape@ shape = this.getShape();
 	if (shape is null) return;
 

--- a/Entities/Structures/Spikes/Spikes.as
+++ b/Entities/Structures/Spikes/Spikes.as
@@ -126,6 +126,18 @@ void onTick(CBlob@ this)
 		facing = temp.facing;
 		placedOnStone = temp.placedOnStone;
 		onSurface = temp.onSurface;
+
+		// Allow spike drop at top of map
+        CMap::Sector@[] sectors;
+        map.getSectorsAtPosition(pos, sectors);
+        for (u8 i = 0; i < sectors.length; i++)
+        {
+            if (sectors[i] !is null && (sectors[i].name == "no build" || sectors[i].name == "no solids" || sectors[i].name == "no blobs"))
+            {
+                onSurface = false;
+				break;
+            }
+        }
 	}
 
 	if (!onSurface && getNet().isServer())

--- a/Entities/Structures/Spikes/Spikes.as
+++ b/Entities/Structures/Spikes/Spikes.as
@@ -88,7 +88,7 @@ void onTick(CBlob@ this)
 	const f32 tilesize = map.tilesize;
 
 	if (getNet().isServer() &&
-	        (map.isTileSolid(map.getTile(pos)) || map.rayCastSolid(pos - this.getVelocity(), pos)))
+			(map.isTileSolid(map.getTile(pos)) || map.rayCastSolid(pos - this.getVelocity(), pos)))
 	{
 		this.server_Hit(this, pos, Vec2f(0, -1), 3.0f, Hitters::fall, true);
 		return;
@@ -128,16 +128,16 @@ void onTick(CBlob@ this)
 		onSurface = temp.onSurface;
 
 		// Allow spike drop at top of map
-        CMap::Sector@[] sectors;
-        map.getSectorsAtPosition(pos, sectors);
-        for (u8 i = 0; i < sectors.length; i++)
-        {
-            if (sectors[i] !is null && (sectors[i].name == "no build" || sectors[i].name == "no solids" || sectors[i].name == "no blobs"))
-            {
-                onSurface = false;
+		CMap::Sector@[] sectors;
+		map.getSectorsAtPosition(pos, sectors);
+		for (u8 i = 0; i < sectors.length; i++)
+		{
+			if (sectors[i] !is null && (sectors[i].name == "no build" || sectors[i].name == "no solids" || sectors[i].name == "no blobs"))
+			{
+				onSurface = false;
 				break;
-            }
-        }
+			}
+		}
 	}
 
 	if (!onSurface && getNet().isServer())

--- a/Rules/CommonScripts/ExtraNoBuild.as
+++ b/Rules/CommonScripts/ExtraNoBuild.as
@@ -24,6 +24,14 @@ void onRestart(CRules@ this)
 	Vec2f brCeiling = Vec2f(mapWidth, barrierHeight);
 	map.server_AddSector(tlCeiling, brCeiling, "no build");
 
+	// Prevents any solid blocks
+	brCeiling.y += barrierHeight;
+    map.server_AddSector(tlCeiling, brCeiling, "no solids");
+
+	// Prevents any blobs
+    brCeiling.y += map.tilesize;
+    map.server_AddSector(tlCeiling, brCeiling, "no blobs");
+
 	// Left
 	Vec2f tlLeft = Vec2f(0.0f, barrierHeight);
 	Vec2f brLeft = Vec2f(barrierWidth, mapHeight);

--- a/Rules/CommonScripts/ExtraNoBuild.as
+++ b/Rules/CommonScripts/ExtraNoBuild.as
@@ -26,11 +26,11 @@ void onRestart(CRules@ this)
 
 	// Prevents any solid blocks
 	brCeiling.y += barrierHeight;
-    map.server_AddSector(tlCeiling, brCeiling, "no solids");
+	map.server_AddSector(tlCeiling, brCeiling, "no solids");
 
 	// Prevents any blobs
-    brCeiling.y += map.tilesize;
-    map.server_AddSector(tlCeiling, brCeiling, "no blobs");
+	brCeiling.y += map.tilesize;
+	map.server_AddSector(tlCeiling, brCeiling, "no blobs");
 
 	// Left
 	Vec2f tlLeft = Vec2f(0.0f, barrierHeight);

--- a/Rules/CommonScripts/KAG.as
+++ b/Rules/CommonScripts/KAG.as
@@ -79,9 +79,27 @@ void onTick(CRules@ this)
 				break;
 			}
 		}
-		map.SetBorderColourTop(SColor(has_solid_tiles ? 0xff000000 : 0x80000000));
+
+		// Set a flag for other scripts
+		if (isServer() && this !is null)
+		{
+			this.set_bool("collide with ceiling", has_solid_tiles);
+			this.Sync("collide with ceiling", true);
+		}
+
+		map.SetBorderColourTop(SColor(has_solid_tiles ? 0xff000000 : 0x30000000));
 	}
 }
+
+void onBlobCreated(CRules@ this, CBlob@ blob)
+{
+	// Remove collision with the top of the map if it's not a cave map
+	if (blob !is null && this !is null && !this.get_bool("collide with ceiling"))
+	{
+		blob.SetMapEdgeFlags(blob.getMapEdgeFlags() & ~CBlob::map_collide_up);
+	}
+}
+
 
 //chat stuff!
 


### PR DESCRIPTION
## Status
- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description
Changes behavior for interacting with the top of the map. Towers at max build height essentially get an artificial buff in how hard they are to get over. This is extra noticeable with the incoming general cut to all map heights with my map cycle update.

## Steps to Test or Reproduce

Adds new `no blobs` and `no solids` sectors to the top of the map. The `no blobs` sector prevents building all static blobs besides shops. The `no solids` sector prevents building any solid blocks. You can still spike drop in these new sectors, as long as the spike will fall.

Original `no build`:
![image](https://github.com/user-attachments/assets/1459082b-b310-45a9-a9b6-27474c689b96)

New `no solids`:
![image](https://github.com/user-attachments/assets/4f62af61-e972-4635-b210-b08159fc86dc)

New `no blobs`:
![image](https://github.com/user-attachments/assets/b96597d3-470e-4f63-8ef4-1253065aabca)

These have the following net effect:
1. You can always build shops at the top of the map
2. You can always put solid blocks in front of doors on the top of the map, unless you have vertical ladders or an exposed shop in the way

You can no longer place backwall (or any block) in the top 3 blocks of the map. This avoids an issue with invulnerable backwall at the 3rd layer at the top of the map where it could be built inside the `no build` zone.

Blobs are no longer limited to the top of the map when it is not a cave map (defined as any blocks at the top of the map in `KAG.as`). This allows players to get over the top of towers much easier rather than being bottle-necked at build height. The border color for the top of the map is lighter when it is not a cave map.
![image](https://github.com/user-attachments/assets/acf85af5-c177-40bd-be85-cbfd7df90f6b)

Cave maps are dark and prevent blobs from passing through as normal. Crates can now deploy at any height:
![image](https://github.com/user-attachments/assets/869abdc0-46ea-4bcc-800b-b6b28a912af9)

These changes have been used on US captains for over a year. They are pretty universally well received.

