### PR TITLE
fix null pointer access with fire particles after fire arrow shooting

### DIFF
--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -255,8 +255,8 @@ void onTick(CBlob@ this)
 				CParticle@ fire2 = makeFireParticle(Vec2f_lerp(this.getOldPosition(), this.getPosition(), 0.5f) + offset, 4);
 				if (fire2 is null) return;
 
-				fire.velocity = -Vec2f_lerp(this.getOldVelocity(), this.getOldVelocity(), 0.5f)  * 0.06f - Vec2f(0.0f, 0.8f + r.NextFloat() * 0.4f);
-				fire.gravity = Vec2f(0.0f, 0.0f);
+				fire2.velocity = -Vec2f_lerp(this.getOldVelocity(), this.getOldVelocity(), 0.5f)  * 0.06f - Vec2f(0.0f, 0.8f + r.NextFloat() * 0.4f);
+				fire2.gravity = Vec2f(0.0f, 0.0f);
 			}
 
 			if (this.isInWater())

--- a/Entities/Items/Projectiles/Arrow.as
+++ b/Entities/Items/Projectiles/Arrow.as
@@ -244,6 +244,8 @@ void onTick(CBlob@ this)
 			offset += (Vec2f(r.NextFloat(), r.NextFloat()) - Vec2f(0.5, 0.5)) * 6.0f;
 
 			CParticle@ fire = makeFireParticle(this.getPosition() + offset, 4);
+			if (fire is null) return;
+
 			fire.velocity = -this.getVelocity() * 0.06f - Vec2f(0.0f, 0.8f + r.NextFloat() * 0.4f);
 			fire.gravity = Vec2f(0.0f, 0.0f);
 
@@ -251,6 +253,8 @@ void onTick(CBlob@ this)
 			{
 				offset += (Vec2f(r.NextFloat(), r.NextFloat()) - Vec2f(0.5, 0.5)) * 6.0f;
 				CParticle@ fire2 = makeFireParticle(Vec2f_lerp(this.getOldPosition(), this.getPosition(), 0.5f) + offset, 4);
+				if (fire2 is null) return;
+
 				fire.velocity = -Vec2f_lerp(this.getOldVelocity(), this.getOldVelocity(), 0.5f)  * 0.06f - Vec2f(0.0f, 0.8f + r.NextFloat() * 0.4f);
 				fire.gravity = Vec2f(0.0f, 0.0f);
 			}


### PR DESCRIPTION
## Description
It's introduced with pr https://github.com/transhumandesign/kag-base/pull/2319
After firing one fire arrow, arrows stop spawning altogether, writing out lines like this in log (It was discovered during testing of changes in the mod):
```
[16:11:11] <RCON> ../Mods/ctf_gruhsha_v2/Base/Entities/Items/Projectiles/Arrow.as:295:4: Exception in function void onTick(CBlob@): Null pointer access
[16:11:11] <RCON> STACK TRACE -- from above warning/error or getCallStack()
[16:11:11] <RCON> #1: ../Mods/ctf_gruhsha_v2/Base/Entities/Items/Projectiles/Arrow.as:295: void onTick(CBlob@ this)
```

This pull-request fixing that issue.

## Steps to Test or Reproduce
1. launch dedicated server OR join on dedicated server with fresh Base folder (or pick changes from lighting changes PR)
2. shoot one fire arrow
3. try shoot one more
4. arrows cant appear because of null pointer access (can be checked in log).
