### PR TITLE
[changed] Water explosion will wake up sleeping players

### DIFF
--- a/Entities/Industry/CTFShops/Quarters/WakeOnHit.as
+++ b/Entities/Industry/CTFShops/Quarters/WakeOnHit.as
@@ -1,6 +1,7 @@
 // WakeOnHit.as
 
 #include "KnockedCommon.as"
+#include "Hitters.as"
 
 void onHealthChange(CBlob@ this, f32 oldHealth)
 {
@@ -20,4 +21,21 @@ void onHealthChange(CBlob@ this, f32 oldHealth)
 			}
 		}
 	}
+}
+
+f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData )
+{
+	if (customData == Hitters::water_stun_force)
+	{
+		CBlob@ bed = this.getAttachments().getAttachmentPointByName("BED").getOccupied();
+		if (bed !is null)
+		{
+			if (isServer())
+			{
+				this.server_DetachFrom(bed);
+			}
+		}
+	}
+	
+	return damage;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2092

This makes it so waterbomb and water arrow will wake up players who are sleeping in quarters.

Previously, water bomb could explode, even in the sleeping player's inventory, and the player would make a grunt sound but still keep sleeping.

Works in testing.