### PR TITLE
[fixed] Capturing an enemy flag multiple times

### DIFF
--- a/Entities/Special/CTF/FlagBase.as
+++ b/Entities/Special/CTF/FlagBase.as
@@ -123,7 +123,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	{
 		//carrying enemy flag
 		CBlob@ flag = blob.getCarriedBlob();
-		if (flag !is null && flag.getName() == flag_name && flag.getTeamNum() != this.getTeamNum())
+		if (flag !is null && !flag.hasTag("was captured") && flag.getName() == flag_name && flag.getTeamNum() != this.getTeamNum())
 		{
 			CPlayer@ p = blob.getPlayer();
 			if (p !is null)
@@ -142,6 +142,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 			CBitStream params;
 			params.write_netid(blob.getNetworkID());
 			flag.SendCommand(flag.getCommandID("capture flag client"), params);
+			flag.Tag("was captured");
 		}
 	}
 }


### PR DESCRIPTION
## Description

You could capture an enemy flag in both of your own flag bases on certain maps. This would give you twice the bonus money, play the sound effect twice simultaneously and send the "flag has been captured" message to the chat twice.
This PR fixes that by tagging the captured flag `was captured` and checking for that tag before giving money or sending a message.

Fixes https://github.com/transhumandesign/kag-base/issues/2352

## Steps to Test or Reproduce

Load map `HearthPlains`
Build ladder right above your two flag bases.
Hold an enemy flag and drop down right in the middle between the two flag bases.
You will get twice the money and the "flag has been captured" message will be shown in the chat twice.
**After this PR, you will still only get the money once and the chat message will be shown only once.**

This was tested and verified in local host.