### PR TITLE
[fixed?] Drill cannot be used by Knight/Archer outside of TDM

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -207,7 +207,7 @@ void onTick(CBlob@ this)
 			sprite.PlaySound("DrillOverheat.ogg");
 		}
 
-		if (holder.getName() == required_class || sv_gamemode == "TDM")
+		if (holder.getName() == required_class || getRules().gamemode_name == "Team Deathmatch")
 		{
 			if (!holder.isKeyPressed(key_action1) || isKnocked(holder))
 			{
@@ -505,7 +505,7 @@ void onRender(CSprite@ this)
 	CBlob@ holderBlob = holder.getBlob();
 	if (holderBlob is null){return;}
 
-	if (holderBlob.getName() != required_class && sv_gamemode != "TDM"){return;}
+	if (holderBlob.getName() != required_class && getRules().gamemode_name != "Team Deathmatch"){return;}
 
 	Vec2f mousePos = getControls().getMouseWorldPos();
 	Vec2f blobPos = blob.getPosition();


### PR DESCRIPTION
## Description

(Hopefully) Fixes https://github.com/transhumandesign/kag-base/issues/2346

The variable `sv_gamemode` seems to be bugged. When playing on a server with one gamemode and then switching to another server with a different gamemode, chances are `sv_gamemode` will not update.

Drill checks for `sv_gamemode` to determine if it can be used. If you are builder or if you are in TDM (according to `sv_gamemode`), you can use it.
When joining TDM and then a different gamemode, it is possible to use the Drill even in Sandbox/CTF, although with glitchy effects (it will heat up but not destroy tiles or deal heat damage to you).

To fix this, I exchanged the check for `sv_gamemode` with a check for `getRules().gamemode_name`. Some other script files also check for the latter, so it should be fine. As far as I tested, the latter seems to update correctly when switching servers.

