### PR TITLE
[fixed] Changing class in Warboat not working consistently

### DIFF
--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -102,8 +102,36 @@ void onRespawnCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			return;
 		}
 
-		// Caller overlapping?
-		if (!caller.isOverlapping(this)) return;
+		// Caller in range?
+		CMap@ map = getMap();
+		CMap::Sector@ change_class_sector = map.getSector("change class zone "+this.getNetworkID());
+		if (change_class_sector !is null)
+		{
+			//check if player is in sector
+			CBlob@[] blobsInSector;
+			if (map.getBlobsInSector(change_class_sector, @blobsInSector))
+			{
+				bool callerFound = false;
+
+				for (uint i = 0; i < blobsInSector.length; i++)
+				{
+					CBlob@ b = blobsInSector[i];
+					if (b is caller)
+					{
+						callerFound = true;
+						break;
+					}
+				}
+				
+				if (!callerFound)
+					return;
+			}
+		}
+		else
+		{
+			//sector doesn't exist, check if overlapping instead
+			if (!caller.isOverlapping(this)) return;
+		}
 
 		// Don't spam the server with class change
 		if (caller.getTickSinceCreated() < 10) return;

--- a/Entities/Vehicles/Boats/WarBoat/WarBoat.as
+++ b/Entities/Vehicles/Boats/WarBoat/WarBoat.as
@@ -131,6 +131,8 @@ void onInit(CBlob@ this)
 	map.server_AddMovingSector(Vec2f(-48.0f, 0.0f), Vec2f(-33.0f, 20.0f), "ladder", this.getNetworkID());
 	// add custom capture zone
 	map.server_AddMovingSector(Vec2f(-34.0f, -30.0f), Vec2f(16.0f, 5.0f), "capture zone "+this.getNetworkID(), this.getNetworkID());
+	// add change class zone
+	map.server_AddMovingSector(Vec2f(-32.0f, -16.0f), Vec2f(32.0f, 16.0f), "change class zone "+this.getNetworkID(), this.getNetworkID());
 
 	//set custom minimap icon
 	this.SetMinimapOutsideBehaviour(CBlob::minimap_snap);
@@ -205,3 +207,32 @@ void onDie(CBlob@ this)
 		}
 	}
 }
+
+// show change class sector
+/*
+void onRender(CSprite@ this)
+{
+	if (g_videorecording)
+		return;
+
+	CBlob@ blob = this.getBlob();
+	CCamera@ camera = getCamera();
+	if (blob is null)
+		return;
+
+	CMap@ map = getMap();
+	CMap::Sector@ change_class_sector = map.getSector("change class zone "+blob.getNetworkID());
+	if (change_class_sector !is null)
+	{
+		Vec2f tl = change_class_sector.upperleft;
+		Vec2f br = change_class_sector.lowerright;
+		Vec2f tr = Vec2f(br.x, tl.y);
+		Vec2f bl = Vec2f(tl.x, br.y);
+		
+		GUI::DrawLine(tl, tr, SColor(0xffffffff));
+		GUI::DrawLine(tr, br, SColor(0xffffffff));
+		GUI::DrawLine(br, bl, SColor(0xffffffff));
+		GUI::DrawLine(bl, tl, SColor(0xffffffff));
+	}
+}
+*/


### PR DESCRIPTION
## Description
Fixes https://github.com/transhumandesign/kag-base/issues/2342

Changing class on warboat didn't work consistently because of the check `if (!caller.isOverlapping(this)) return;` in `StandardRespawnCommand.as` triggering. Basicly, you would have to actually touch the boat's shape and even then it wouldn't work sometimes.

This PR adds a sector to warboat `"change class zone "+this.getNetworkID()` which `StandardRespawnCommand.as` will now check if it exists: 
- If yes, it will check if the player who wants to change class is inside the sector. 
- If no, it will use the old check if the player is overlapping with the respawn point.

Now players can consistently change class when on the boat, even if they are on the ladder.

Tested, it works.

I added commented out code which displays the change class sector.

The sector looks like this:

<img width="577" height="490" alt="changeclasssector" src="https://github.com/user-attachments/assets/8b29522c-1759-4b4c-a437-1602d1337ff1" />

## Reproduction Steps

Go to any game mode and spawn a warboat on water.
Try to change class a few times - sometimes it will not let you change class.
If you are on the ladder without touching the boat, it will never let you change class.
__After this PR, it will always let you change class if you are inside of the boat__
