### PR TITLE
[change] You can't pick up if you are holding something already

### DIFF
--- a/Entities/Common/Controls/StandardControls.as
+++ b/Entities/Common/Controls/StandardControls.as
@@ -59,6 +59,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (caller !is this) return;
 		if (caller.isInInventory()) return;
 		if (caller.isAttached()) return;
+		if (caller.hasAttached()) return;
 
 		u16 pickedup_id;
 		if (!params.saferead_u16(pickedup_id)) return;


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2394

When holding a blob and trying to pickup a 2nd blob via pickup modifier, the 2nd blob won't be picked up.

Tested briefly in dedicated server, works.

Probably also fixes that you would pick up something if you pick up right after selecting an item from your inventory (noticable at high ping).