### PR TITLE
[fixed] problems related to flipping over vehicles

### DIFF
--- a/Entities/Common/Decaying/DecayIfFlipped.as
+++ b/Entities/Common/Decaying/DecayIfFlipped.as
@@ -12,7 +12,7 @@ void onTick(CBlob@ this)
 	if (dissalowDecaying(this))
 		return;
 
-	const f32 thresh = 45.0f;
+	const f32 thresh = 70.0f;
 	const f32 angle = this.getAngleDegrees();
 	if (angle > thresh && angle < 360.0f - thresh)
 	{

--- a/Entities/Vehicles/Common/Vehicle.as
+++ b/Entities/Vehicles/Common/Vehicle.as
@@ -233,7 +233,9 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			this.getShape().SetStatic(false);
 			this.getShape().doTickScripts = true;
 			this.AddTorque(this.getAngleDegrees() < 180 ? -1000 : 1000);
-			this.AddForce(Vec2f(0, -1000));
+
+			if (this.isOnGround())
+				this.AddForce(Vec2f(0, -1000));
 		}
 	}
 	/// SYNC AMMUNITION

--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -652,5 +652,5 @@ bool Vehicle_doesCollideWithBlob_boat(CBlob@ this, CBlob@ blob)
 bool isFlipped(CBlob@ this)
 {
 	const f32 angle = this.getAngleDegrees();
-	return (angle > 80 && angle < 290);
+	return (angle > 70 && angle < 290);
 }


### PR DESCRIPTION
## Description

This fixes problems related to flipping over upside-down vehicles.

* Flip button makes the vehicle only bounce up if on the ground. 
Fixes [#2335](https://github.com/transhumandesign/kag-base/issues/2335)
* Fix problem where decay damage was applied but you couldn't flip over the vehicle.
Previously,  flipping over could be done when beyond 80° or below -70° and decaying would start if the vehicle was beyond 45°. Now, flipping over can be done when beyond 70° in both directions and decaying starts beyond 70°, making decaying behavior more lenient.

