### PR TITLE
[fixed] Tree minimap icon bug

### DIFF
--- a/Entities/Natural/Trees/BushyTreeLogic.as
+++ b/Entities/Natural/Trees/BushyTreeLogic.as
@@ -42,6 +42,8 @@ void onInit(CBlob@ this)
 
 	this.SetMinimapVars("GUI/Minimap/MinimapIcons.png", icon_frame, Vec2f(8, 32));
 	this.SetMinimapRenderAlways(true);
+
+	UpdateMinimapIcon(this, vars);
 }
 
 void GrowSprite(CSprite@ this, TreeVars@ vars)

--- a/Entities/Natural/Trees/PineTreeLogic.as
+++ b/Entities/Natural/Trees/PineTreeLogic.as
@@ -42,6 +42,8 @@ void onInit(CBlob@ this)
 
 	this.SetMinimapVars("GUI/Minimap/MinimapIcons.png", icon_frame, Vec2f(8, 32));
 	this.SetMinimapRenderAlways(true);
+
+	UpdateMinimapIcon(this, vars);
 }
 
 void GrowSprite(CSprite@ this, TreeVars@ vars)


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2357

When rejoining server, any tree that is currently regrowing will be shown to have a small tree icon until it goes through another growth step (`UpdateMinimapIcon(this, vars);` in `DoGrow()` in `TreeSync.as` is called). 

If the tree has finished growing and you rejoin, it will keep the small icon and it will not fix itself until the tree is felled and regrowing again.

This PR fixing that by adding `UpdateMinimapIcon(this, vars);` to `onInit()` in the tree's script files.
Therefore, when rejoining the server the icon will be correct.

Tested in dedicated server while rejoining a bunch of times with trees regrowing or having finished growing.