### PR TITLE
[change] Coinslot can be used when inactive

### DIFF
--- a/Entities/Structures/Components/Source/CoinSlot/CoinSlot.as
+++ b/Entities/Structures/Components/Source/CoinSlot/CoinSlot.as
@@ -37,7 +37,7 @@ void onInit(CBlob@ this)
 
 	AddIconToken("$insert_coin$", "InteractionIcons.png", Vec2f(32, 32), 26);
 
-	//this.getCurrentScript().tickIfTag = "active";
+	this.getCurrentScript().tickIfTag = "active";
 }
 
 void onSetStatic(CBlob@ this, const bool isStatic)

--- a/Entities/Structures/Components/Source/CoinSlot/CoinSlot.as
+++ b/Entities/Structures/Components/Source/CoinSlot/CoinSlot.as
@@ -37,7 +37,7 @@ void onInit(CBlob@ this)
 
 	AddIconToken("$insert_coin$", "InteractionIcons.png", Vec2f(32, 32), 26);
 
-	this.getCurrentScript().tickIfTag = "active";
+	//this.getCurrentScript().tickIfTag = "active";
 }
 
 void onSetStatic(CBlob@ this, const bool isStatic)
@@ -91,6 +91,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	button.radius = 8.0f;
 	button.enableRadius = 20.0f;
+	button.SetEnabled( !this.hasTag("active") );
 }
 
 void onTick(CBlob@ this)
@@ -104,6 +105,7 @@ void onTick(CBlob@ this)
 	if (!getRules().get("power grid", @grid)) return;
 
 	this.Untag("active");
+	this.Sync("active", true);
 
 	grid.setInfo(
 	component.x,                        // x
@@ -115,6 +117,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
 	if (cmd == this.getCommandID("server_activate") && isServer())
 	{
+		if (this.hasTag("active")) return;
+	
 		CPlayer@ player = getNet().getActiveCommandPlayer();
 		if (player is null) return;
 		
@@ -135,6 +139,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		addCoin(this, COIN_COST / 3);
 
 		this.Tag("active");
+		this.Sync("active", true);
 
 		this.set_u32("duration", getGameTime() + DURATION);
 


### PR DESCRIPTION
## Description

This makes it so you can insert coins only when the coinslot is inactive (not transfering power).
Therefore you will not accidentally insert 60 coins twice in quick succession.

Although this doesn't [directly address the "chest overlapping with coinslot" issue](https://github.com/transhumandesign/kag-base/issues/2294) it does make it so you don't accidentally spend 180 coins when spamming to open the chest. Perhaps this is as close a fix as we can get.

I tested in offline and dedicated server and it works as I intended.