### PR TITLE
[fixed] Class Quick swapping wasn't working

### DIFF
--- a/Entities/Common/Respawning/StandardRespawnCommand.as
+++ b/Entities/Common/Respawning/StandardRespawnCommand.as
@@ -224,6 +224,8 @@ void CycleClass(CBlob@ this, CBlob@ blob)
 			new_i = 0;
 		}
 
+		params.write_u8(new_i);
+
 		//switch to class
 		this.SendCommand(this.getCommandID("change class"), params);
 	}


### PR DESCRIPTION
## Description

This PR fixes class quick swapping not working due to a missing write to params.

Quick swapping is disabled right now but let's still fix the code, ok?

To test this, you need to set `const bool enable_quickswap = false;` in `StandardRespawnCommand.as` to `true`.