### PR TITLE
[fix] drill null onrender

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -489,9 +489,11 @@ void onThisAddToInventory(CBlob@ this, CBlob@ blob)
 void onRender(CSprite@ this)
 {
 	CPlayer@ local = getLocalPlayer();
-	CBlob@ localBlob = local.getBlob();
+	if (local is null)
+		return;
 
-	if (local is null || localBlob is null)
+	CBlob@ localBlob = local.getBlob();
+	if (localBlob is null)
 		return;
 
 	CBlob@ blob = this.getBlob();


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

local can be null. this fixes it.

## Steps to Test or Reproduce

Put a bunch of drills on a map, load the map, you should see null reference in console.