### PR TITLE
[added] DecayIfInSky script, [removed] DecayIfFlipped from bomber

### DIFF
--- a/Entities/Common/Decaying/DecayIfInSky.as
+++ b/Entities/Common/Decaying/DecayIfInSky.as
@@ -1,0 +1,21 @@
+#include "DecayCommon.as";
+
+#define SERVER_ONLY
+
+void onInit(CBlob@ this)
+{
+	this.getCurrentScript().tickFrequency = 84; // opt
+}
+
+void onTick(CBlob@ this)
+{
+	if (dissalowDecaying(this))
+		return;
+
+	if (this.getPosition().y < this.getHeight())
+	{
+		if (DECAY_DEBUG)
+			printf(this.getName() + " decay sky high");
+		SelfDamage(this);
+	}
+}

--- a/Entities/Common/Decaying/DecayIfInSky.as
+++ b/Entities/Common/Decaying/DecayIfInSky.as
@@ -15,7 +15,7 @@ void onTick(CBlob@ this)
 	if (this.getPosition().y < this.getHeight())
 	{
 		if (DECAY_DEBUG)
-			printf(this.getName() + " decay sky high");
+			printf(this.getName() + " decay in sky");
 		SelfDamage(this);
 	}
 }

--- a/Entities/Vehicles/Airships/Bomber.as
+++ b/Entities/Vehicles/Airships/Bomber.as
@@ -82,14 +82,6 @@ void onTick(CBlob@ this)
 			if (!this.get("VehicleInfo", @v)) return;
 
 			Vehicle_StandardControls(this, v);
-
-			//TODO: move to atmosphere damage script
-			f32 y = this.getPosition().y;
-			if (y < 100)
-			{
-				if (getGameTime() % 15 == 0)
-					this.server_Hit(this, this.getPosition(), Vec2f(0, 0), y < 50 ? (y < 0 ? 2.0f : 1.0f) : 0.25f, 0, true);
-			}
 		}
 		else
 		{

--- a/Entities/Vehicles/Airships/Bomber.cfg
+++ b/Entities/Vehicles/Airships/Bomber.cfg
@@ -101,7 +101,7 @@ $inventory_name                            = Bomber Compartment
 
 $name                                      = bomber
 @$scripts                              = Seats.as;
-										 DecayIfFlipped.as;
+										 DecayIfInSky.as;
 										 WoodVehicleDamages.as;
 										 Wooden.as;
 										 HurtOnCollide.as;


### PR DESCRIPTION
## Description

Moved Bomber's self damage logic if it is just below the map's upper boundary to a new decay script `DecayIfInSky.as`.

Changed the self damage logic. Instead of applying the damage if the blob's y pos is less than `100.0f`, it now applies if the blob's y pos is less than its height.

Removed `DecayIfFlipped.as` from Bomber's config, since Bomber cannot be flipped.

Worked in testing.