### PR TITLE
Improve picking up, throwing, and putting items in inventory with high ping

### DIFF
--- a/Entities/Characters/Archer/ArcherCommon.as
+++ b/Entities/Characters/Archer/ArcherCommon.as
@@ -85,8 +85,7 @@ shared class ArcherInfo
 
 void ClientSendArrowState(CBlob@ this)
 {
-	if (!isClient()) { return; }
-	if (isServer()) { return; } // no need to sync on localhost
+	if (isClient() && isServer()) { return; } // no need to sync on localhost
 
 	ArcherInfo@ archer;
 	if (!this.get("archerInfo", @archer)) { return; }
@@ -94,7 +93,14 @@ void ClientSendArrowState(CBlob@ this)
 	CBitStream params;
 	params.write_u8(archer.arrow_type);
 
-	this.SendCommand(this.getCommandID("arrow sync"), params);
+	if (isClient())
+	{
+		this.SendCommand(this.getCommandID("arrow sync"), params);
+	}
+	else
+	{
+		this.SendCommand(this.getCommandID("arrow sync client"), params);
+	}
 }
 
 bool ReceiveArrowState(CBlob@ this, CBitStream@ params)
@@ -106,8 +112,14 @@ bool ReceiveArrowState(CBlob@ this, CBitStream@ params)
 	ArcherInfo@ archer;
 	if (!this.get("archerInfo", @archer)) { return false; }
 
+	u8 prevType = archer.arrow_type;
 	archer.arrow_type = 0;
 	if (!params.saferead_u8(archer.arrow_type)) { return false; }
+
+	if (prevType != archer.arrow_type && this.isMyPlayer())
+	{
+		Sound::Play("/CycleInventory.ogg");
+	}
 
 	if (isServer())
 	{

--- a/Entities/Characters/Archer/ArcherCommon.as
+++ b/Entities/Characters/Archer/ArcherCommon.as
@@ -103,35 +103,6 @@ void ClientSendArrowState(CBlob@ this)
 	}
 }
 
-bool ReceiveArrowState(CBlob@ this, CBitStream@ params)
-{
-	// valid both on client and server
-
-	if (isServer() && isClient()) { return false; }
-
-	ArcherInfo@ archer;
-	if (!this.get("archerInfo", @archer)) { return false; }
-
-	u8 prevType = archer.arrow_type;
-	archer.arrow_type = 0;
-	if (!params.saferead_u8(archer.arrow_type)) { return false; }
-
-	if (prevType != archer.arrow_type && this.isMyPlayer())
-	{
-		Sound::Play("/CycleInventory.ogg");
-	}
-
-	if (isServer())
-	{
-		CBitStream reserialized;
-		reserialized.write_u8(archer.arrow_type);
-
-		this.SendCommand(this.getCommandID("arrow sync client"), reserialized);
-	}
-
-	return true;
-}
-
 const string grapple_sync_cmd = "grapple sync";
 
 void SyncGrapple(CBlob@ this)

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -900,6 +900,7 @@ CBlob@ CreateArrow(CBlob@ this, Vec2f arrowPos, Vec2f arrowVel, u8 arrowType)
 	return arrow;
 }
 
