### PR TITLE
[fixed] Nextmap / Surrender / Scramble vote gets cancelled when a match finishes

### DIFF
--- a/Rules/CommonScripts/DefaultVotes.as
+++ b/Rules/CommonScripts/DefaultVotes.as
@@ -240,6 +240,7 @@ VoteObject@ Create_Votekick(CPlayer@ player, CPlayer@ byplayer, u8 reasonid)
 	vote.user_to_kick = player.getUsername();
 	vote.forcePassFeature = "ban";
 	vote.cancel_on_restart = false;
+	vote.cancel_on_gameover = false;
 
 	CalculateVoteThresholds(vote);
 
@@ -316,6 +317,7 @@ VoteObject@ Create_VoteNextmap(CPlayer@ byplayer, u8 reasonid)
 	vote.byuser = byplayer.getUsername();
 	vote.forcePassFeature = "nextmap";
 	vote.cancel_on_restart = true;
+	vote.cancel_on_gameover = true;
 
 	CalculateVoteThresholds(vote);
 
@@ -409,6 +411,7 @@ VoteObject@ Create_VoteSurrender(CPlayer@ byplayer)
 	vote.byuser = byplayer.getUsername();
 	vote.forcePassFeature = "surrender";
 	vote.cancel_on_restart = true;
+	vote.cancel_on_gameover = true;
 
 	CalculateVoteThresholds(vote);
 
@@ -485,6 +488,7 @@ VoteObject@ Create_VoteScramble(CPlayer@ byplayer)
 	vote.byuser = byplayer.getUsername();
 	vote.forcePassFeature = "scramble";
 	vote.cancel_on_restart = true;
+	vote.cancel_on_gameover = true;
 
 	CalculateVoteThresholds(vote);
 

--- a/Rules/CommonScripts/VoteCommon.as
+++ b/Rules/CommonScripts/VoteCommon.as
@@ -45,6 +45,7 @@ class VoteObject
 		timeremaining = 30 * 30; //default 30s
 		required_percent = 0.5f; //default 50%
 		cancel_on_restart = false;
+		cancel_on_gameover = false;
 	}
 
 	VoteFunctor@ onvotepassed;

--- a/Rules/CommonScripts/VoteCommon.as
+++ b/Rules/CommonScripts/VoteCommon.as
@@ -68,6 +68,7 @@ class VoteObject
 	int timeremaining;
 
 	bool cancel_on_restart;
+	bool cancel_on_gameover;
 };
 
 shared SColor vote_message_colour() { return SColor(0xff444444); }

--- a/Rules/CommonScripts/VoteCore.as
+++ b/Rules/CommonScripts/VoteCore.as
@@ -215,6 +215,18 @@ void onRestart(CRules@ this)
 	}
 }
 
+void onStateChange( CRules@ this, const u8 oldState )
+{
+	if (!this.isGameOver()) return;
+
+	if(Rules_AlreadyHasVote(this))
+	{
+		VoteObject@ vote = Rules_getVote(this);
+		if(vote.cancel_on_gameover)
+			CancelVote(vote, null);
+	}
+}
+
 void onPlayerLeave(CRules@ this, CPlayer@ player)
 {
 	if (Rules_AlreadyHasVote(this))


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2411

This makes it so voting for next map / surrender / scramble gets canceled when the match is finished.

When a team wins, next map doesn't need to get voted since there is going to be a democratic map vote anyway.
When a team wins, the winning team shouldn't change because of the surrender vote.
When a team wins, the game doesn't need to scramble teams and restart.

Works in testing. I edited scripts to allow me to bypass timelimits and required percentages and to change game state on the fly.

