### PR TITLE
[fixed] no build area for chicken isn't offsetted anymore

### DIFF
--- a/Entities/Natural/Animals/Chicken/Chicken.as
+++ b/Entities/Natural/Animals/Chicken/Chicken.as
@@ -89,8 +89,6 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -0.0f);
 	this.Tag("flesh");
 
-	this.getShape().SetOffset(Vec2f(0, 6));
-
 	this.getCurrentScript().runFlags |= Script::tick_blob_in_proximity;
 	this.getCurrentScript().runProximityTag = "player";
 	this.getCurrentScript().runProximityRadius = 320.0f;

--- a/Entities/Natural/Animals/Chicken/Chicken.cfg
+++ b/Entities/Natural/Animals/Chicken/Chicken.cfg
@@ -11,7 +11,7 @@ $sprite_texture                      = Chicken.png
 s32_sprite_frame_width               = 16
 s32_sprite_frame_height              = 16
 f32 sprite_offset_x                  = 0
-f32 sprite_offset_y                  = 3
+f32 sprite_offset_y                  = -3
 
 	$sprite_gibs_start               = *start*
 
@@ -98,7 +98,7 @@ $brain_factory                       = generic_brain
 $attachment_factory                   = box2d_attachment
 @$attachment_scripts                  =
 # name; pixel offset (from center) X; offset Y; socket/plug 0/1; controller; radius
-@$attachment_points                   = PICKUP; -1; 5; 1; 0; 0;
+@$attachment_points                   = PICKUP; -1; -1; 1; 0; 0;
 
 $inventory_factory                   =
 

--- a/Entities/Natural/Animals/Scripts/AnimalBrain.as
+++ b/Entities/Natural/Animals/Scripts/AnimalBrain.as
@@ -126,7 +126,7 @@ void onTick(CBrain@ this)
 					else
 					{
 						blob.setKeyPressed((tpos.x > pos.x) ? key_left : key_right, true);
-						blob.setKeyPressed((tpos.y > pos.y) ? key_up : key_down, true);
+						blob.setKeyPressed((tpos.y > (pos.y - blob.getRadius())) ? key_up : key_down, true);
 					}
 				}
 			}


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2423

The "no build" area is now centered on the chicken. Removed shape offset and changed sprite offset/attachment point offset to make it look the same as before.

In `AnimalBrain.as`, while fleeing, chicken wouldn't jump since it now has lower y pos than the player. I corrected that so it would still jump if the top position of the animal is higher than the player's position.
Therefore, chicken will jump if player is on the same row of blocks but won't jump if it is 1 tile lower - same behavior as before.

Chicken is the only land animal using `DEFAULT_PERSONALITY = SCARED_BIT;`, 
Since there are no other land animals using it, the above change doesn't affect anything else.

