### PR TITLE
[changed] Catapult launches dinghy less far

### DIFF
--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -93,7 +93,7 @@ class CatapultInfo : VehicleInfo
 			vel += (Vec2f((_r.NextFloat() - 0.5f) * 128, (_r.NextFloat() - 0.5f) * 128) * 0.01f);
 			vel.RotateBy(this.getAngleDegrees());
 
-			if (bullet.hasTag("player"))
+			if (bullet.hasTag("player") || bullet.hasTag("dinghy"))
 			{
 				delay *= f32(cooldown_time_player) / cooldown_time_ammo;
 				bullet.setVelocity(vel * player_launch_modifier);

--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -93,7 +93,7 @@ class CatapultInfo : VehicleInfo
 			vel += (Vec2f((_r.NextFloat() - 0.5f) * 128, (_r.NextFloat() - 0.5f) * 128) * 0.01f);
 			vel.RotateBy(this.getAngleDegrees());
 
-			if (bullet.hasTag("player") || bullet.hasTag("dinghy"))
+			if (bullet.hasTag("player") || bullet.getName() == "dinghy")
 			{
 				delay *= f32(cooldown_time_player) / cooldown_time_ammo;
 				bullet.setVelocity(vel * player_launch_modifier);


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2351

This makes dinghy to get launched the same as players (modifier `0.75f` instead of `1.1f`) and impose the same cooldown as if a player was launched, hopefully fixing the issue with players sitting in dinghies getting shot across the whole map, but not nerfing it too hard so players will still get launched at the velocity they would have got as if they sat in the catapult's mag alone.

Needs testing in match.