### PR TITLE
Brain activated knight/archer command

### DIFF
--- a/Rules/CommonScripts/ChatCommands.cfg
+++ b/Rules/CommonScripts/ChatCommands.cfg
@@ -24,6 +24,8 @@ commands =
 	scroll; 0; 1;
 	bot; 1; 1;
 	spawn; 0; 1;
+	knight; 0; 1;
+	archer; 0; 1;
 	time; 0; 1;
 	startgame; 1; 0;
 	endgame; 1; 0;

--- a/Rules/CommonScripts/ChatCommands/BlobCommands.as
+++ b/Rules/CommonScripts/ChatCommands/BlobCommands.as
@@ -183,3 +183,85 @@ class SpawnCommand : BlobCommand
 		}
 	}
 }
+
+class KnightCommand : BlobCommand
+{
+	KnightCommand()
+	{
+		super("knight", "Spawn a knight with activated brain");
+		SetUsage("(level, max and default 15)");
+	}
+
+	void SpawnBlobAt(Vec2f pos, string[] args, CPlayer@ player)
+	{
+		string blobName = "knight";
+
+		if (isBlobBlacklisted(blobName, player))
+		{
+			server_AddToChat(getTranslatedString("This blacklisted blob cannot be spawned"), ConsoleColour::ERROR, player);
+			return;
+		}
+
+		int level = args.size() >= 1 ? parseInt(args[0]) : 15;
+
+		if (level < 0 || level > 15)
+		{
+			server_AddToChat(getTranslatedString("Level must be >= 0 and <= 15"), ConsoleColour::ERROR, player);
+			return;
+		}
+
+		u8 team = player.getBlob().getTeamNum();
+
+		CBlob@ newBlob = server_CreateBlob(blobName, team, pos + Vec2f(0, -5));
+
+		if (newBlob !is null)
+		{
+			newBlob.set_s32("difficulty", level);
+			newBlob.getBrain().server_SetActive(true);
+		}
+	}
+}
+
+class ArcherCommand : BlobCommand
+{
+	ArcherCommand()
+	{
+		super("archer", "Spawn a archer with activated brain");
+		SetUsage("(level, max and default 15)");
+	}
+
+	void SpawnBlobAt(Vec2f pos, string[] args, CPlayer@ player)
+	{
+		string blobName = "archer";
+
+		if (isBlobBlacklisted(blobName, player))
+		{
+			server_AddToChat(getTranslatedString("This blacklisted blob cannot be spawned"), ConsoleColour::ERROR, player);
+			return;
+		}
+
+		int level = args.size() >= 1 ? parseInt(args[0]) : 15;
+
+		if (level < 0 || level > 15)
+		{
+			server_AddToChat(getTranslatedString("Level must be >= 0 and <= 15"), ConsoleColour::ERROR, player);
+			return;
+		}
+
+		u8 team = player.getBlob().getTeamNum();
+
+		CBlob@ newBlob = server_CreateBlob(blobName, team, pos + Vec2f(0, -5));
+
+		if (newBlob !is null)
+		{
+			newBlob.set_s32("difficulty", level);
+			newBlob.getBrain().server_SetActive(true);
+
+			CBlob@ mat = server_CreateBlob("mat_arrows");
+			if (mat !is null)
+			{
+				newBlob.server_PutInInventory(mat);
+			}
+		}
+	}
+}

--- a/Rules/CommonScripts/DefaultChatCommands.as
+++ b/Rules/CommonScripts/DefaultChatCommands.as
@@ -51,5 +51,7 @@ void RegisterDefaultChatCommands(ChatCommandManager@ manager)
 	manager.RegisterCommand(ScrollCommand());
 	manager.RegisterCommand(BotCommand());
 	manager.RegisterCommand(SpawnCommand());
+	manager.RegisterCommand(KnightCommand());
+	manager.RegisterCommand(ArcherCommand());
 	manager.RegisterCommand(TimeCommand());
 }


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game. fixed.

## Description

New command
/knight (level)
/archer (level)

## Steps to Test or Reproduce

1. Open kag with config sv_test = 1
2. Type /knight 15 or /archer 15(0~15) in chat
3. Type /team 1
4. See behavior of spawned knight/archer