+// serverside
 void onCycle(CBitStream@ params)
 {
 	u16 this_id;

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -51,20 +51,12 @@ void onInit(CBlob@ this)
 	this.addCommandID("pickup arrow");
 	this.addCommandID("pickup arrow client");
 	this.addCommandID("request shoot");
-	this.addCommandID("arrow sync");
-	this.addCommandID("arrow sync client");
 	this.getShape().getConsts().net_threshold_multiplier = 0.5f;
 
 	this.addCommandID(grapple_sync_cmd);
 
 	SetHelp(this, "help self hide", "archer", getTranslatedString("Hide    $KEY_S$"), "", 1);
 	SetHelp(this, "help self action2", "archer", getTranslatedString("$Grapple$ Grappling hook    $RMB$"), "", 3);
-
-	//add a command ID for each arrow type
-	for (uint i = 0; i < arrowTypeNames.length; i++)
-	{
-		this.addCommandID("pick " + arrowTypeNames[i]);
-	}
 
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -346,14 +338,11 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		if (!hasarrow && hasnormal)
 		{
 			// set back to default
-			archer.arrow_type = ArrowType::normal;
-			ClientSendArrowState(this);
+			CycleToArrowType(this, ArrowType::normal);
+			CBitStream sparams;
+			sparams.write_u8(ArrowType::normal);
+			this.SendCommand(this.getCommandID("client pick utility"), sparams);
 			hasarrow = hasnormal;
-
-			if (ismyplayer)
-			{
-				Sound::Play("/CycleInventory.ogg");
-			}
 		}
 
 		if (hasarrow != this.get_bool("has_arrow"))
@@ -447,14 +436,11 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 
 			if (!hasarrow && hasnormal)
 			{
-				archer.arrow_type = ArrowType::normal;
-				ClientSendArrowState(this);
+				CycleToArrowType(this, ArrowType::normal);
+				CBitStream sparams;
+				sparams.write_u8(ArrowType::normal);
+				this.SendCommand(this.getCommandID("client pick utility"), sparams);
 				hasarrow = hasnormal;
-
-				if (ismyplayer)
-				{
-					Sound::Play("/CycleInventory.ogg");
-				}
 			}
 
 			if (responsible)
@@ -930,7 +916,10 @@ void onCycle(CBitStream@ params)
 		}
 		if (hasArrows(this, type))
 		{
-			CycleToArrowType(this, archer, type);
+			CycleToArrowType(this, type);
+			CBitStream sparams;
+			sparams.write_u8(type);
+			this.SendCommand(this.getCommandID("server pick utility"), sparams);
 			break;
 		}
 	}
@@ -949,15 +938,12 @@ void onSwitch(CBitStream@ params)
 	u8 type;
 	if (!params.saferead_u8(type)) return;
 
-	ArcherInfo@ archer;
-	if (!this.get("archerInfo", @archer))
-	{
-		return;
-	}
-
 	if (hasArrows(this, type))
 	{
-		CycleToArrowType(this, archer, type);
+		CycleToArrowType(this, type);
+		CBitStream sparams;
+		sparams.write_u8(type);
+		this.SendCommand(this.getCommandID("server pick utility"), sparams);
 	}
 }
 
@@ -1054,7 +1040,12 @@ void onSendCreateData(CBlob@ this, CBitStream@ params)
 
 bool onReceiveCreateData(CBlob@ this, CBitStream@ params)
 {
-	return ReceiveArrowState(this, params);
+	ArcherInfo@ archer;
+	if (!this.get("archerInfo", @archer)) return false;
+
+	if (!params.saferead_u8(archer.arrow_type)) return false;
+
+	return true; 
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
@@ -1079,13 +1070,27 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		ShootArrow(this);
 	}
-	else if (cmd == this.getCommandID("arrow sync") && isServer())
+	else if (cmd == this.getCommandID("client pick utility") && isServer())
 	{
-		ReceiveArrowState(this, params);
+		CPlayer@ callerp = getNet().getActiveCommandPlayer();
+		if (callerp is null) return;
+
+		CBlob@ caller = callerp.getBlob();
+		if (caller is null) return;
+
+		if (caller !is this) return;
+
+		u8 type;
+		if (!params.saferead_u8(type)) return;
+
+		CycleToArrowType(this, type);
 	}
-	else if (cmd == this.getCommandID("arrow sync client") && isClient())
+	else if (cmd == this.getCommandID("server pick utility") && isClient())
 	{
-		ReceiveArrowState(this, params);
+		u8 type;
+		if (!params.saferead_u8(type)) return;
+
+		CycleToArrowType(this, type);
 	}
 	else if (cmd == this.getCommandID("pickup arrow") && isServer())
 	{
@@ -1142,35 +1147,21 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		HandleGrapple(this, params, !canSend(this));
 	}
