### PR TITLE
[fixed] Fireplace gets extinguished in water

### DIFF
--- a/Entities/Industry/Fireplace/Fireplace.as
+++ b/Entities/Industry/Fireplace/Fireplace.as
@@ -42,11 +42,14 @@ void onTick(CBlob@ this)
 		}
 	}
 
-	if (this.isInWater())
+	// in water? 
+	CMap@ map = getMap();
+	if (this.isInWater() || map.isInWater(this.getPosition() + Vec2f(0, this.getHeight()/2)))
 	{
 		Extinguish(this);
 	}
 
+	// in flames?
 	if (this.isInFlames())
 	{
 		Ignite(this);
@@ -67,7 +70,9 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	}
 	else if (blob.hasTag("fire source")) //fire arrow works
 	{
-		Ignite(this);
+		CMap@ map = getMap();
+		if (!(this.isInWater() || map.isInWater(this.getPosition() + Vec2f(0, this.getHeight()/2))))
+			Ignite(this);
 	}
 }
 

--- a/Entities/Industry/Fireplace/Fireplace.as
+++ b/Entities/Industry/Fireplace/Fireplace.as
@@ -67,10 +67,9 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 			food.setVelocity(blob.getVelocity().opMul(0.5f));
 		}
 	}
-	else if (blob.hasTag("fire source")) //fire arrow works
+	else if (blob.hasTag("fire source") && !isInWater(this)) //fire arrow works
 	{
-		if (!isInWater(this))
-			Ignite(this);
+		Ignite(this);
 	}
 }
 

--- a/Entities/Industry/Fireplace/Fireplace.as
+++ b/Entities/Industry/Fireplace/Fireplace.as
@@ -43,8 +43,7 @@ void onTick(CBlob@ this)
 	}
 
 	// in water? 
-	CMap@ map = getMap();
-	if (this.isInWater() || map.isInWater(this.getPosition() + Vec2f(0, this.getHeight()/2)))
+	if (isInWater(this))
 	{
 		Extinguish(this);
 	}
@@ -70,8 +69,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	}
 	else if (blob.hasTag("fire source")) //fire arrow works
 	{
-		CMap@ map = getMap();
-		if (!(this.isInWater() || map.isInWater(this.getPosition() + Vec2f(0, this.getHeight()/2))))
+		if (!isInWater(this))
 			Ignite(this);
 	}
 }
@@ -145,4 +143,9 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		Ignite(this);
 	}
 	return damage;
+}
+
+bool isInWater(CBlob@ this)
+{
+	return this.isInWater() || getMap().isInWater(this.getPosition() + Vec2f(0, this.getHeight()/2));
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2102

Fireplace could keep burning in one tile tall water or in contructions like this:

![1111](https://github.com/transhumandesign/kag-base/assets/14877281/b627a268-704c-439d-9dae-52a9239cb96c)

because its center position is the only thing checked when using `this.isInWater()`.

This PR changing this so that the center position AND the bottom position gets checked. Also, fireplace that is inside water like this will not be ignited by fire source blobs.

Works in testing.

## Alternative Solution

Alternatively, the `Blob.isInWater()` function could be improved engine-side, but it would probably demand more bandwidth unnecessarily.