### PR TITLE
[new] Enable active sync on a few blobs

### DIFF
--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -22,6 +22,8 @@ void onInit(CBlob@ this)
 	this.SetChatBubbleFont("hud");
 	this.maxChatBubbleLines = 4;
 
+	this.getShape().SetActiveSync(true);
+
 	InitKnockable(this);
 }
 

--- a/Entities/Items/Explosives/Bomb.as
+++ b/Entities/Items/Explosives/Bomb.as
@@ -13,6 +13,7 @@ void onInit(CBlob@ this)
 	SetupBomb(this, bomb_fuse, 48.0f, 3.0f, 24.0f, 0.4f, true);
 	//
 	this.Tag("activated"); // make it lit already and throwable
+	this.getShape().SetActiveSync(true);
 }
 
 //start ugly bomb logic :)

--- a/Entities/Items/Explosives/Keg.as
+++ b/Entities/Items/Explosives/Keg.as
@@ -35,6 +35,8 @@ void onInit(CBlob@ this)
 	}
 
 	this.set_f32("important-pickup", 30.0f);
+
+	this.getShape().SetActiveSync(true);
 }
 
 //sprite update

--- a/Entities/Items/Explosives/Mine/Mine.as
+++ b/Entities/Items/Explosives/Mine/Mine.as
@@ -56,6 +56,8 @@ void onInit(CBlob@ this)
 	this.addCommandID("mine_primed_client");
 
 	this.getCurrentScript().tickIfTag = MINE_PRIMING;
+
+	this.getShape().SetActiveSync(true);
 }
 
 void onInit(CSprite@ this)

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -32,6 +32,7 @@ void onInit(CBlob@ this)
 	consts.bullet = false;
 	consts.net_threshold_multiplier = 4.0f;
 	this.Tag("projectile");
+	this.getShape().SetActiveSync(true);
 
 	//dont collide with top of the map
 	this.SetMapEdgeFlags(CBlob::map_collide_left | CBlob::map_collide_right);

--- a/Entities/Items/Projectiles/BallistaBolt.as
+++ b/Entities/Items/Projectiles/BallistaBolt.as
@@ -20,6 +20,7 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().mapCollisions = false;
 	this.getShape().getConsts().bullet = true;
 	this.getShape().getConsts().net_threshold_multiplier = 4.0f;
+	this.getShape().SetActiveSync(true);
 
 	LimitedAttack_setup(this);
 

--- a/Entities/Vehicles/Catapult/Rock.as
+++ b/Entities/Vehicles/Catapult/Rock.as
@@ -31,6 +31,7 @@ void onInit(CBlob@ this)
 
 	this.getShape().getConsts().mapCollisions = false;
 	this.getShape().getConsts().bullet = false;
+	this.getShape().SetActiveSync(true);
 
 	if (isClient())
 	{


### PR DESCRIPTION
The TLDR is that the blob is synced whilst the box2d body is active (you can check this with g_debug 1). You only want to use this on blobs where knowing where the blob position is very important (e.g. players, projectiles, explosives etc). The trade off is that this will consume more bandwidth.

Disabling this/not setting it will use the default sync method, where every tick, we check to see if our blob position has moved in any direction far enough for the sync to be worth it.

Currently enabled for:
- Anything that uses `RunnerDefault` (Archer, Builder, Knight, Migrant, Necromancer, Princess, Trader)
- Arrows
- Bombs
- BallistaBolt
- Keg
- Mine