### PR TITLE
[changed] Flowers color will not change on rejoin

### DIFF
--- a/Entities/Natural/Flowers/FlowerLogic.as
+++ b/Entities/Natural/Flowers/FlowerLogic.as
@@ -5,10 +5,22 @@
 void onInit(CBlob@ this)
 {
 	this.SetFacingLeft(XORRandom(2) == 0); //random facing
-	this.getSprite().ReloadSprites(uint(XORRandom(8)), 0); //random colour
+
+	CSprite@ sprite = this.getSprite();
+	if (sprite !is null)
+	{
+		//random color
+		u8 col = XORRandom(8);
+		if (this.exists("color"))
+			col = this.get_u8("color");
+		else
+			this.set_u8("color", col);
+		sprite.ReloadSprites(col, 0);
+		
+		sprite.SetZ(10.0f);
+	}
 
 	this.getCurrentScript().tickFrequency = 15;
-	this.getSprite().SetZ(10.0f);
 
 	this.set_u8(growth_chance, default_growth_chance);
 	this.set_u8(growth_time, default_growth_time);


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2409

Flowers color will not change between clients or when rejoining.

Same fix as with chests: https://github.com/transhumandesign/kag-base/pull/2372

(Let's not care about the random facing direction.)

## Reproduction

Be on a server and have flowers grow on the ground.
Rejoin server a few times and notice the flower's color will change.
Talk to a friend and say "see that red flower over there, it's so beautiful" and he will respond "you must be color blind that flower is obviously blue".
**After this PR, flower's color won't change.**