### PR TITLE
[fixed] Catapult's arm looks normal

### DIFF
--- a/Entities/Vehicles/Catapult/Catapult.as
+++ b/Entities/Vehicles/Catapult/Catapult.as
@@ -184,8 +184,9 @@ void onTick(CBlob@ this)
 
 	AmmoInfo@ ammo = v.getCurrentAmmo();
 	const f32 time_til_fire = Maths::Max(0, Maths::Min(v.fire_time - getGameTime(), ammo.fire_delay));
-	if (this.hasAttached() || this.get_bool("hadattached") || this.get_bool("facing") != this.isFacingLeft() || time_til_fire > 0)
-	{
+
+	if (this.getTickSinceCreated() == 0 || this.hasAttached() || this.get_bool("hadattached") || this.get_bool("facing") != this.isFacingLeft() || time_til_fire > 0)
+	{	
 		Vehicle_StandardControls(this, v);
 
 		if (v.cooldown_time > 0)


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2389

Between unpacking a catapult or spawning one in, there is a difference with `this.get_bool("facing")`, causing the arm setup to fail for unpacked catapults (or when rejoining the server). I tried a few things but couldn't find out what was causing the difference.

However, the issue is easily fixed by allowing the arm setup to happen on the first tick, by allowing `this.getTickSinceCreated() == 0`. This allows the catapult's arm to look normal when unpacked or when rejoining.

Tested in dedicated server, with spawning / unpacking a bunch of catapults and rejoining a few times.