### PR TITLE
[fixed] Bomber and Airship don't keep flying without player

### DIFF
--- a/Entities/Vehicles/Common/VehicleCommon.as
+++ b/Entities/Vehicles/Common/VehicleCommon.as
@@ -127,7 +127,6 @@ void Vehicle_SetupAirship(CBlob@ this, VehicleInfo@ v, const f32 &in flySpeed)
 {
 	v.fly_speed = flySpeed;
 	v.fly_amount = 0.25f;
-	this.Tag("airship");
 }
 
 void Vehicle_SetupGroundSound(CBlob@ this, VehicleInfo@ v, const string &in movementSound, const f32 &in movementVolumeMod, const f32 &in movementPitchMod)
@@ -352,11 +351,6 @@ void Vehicle_StandardControls(CBlob@ this, VehicleInfo@ v)
 			Vehicle_RowerControls(this, blob, ap, v);
 		}
 	}
-
-	if (this.hasTag("airship"))
-	{
-		this.AddForce(Vec2f(0, v.fly_speed * v.fly_amount));
-	}
 }
 
 void Vehicle_DriverControls(CBlob@ this, CBlob@ blob, AttachmentPoint@ ap, VehicleInfo@ v)
@@ -534,6 +528,9 @@ void Vehicle_FlyerControls(CBlob@ this, CBlob@ blob, AttachmentPoint@ ap, Vehicl
 	{
 		this.AddForce(force);
 	}
+
+	// apply force
+	this.AddForce(Vec2f(0, v.fly_speed * v.fly_amount));
 }
 
 void Vehicle_RowerControls(CBlob@ this, CBlob@ blob, AttachmentPoint@ ap, VehicleInfo@ v)


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2343

This fixes that Bomber and Airship would keep flying if attached to a Mounted Bow or Catapult.

Now, the upward movement only keeps applying when a player actually sits in the Flyer position.

Worked in testing.

Note that this makes it so that the Bomber will fall down even if a player would be sitting in the PASSENGER attachment point. Which I think makes sense since the passenger player cannot control the Bomber.