### PR TITLE
[fixed] magazines wouldn't spawn food

### DIFF
--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -183,7 +183,7 @@ class PNGLoader
 				string name;
 				if(alpha == items.length) // random
 				{
-					name = items[XORRandom(items.length - 1)];
+					name = items[XORRandom(items.length)];
 				}
 				else
 				{


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.

## Description

XORRandom was treated like it was inclusive, preventing food spawning (mainly in TDM).

## Steps to Test or Reproduce

1) Load into a map with magazines, such as Noah_Subterranean
2) Food should spawn from a magazine. If not, try to restart the map a few times.