### PR TITLE
[change] Mine does not explode when touching a static enemy arrow or ballista bolt

### DIFF
--- a/Entities/Items/Explosives/Mine/Mine.as
+++ b/Entities/Items/Explosives/Mine/Mine.as
@@ -178,7 +178,7 @@ void onThisRemoveFromInventory(CBlob@ this, CBlob@ inventoryBlob)
 bool explodeOnCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
 	return this.getTeamNum() != blob.getTeamNum() &&
-	(blob.hasTag("flesh") || blob.hasTag("projectile") || blob.hasTag("vehicle"));
+	(blob.hasTag("flesh") || blob.hasTag("vehicle") || (blob.hasTag("projectile") && !blob.getShape().isStatic()));
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)

--- a/Entities/Items/Explosives/Mine/Mine.as
+++ b/Entities/Items/Explosives/Mine/Mine.as
@@ -178,7 +178,7 @@ void onThisRemoveFromInventory(CBlob@ this, CBlob@ inventoryBlob)
 bool explodeOnCollideWithBlob(CBlob@ this, CBlob@ blob)
 {
 	return this.getTeamNum() != blob.getTeamNum() &&
-	(blob.hasTag("flesh") || blob.hasTag("vehicle") || (blob.hasTag("projectile") && !blob.getShape().isStatic()));
+	(blob.hasTag("flesh") || blob.hasTag("vehicle") || (blob.hasTag("projectile") && !blob.hasTag("collided")));
 }
 
 bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)

--- a/Entities/Items/Projectiles/BallistaBolt.as
+++ b/Entities/Items/Projectiles/BallistaBolt.as
@@ -13,7 +13,6 @@ void onInit(CBlob@ this)
 {
 
 	this.set_u8("blocks_pierced", 0);
-	this.set_bool("static", false);
 
 	this.server_SetTimeToDie(20);
 
@@ -48,7 +47,7 @@ void onTick(CBlob@ this)
 {
 	f32 angle = 0;
 
-	if (!this.get_bool("static"))
+	if (!this.hasTag("collided"))
 	{
 
 		Vec2f velocity = this.getVelocity();
@@ -202,7 +201,7 @@ void BallistaHitBlob(CBlob@ this, Vec2f hit_position, Vec2f velocity, const f32 
 {
 
 	if (DoExplosion(this, velocity)
-	        || this.get_bool("static"))
+	        || this.hasTag("collided"))
 		return;
 
 	if (blob.hasTag("flesh"))
@@ -240,7 +239,7 @@ void BallistaHitMap(CBlob@ this, const u32 offset, Vec2f hit_position, Vec2f vel
 {
 
 	if (DoExplosion(this, velocity)
-	        || this.get_bool("static"))
+	        || this.hasTag("collided"))
 		return;
 
 	this.getSprite().PlaySound("ArrowHitGroundFast.ogg");
@@ -286,11 +285,11 @@ void SetStatic(CBlob@ this, const f32 angle)
 	Vec2f position = this.getPosition();
 
 	this.set_u8("angle", Maths::get256DegreesFrom360(angle));
-	this.set_bool("static", true);
+	this.Tag("collided");
 	this.set_f32("lock_x", position.x);
 	this.set_f32("lock_y", position.y);
 
-	this.Sync("static", true);
+	this.Sync("collided", true);
 	this.Sync("lock_x", true);
 	this.Sync("lock_y", true);
 


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2362

This makes it so a Mine does not get triggered by an enemy projectile (arrow, ballista bolt) after it has become static.

Tested in offline, works.

I found this to be odd behavior so I made this change. A primed Mine will still explode on collision with a standstill enemy vehicle (dinghy, mounted bow, catapult, etc.)