### PR TITLE
[change] neutral archer can grapple in red barrier

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -751,7 +751,7 @@ bool checkGrappleBarrier(Vec2f pos)
 
 bool checkGrappleStep(CBlob@ this, ArcherInfo@ archer, CMap@ map, const f32 dist)
 {
-	if (checkGrappleBarrier(archer.grapple_pos)) // red barrier
+	if (this.getTeamNum() != 255 && checkGrappleBarrier(archer.grapple_pos)) // red barrier
 	{
 		if (canSend(this) || isServer())
 		{


### PR DESCRIPTION

## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2450

This lets neutral team archer grapple in red barrier.