-	else if (isServer())
-	{
-		ArcherInfo@ archer;
-		if (!this.get("archerInfo", @archer))
-		{
-			return;
-		}
-		for (uint i = 0; i < arrowTypeNames.length; i++)
-		{
-			if (cmd == this.getCommandID("pick " + arrowTypeNames[i]))
-			{
-				CBitStream params;
-				params.write_u8(i);
-				archer.arrow_type = i;
-				this.SendCommand(this.getCommandID("arrow sync client"), params);
-				break;
-			}
-		}
-	}
 }
 
-void CycleToArrowType(CBlob@ this, ArcherInfo@ archer, u8 arrowType)
+void CycleToArrowType(CBlob@ this, u8 arrowType)
 {
+	ArcherInfo@ archer;
+	if (!this.get("archerInfo", @archer)) return;
+
+	u8 prevArrowType = archer.arrow_type;
+	if (arrowType == prevArrowType) return;
+	
 	archer.arrow_type = arrowType;
 	if (this.isMyPlayer())
 	{
 		Sound::Play("/CycleInventory.ogg");
 	}
-	ClientSendArrowState(this);
 }
 
 void Callback_PickArrow(CBitStream@ params)
@@ -1184,16 +1175,10 @@ void Callback_PickArrow(CBitStream@ params)
 	u8 arrow_id;
 	if (!params.saferead_u8(arrow_id)) return;
 
-	ArcherInfo@ archer;
-	if (!blob.get("archerInfo", @archer))
-	{
-		return;
-	}
-
-	archer.arrow_type = arrow_id;
-
-	string matname = arrowTypeNames[arrow_id];
-	blob.SendCommand(blob.getCommandID("pick " + matname));
+	CycleToArrowType(blob, arrow_id);
+	CBitStream sparams;
+	sparams.write_u8(arrow_id);
+	blob.SendCommand(blob.getCommandID("client pick utility"), sparams);
 }
 
 // arrow pick menu
@@ -1285,12 +1270,10 @@ void onAddToInventory(CBlob@ this, CBlob@ blob)
 		{
 			if (itemname == arrowTypeNames[i])
 			{
-				archer.arrow_type = i;
-				ClientSendArrowState(this);
-				if (this.isMyPlayer())
-				{
-					Sound::Play("/CycleInventory.ogg");
-				}
+				CycleToArrowType(this, i);
+				CBitStream sparams;
+				sparams.write_u8(i);
+				this.SendCommand(this.getCommandID("client pick utility"), sparams);
 			}
 		}
 	}

--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -900,7 +900,6 @@ CBlob@ CreateArrow(CBlob@ this, Vec2f arrowPos, Vec2f arrowVel, u8 arrowType)
 	return arrow;
 }
 
-// clientside
 void onCycle(CBitStream@ params)
 {
 	u16 this_id;

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -90,14 +90,12 @@ void onInit(CBlob@ this)
 	this.set("onCycle handle", @controls_cycle);
 
 	this.addCommandID("activate/throw bomb");
+	this.addCommandID("client pick bomb");
+	this.addCommandID("server pick bomb");
 
 	this.push("names to activate", "keg");
 
 	this.set_u8("bomb type", 255);
-	for (uint i = 0; i < bombTypeNames.length; i++)
-	{
-		this.addCommandID("pick " + bombTypeNames[i]);
-	}
 
 	//centered on bomb select
 	//this.set_Vec2f("inventory offset", Vec2f(0.0f, 122.0f));
@@ -1075,6 +1073,7 @@ void SwordCursorUpdate(CBlob@ this, KnightInfo@ knight)
 		}
 }
 
+// serverside
 void onCycle(CBitStream@ params)
 {
 	u16 this_id;
@@ -1099,7 +1098,7 @@ void onCycle(CBitStream@ params)
 			CycleToBombType(this, type);
 			CBitStream sparams;
 			sparams.write_u8(type);
-			this.SendCommand(this.getCommandID("switch"), sparams);
+			this.SendCommand(this.getCommandID("server pick bomb"), sparams);
 			break;
 		}
 	}
@@ -1123,13 +1122,13 @@ void onSwitch(CBitStream@ params)
 		CycleToBombType(this, type);
 		CBitStream sparams;
 		sparams.write_u8(type);
