### PR TITLE
[fixed] Scoreboard stuck bug

### DIFF
--- a/Rules/CommonScripts/ScoreboardRender.as
+++ b/Rules/CommonScripts/ScoreboardRender.as
@@ -709,7 +709,7 @@ void onRenderScoreboard(CRules@ this)
 	float screenHeight = getScreenHeight();
 	CControls@ controls = getControls();
 
-	if(scoreboardHeight > screenHeight) {
+	if(scoreboardHeight > screenHeight || scrollOffset > 0) {
 		Vec2f mousePos = controls.getMouseScreenPos();
 
 		float fullOffset = (scoreboardHeight + scoreboardMargin) - screenHeight;


### PR DESCRIPTION
## Description

When many people are online and you scroll down the scoreboard, then some people leave and you bring up the scoreboard again, it is possible that you could find yourself unable to scroll up the scoreboard.

It is possible to do the bug by entering CTF tutorial and using `AddBot()` a bunch of times. The Bots would enter Red team but then switch over the Blue team. If you add so many bots the scoreboard reaches the bottom of your screen, and scroll down, and then the bot switches to blue (so Red Team's field on the scoreboard doesn't get rendered anymore), the bug could happen and the scoreboard gets stuck.

After applying the change in this PR, the scoreboard can be scrolled back up in cases where it would have gotten stuck. So the scoreboard doesn't get stuck anymore. I haven't seen any odd behavior with this change. The scrolling and scoreboard offsetting looks to work as intended.