### PR TITLE
[fixed] Sandbox surrender text

### DIFF
--- a/Rules/CommonScripts/DefaultVotes.as
+++ b/Rules/CommonScripts/DefaultVotes.as
@@ -360,11 +360,16 @@ class VoteSurrenderFunctor : VoteFunctor
 				s32 teamWonNum = (team + 1) % rules.getTeamsCount();
 				CTeam@ teamLost = rules.getTeam(team);
 				CTeam@ teamWon = rules.getTeam(teamWonNum);
+				bool no_winner = team == teamWonNum; // this can happen if there is only one team
 
-				rules.SetTeamWon(teamWonNum);
+				if (!no_winner)
+				{
+					rules.SetTeamWon(teamWonNum);
+				}
+				
 				rules.SetCurrentState(GAME_OVER);
-
-				rules.SetGlobalMessage("{LOSING_TEAM} Surrendered! {WINNING_TEAM} wins the Game!");
+				string win_team_text = !no_winner ? " {WINNING_TEAM} wins the Game!" : "";
+				rules.SetGlobalMessage("{LOSING_TEAM} Surrendered!" + win_team_text);
 				rules.AddGlobalMessageReplacement("LOSING_TEAM", teamLost.getName());
 				rules.AddGlobalMessageReplacement("WINNING_TEAM", teamWon.getName());
 			}


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2414

In Sandbox you could start a surrender vote and if everyone votes yes, the game would say 

`"Blue Team Surrendered! Blue Team wins the game!"`

This PR makes it so the text will be just

`"Blue Team Surrendered!"`

instead, and `rules.SetTeamWon(teamWonNum)` won't be called and no fanfare plays, if the winning team is the same as the losing team.

Tested in dedicated server.

I refrained from outright blocking surrender vote in sandbox because there may be edge-cases when relying on `rules.getTeamsCount()`.