### PR TITLE
[fixed] fishy won't grow bigger when dead

### DIFF
--- a/Entities/Natural/Animals/Fishy/Fishy.as
+++ b/Entities/Natural/Animals/Fishy/Fishy.as
@@ -82,6 +82,12 @@ void onInit(CBlob@ this)
 
 void onTick(CBlob@ this)
 {
+	if (this.hasTag("dead"))
+	{
+		this.getCurrentScript().runFlags |= Script::remove_after_this;
+		return;
+	}
+
 	f32 x = this.getVelocity().x;
 	if (Maths::Abs(x) > 1.0f)
 	{
@@ -95,7 +101,7 @@ void onTick(CBlob@ this)
 			this.SetFacingLeft(false);
 	}
 
-	if (getNet().isServer())
+	if (isServer())
 	{
 		u8 age = this.get_u8("age");
 		if (age < 3)


### PR DESCRIPTION
## Description

Can't remember if I fixed this already in some other PR, but anyway, this makes it so Fishy won't grow bigger when it is already dead.

`this.getCurrentScript().runFlags |= Script::remove_after_this;` is used because when the fishy is dead, nothing else in the script is relevant anymore.

Tested. After this PR, small fishy won't grow bigger while lying dead on the floor.