### PR TITLE
Do not load runner textures on server

### DIFF
--- a/Entities/Characters/Scripts/RunnerTextures.as
+++ b/Entities/Characters/Scripts/RunnerTextures.as
@@ -175,6 +175,11 @@ RunnerTextures@ getRunnerTextures(CSprite@ sprite)
 //ensure the right texture is used
 void ensureCorrectRunnerTexture(CSprite@ sprite, string shortname, string texture_prefix)
 {
+	if (!isClient())
+	{
+		return;
+	}
+
 	RunnerTextures@ tex = getRunnerTextures(sprite);
 	if (tex is null || tex.shortname != shortname)
 	{

--- a/Rules/CommonScripts/KAG.as
+++ b/Rules/CommonScripts/KAG.as
@@ -28,7 +28,10 @@ void onInit(CRules@ this)
 
 	sv_max_localplayers = 1;
 
-	PrecacheTextures();
+	if (isClient())
+	{
+		PrecacheTextures();
+	}
 
 	//smooth shader
 	Driver@ driver = getDriver();


### PR DESCRIPTION
## Description

Small optimization to server memory usage. AFAIK there isn't ever a point in having those textures be loaded serverside so let's not.