-		this.SendCommand(this.getCommandID("switch"), sparams);
+		this.SendCommand(this.getCommandID("server pick bomb"), sparams);
 	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("switch") && isServer())
+	if (cmd == this.getCommandID("client pick bomb") && isServer())
 	{
 		CPlayer@ callerp = getNet().getActiveCommandPlayer();
 		if (callerp is null) return;
@@ -1139,6 +1138,13 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		if (caller !is this) return;
 		// cycle bombs
+		u8 type;
+		if (!params.saferead_u8(type)) return;
+
+		CycleToBombType(this, type);
+	}
+	else if (cmd == this.getCommandID("server pick bomb") && isClient())
+	{
 		u8 type;
 		if (!params.saferead_u8(type)) return;
 
@@ -1215,21 +1221,13 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		}
 		SetFirstAvailableBomb(this);
 	}
-	else if (isServer())
-	{
-		for (uint i = 0; i < bombTypeNames.length; i++)
-		{
-			if (cmd == this.getCommandID("pick " + bombTypeNames[i]))
-			{
-				this.set_u8("bomb type", i);
-				break;
-			}
-		}
-	}
 }
 
 void CycleToBombType(CBlob@ this, u8 bombType)
 {
+	u8 prevBombType = this.get_u8("bomb type");
+	if (bombType == prevBombType) return;
+
 	this.set_u8("bomb type", bombType);
 	if (this.isMyPlayer())
 	{
@@ -1672,10 +1670,10 @@ void Callback_PickBomb(CBitStream@ params)
 	u8 bomb_id;
 	if (!params.saferead_u8(bomb_id)) return;
 
-	string matname = bombTypeNames[bomb_id];
-	blob.set_u8("bomb type", bomb_id);
-
-	blob.SendCommand(blob.getCommandID("pick " + matname));
+	CycleToBombType(blob, bomb_id);
+	CBitStream sparams;
+	sparams.write_u8(bomb_id);
+	blob.SendCommand(blob.getCommandID("client pick bomb"), sparams);
 }
 
 // bomb pick menu

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -1075,7 +1075,6 @@ void SwordCursorUpdate(CBlob@ this, KnightInfo@ knight)
 		}
 }
 
-// clientside
 void onCycle(CBitStream@ params)
 {
 	u16 this_id;

--- a/Entities/Characters/Knight/KnightLogic.as
+++ b/Entities/Characters/Knight/KnightLogic.as
@@ -90,8 +90,6 @@ void onInit(CBlob@ this)
 	this.set("onCycle handle", @controls_cycle);
 
 	this.addCommandID("activate/throw bomb");
-	this.addCommandID("client pick bomb");
-	this.addCommandID("server pick bomb");
 
 	this.push("names to activate", "keg");
 
@@ -1098,7 +1096,7 @@ void onCycle(CBitStream@ params)
 			CycleToBombType(this, type);
 			CBitStream sparams;
 			sparams.write_u8(type);
-			this.SendCommand(this.getCommandID("server pick bomb"), sparams);
+			this.SendCommand(this.getCommandID("server pick utility"), sparams);
 			break;
 		}
 	}
@@ -1122,13 +1120,13 @@ void onSwitch(CBitStream@ params)
 		CycleToBombType(this, type);
 		CBitStream sparams;
 		sparams.write_u8(type);
-		this.SendCommand(this.getCommandID("server pick bomb"), sparams);
+		this.SendCommand(this.getCommandID("server pick utility"), sparams);
 	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-	if (cmd == this.getCommandID("client pick bomb") && isServer())
+	if (cmd == this.getCommandID("client pick utility") && isServer())
 	{
 		CPlayer@ callerp = getNet().getActiveCommandPlayer();
 		if (callerp is null) return;
@@ -1143,7 +1141,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		CycleToBombType(this, type);
 	}
