### PR TITLE
[dev] Don't hardset suicide hitter value in RunnerDefault.as

### DIFF
--- a/Entities/Characters/Scripts/RunnerDefault.as
+++ b/Entities/Characters/Scripts/RunnerDefault.as
@@ -73,7 +73,7 @@ bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 // make Suicide ignore invincibility
 f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
 {
-	if (this.hasTag("invincible") && customData == 11)
+	if (this.hasTag("invincible") && customData == Hitters::suicide)
 		this.Untag("invincible");
 	return damage;
 }


### PR DESCRIPTION
## Description

`#include "Hitters.as";` is used so `Hitters::suicide` instead of `11` should be used.

