### PR TITLE
[changed] Improved TimeCommand

### DIFF
--- a/Rules/CommonScripts/ChatCommands/MiscCommands.as
+++ b/Rules/CommonScripts/ChatCommands/MiscCommands.as
@@ -84,9 +84,13 @@ class WaterCommand : ChatCommand
 
 class TimeCommand : ChatCommand
 {
+	string[] timeLabels = {"dawn", "noon", "day", "sunset", "night"};
+	f32[] timeValues = {0.12, 0.33, 0.5, 0.82, 0.94};
+
 	TimeCommand()
 	{
 		super("time", "Change day time");
+		SetUsage("[daytime]");
 	}
 
 	void Execute(string[] args, CPlayer@ player)
@@ -95,19 +99,27 @@ class TimeCommand : ChatCommand
 		
 		if (args.size() == 0)
 		{
-			server_AddToChat(getTranslatedString("Specify the time: day, night or a number in range from 0.0 to 1.0"), ConsoleColour::ERROR, player);
+			server_AddToChat(getTranslatedString("Specify the time: " + join(timeLabels, ", ") + " or a number between 0.0 to 1.0"), ConsoleColour::ERROR, player);
 			return;
 		}
 
 		string timeString = args[0];
 		float time = 0;
-		if (timeString == "day")
-			time = 0.14;
-		else if (timeString == "night")
-			time = 0.94;
+		int stringIndex = timeLabels.find(timeString);
+
+		if (stringIndex != -1)
+		{
+			time = timeValues[stringIndex];
+		}
 		else
-			time = parseFloat(timeString);
-		
+		{			
+			if (time < 0 || time > 1)
+			{
+				server_AddToChat(getTranslatedString("Specify a number between 0.0 and 1.0"), ConsoleColour::ERROR, player);
+				return;
+			}
+		}
+
 		getMap().SetDayTime(time);
 	}
 }


### PR DESCRIPTION
## Description

This improves the chat command `TimeCommand()` in `MiscCommands.as` which was added https://github.com/transhumandesign/kag-base/pull/1899 but has not gone live yet.

String array and f32 array have been added. 
The string array is directly parsed into the error message instead of hardsetting the strings.

The code tries to find the inserted string in the string array, rather than checking against hardset strings.

Previously, you could only use `day` and `night` as arguments. 
Now you can use `dawn`, `noon`, `day`, `sunset`, `night`.

An additional error message was added for when a number is inserted that is not between 0 and 1.

Note that - due to https://github.com/transhumandesign/kag-base/issues/2402 - it is still possible that the user enters a random string which sets the day time to 0, rather than returning an error. Please let me know if there is a workaround.

`SetUsage("[daytime]");` has been added so that `/help` will show that `/time [daytime]` has to be typed and not just `/time`.

## Steps to Test or Reproduce
`/help` --> suggests to use `/time`
**After this PR, it suggests to use `/time [day time]`.**

`/time 2` `/time -1` --> Are acceptable numbers
**After this PR, gives an error that asks to enter a value between 0 and 1**

`/time sunset` `/time dawn` `/time noon` --> Don't work
**After this PR, these commands will work**





## Related Post

https://github.com/transhumandesign/kag-base/pull/1899#issuecomment-1936304738