-	else if (cmd == this.getCommandID("server pick bomb") && isClient())
+	else if (cmd == this.getCommandID("server pick utility") && isClient())
 	{
 		u8 type;
 		if (!params.saferead_u8(type)) return;
@@ -1673,7 +1671,7 @@ void Callback_PickBomb(CBitStream@ params)
 	CycleToBombType(blob, bomb_id);
 	CBitStream sparams;
 	sparams.write_u8(bomb_id);
-	blob.SendCommand(blob.getCommandID("client pick bomb"), sparams);
+	blob.SendCommand(blob.getCommandID("client pick utility"), sparams);
 }
 
 // bomb pick menu

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -45,7 +45,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (caller.isAttached()) return;
 
 		CBlob@ held = this.getCarriedBlob();
-		if (held is null) return;
+		if (held is null)
+		{
+			bool quickswitch;
+			if (!params.saferead_bool(quickswitch)) return;
+
+			ControlsCycle@ onCycle;
+			if (quickswitch && this.get("onCycle handle", @onCycle))
+			{
+				CBitStream params;
+				params.write_u16(this.getNetworkID());
+				params.ResetBitIndex();
+
+				onCycle(params);
+			}
+			return;
+		}
 
 		putInHeld(caller);
 	}
@@ -283,23 +298,7 @@ void onTick(CBlob@ this)
 
 			if (isTap(this, minimum_ticks))     // tap - put thing in inventory
 			{
-				CBlob@ held = this.getCarriedBlob();
-
-				ControlsCycle@ onCycle;
-				if (this.get("onCycle handle", @onCycle))
-				{
-					CBitStream params;
-					params.write_u16(this.getNetworkID());
-					params.ResetBitIndex();
-
-					onCycle(params);
-				}
-
-				if (held !is null)
-				{
-					this.SendCommand(this.getCommandID("putinheld"));
-				}
-
+				client_PutInHeld(this, true);
 				this.ClearMenus();
 				return;
 			}

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -60,18 +60,24 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (caller.isInInventory()) return;
 		if (caller.isAttached()) return;
 
-		u16 pickedup_id;
-		if (!params.saferead_u16(pickedup_id)) return;
+		bool hasBlob;
+		if (!params.saferead_bool(hasBlob)) return;
 
-		CBlob@ pickedup = getBlobByNetworkID(pickedup_id);
-		if (pickedup is null) return;
+		if (hasBlob && this.get_bool("release click"))
+		{
+			u16 pickedup_id;
+			if (!params.saferead_u16(pickedup_id)) return;
 
-		if (!pickedup.canBePickedUp(caller)) return;
+			CBlob@ pickedup = getBlobByNetworkID(pickedup_id);
+			if (pickedup is null) return;
 
-		if (pickedup.isAttached()) return;
+			if (!pickedup.canBePickedUp(caller)) return;
 
-		pickedup.setPosition(caller.getPosition());
-		caller.server_Pickup(pickedup);
+			if (pickedup.isAttached()) return;
+
+			pickedup.setPosition(caller.getPosition());
+			caller.server_Pickup(pickedup);
+		}
 	}
 	else if (cmd == this.getCommandID("detach"))
 	{

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -16,6 +16,8 @@ void onInit(CBlob@ this)
 	this.addCommandID("putinheld");
 	this.addCommandID("getout");
 	this.addCommandID("detach");
+	this.addCommandID("client pick utility");
+	this.addCommandID("server pick utility");
 
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";

--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -16,7 +16,6 @@ void onInit(CBlob@ this)
 	this.addCommandID("putinheld");
 	this.addCommandID("getout");
 	this.addCommandID("detach");
-	this.addCommandID("switch");
 
 	this.getCurrentScript().runFlags |= Script::tick_myplayer;
 	this.getCurrentScript().removeIfTag = "dead";

--- a/Entities/Common/Controls/StandardControlsCommon.as
+++ b/Entities/Common/Controls/StandardControlsCommon.as
@@ -16,13 +16,15 @@ void client_Pickup(CBlob@ this, CBlob@ pickBlob)
 	this.SendCommand(this.getCommandID("pickup"), params);
 }
 
-void client_PutInHeld(CBlob@ this)
+void client_PutInHeld(CBlob@ this, bool quickswitch = false)
 {
     if (!isClient()) return;
 
 	if (this is null) return;
 
-	this.SendCommand(this.getCommandID("putinheld"));
+    CBitStream params;
+    params.write_bool(quickswitch);
+	this.SendCommand(this.getCommandID("putinheld"), params);
 }
 
 void Tap(CBlob@ this)

