### PR TITLE
[fixed] Cinematic camera button was showing when videorecording

### DIFF
--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -180,11 +180,6 @@ void onRender(CRules@ this)
 		return;
 	}
 
-	if (!v_camera_cinematic)
-	{
-		return;
-	}
-
 	CBlob@ localblob = getLocalPlayerBlob();
 
 	if (localblob !is null)
@@ -203,6 +198,11 @@ void onRender(CRules@ this)
 			Vec2f(getScreenWidth() / 2 + 90, getScreenHeight() * (0.2f) + 30),
 			SColor(0xffffffff), true, true
 		);
+	}
+
+	if (!v_camera_cinematic)
+	{
+		return;
 	}
 
 	int time = getGameTime() + getInterpolationFactor();

--- a/Rules/CommonScripts/PlayerCamera.as
+++ b/Rules/CommonScripts/PlayerCamera.as
@@ -175,7 +175,24 @@ void onRender(CRules@ this)
 		SpecCamera(this);
 	}
 
-	if (targetPlayer() !is null && getLocalPlayerBlob() is null)
+	if (g_videorecording)
+	{
+		return;
+	}
+
+	if (!v_camera_cinematic)
+	{
+		return;
+	}
+
+	CBlob@ localblob = getLocalPlayerBlob();
+
+	if (localblob !is null)
+	{
+		return;
+	}
+
+	if (targetPlayer() !is null && localblob is null)
 	{
 		GUI::SetFont("menu");
 		GUI::DrawText(
@@ -186,16 +203,6 @@ void onRender(CRules@ this)
 			Vec2f(getScreenWidth() / 2 + 90, getScreenHeight() * (0.2f) + 30),
 			SColor(0xffffffff), true, true
 		);
-	}
-
-	if (getLocalPlayerBlob() !is null)
-	{
-		return;
-	}
-
-	if (!v_camera_cinematic)
-	{
-		return;
 	}
 
 	int time = getGameTime() + getInterpolationFactor();


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2430

This makes two changes:
- Hides the cinematic camera button at the bottom of the screen if `g_videorecording` is true.
- `getLocalPlayerBlob()` in `onRender()` in `PlayerCamera.as` is only called once instead of twice.

Tested, works.