### PR TITLE
[dev] Remove unused #include "canGrow.as" from Bush

### DIFF
--- a/Entities/Natural/Bushes/Bush.as
+++ b/Entities/Natural/Bushes/Bush.as
@@ -1,7 +1,5 @@
 // Bush logic
 
-#include "canGrow.as";
-
 void onInit(CBlob@ this)
 {
 	this.set_bool("grown", true);


### PR DESCRIPTION
## Description

This removes an unused `#include "canGrow.as"` from `Bush.as`