--- a/Entities/Common/Controls/StandardControlsCommon.as
+++ b/Entities/Common/Controls/StandardControlsCommon.as
@@ -5,10 +5,14 @@ void client_Pickup(CBlob@ this, CBlob@ pickBlob)
 {
     if (!isClient()) return;
 
-	if (this is null || pickBlob is null || pickBlob.isAttached()) return;
+	if (this is null) return;
 
 	CBitStream params;
-	params.write_netid(pickBlob.getNetworkID());
+	params.write_bool(pickBlob !is null);
+	if (pickBlob !is null)
+	{
+		params.write_netid(pickBlob.getNetworkID());
+	}
 	this.SendCommand(this.getCommandID("pickup"), params);
 }
 

--- a/Entities/Common/Controls/StandardPickup.as
+++ b/Entities/Common/Controls/StandardPickup.as
@@ -159,21 +159,12 @@ void onTick(CBlob@ this)
 					CBitStream params;
 					params.write_u16(ap.getOccupied().getNetworkID());
 					this.SendCommand(this.getCommandID("detach"), params);
-					this.set_bool("release click", false);
 					break;
 				}
 			}
 		}
-		else if (carryBlob !is null && !carryBlob.hasTag("custom drop") && (!carryBlob.hasTag("temp blob")))
-		{
-			pickup_netids.clear();
-			client_SendThrowCommand(this);
-			this.set_bool("release click", false);
-		}
-		else
-		{
-			this.set_bool("release click", true);
-		}
+		
+		client_SendThrowCommand(this);
 	}
 	else
 	{
@@ -236,7 +227,7 @@ void onTick(CBlob@ this)
 
 		if (this.isKeyJustReleased(key_pickup))
 		{
-			if (this.get_bool("release click") && closest_netids.length > 0)
+			if (closest_netids.length > 0)
 			{
 				CBlob@ closest = getBlobByNetworkID(closest_netids[0]);
 				client_Pickup(this, closest);

--- a/Entities/Common/Throwing/ActivateHeldObject.as
+++ b/Entities/Common/Throwing/ActivateHeldObject.as
@@ -55,5 +55,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 			//this.Tag( carried.getName() + " done throw" );
 		}
+		
+		this.set_bool("release click", carried is null);
 	}
 }

--- a/Entities/Common/Throwing/ActivationThrowCommon.as
+++ b/Entities/Common/Throwing/ActivationThrowCommon.as
@@ -25,8 +25,7 @@ void client_SendThrowOrActivateCommandBomb(CBlob@ this, u8 bombtype)
 
 void client_SendThrowCommand(CBlob@ this)
 {
-	CBlob @carried = this.getCarriedBlob();
-	if (carried !is null && this.isMyPlayer())
+	if (this.isMyPlayer())
 	{
 		CBitStream params;
 		params.write_Vec2f(this.getPosition());


### PR DESCRIPTION
## Description

Currently, players with high ping suffer from the following setbacks:
- Items can only be put into your inventory when it's visibly in your hand, slowing you down when you need to pick up a lot of items.
- Items can only be thrown when items are visible in your hand, slowing you down when you need to throw a lot of items.

The root cause of this is quick switching being client-side. The client must know what's in your hand before it decides to put the held item in your hand or quick switch bombs/arrows. This can be improved by moving quick switching server-side so the server can decide these actions rather than the client.

The following changes have been implemented:
- Items can be thrown before they are visibly in your hand.
- Items can be put in your inventory before they are visibly in your hand.
- Quick switching bombs/arrows occurs server-side, but this doesn't prevent players from quick switching before shooting. The arrow that was switched to will be shot even if it hasn't yet switched on the client.
- Manually switching to a bomb/arrow will play the quick switch sound, unless it's already selected. This is to strengthen the association between the sound and the bomb/arrow type changing.
- Manually selecting bombs/arrows is still client-side so it's responsive.

## Steps to Test or Reproduce

Test each change using [clumsy](https://jagt.github.io/clumsy/).