### PR TITLE
No build damage

### DIFF
--- a/Entities/Items/Boulder/Boulder.as
+++ b/Entities/Items/Boulder/Boulder.as
@@ -97,10 +97,6 @@ void Slam(CBlob @this, f32 angle, Vec2f vel, f32 vellen)
 	Tile tile = map.getTile(pos);
 	if (map.isTileBackgroundNonEmpty(tile))
 	{
-		if (map.getSectorAtPosition(pos, "no build") !is null)
-		{
-			return;
-		}
 		map.server_DestroyTile(pos + Vec2f(7.0f, 7.0f), 10.0f, this);
 		map.server_DestroyTile(pos - Vec2f(7.0f, 7.0f), 10.0f, this);
 	}
@@ -123,14 +119,8 @@ bool BoulderHitMap(CBlob@ this, Vec2f worldPoint, int tileOffset, Vec2f velocity
 
 	if (map.isTileCastle(t) || map.isTileWood(t))
 	{
-		Vec2f tpos = this.getMap().getTileWorldPosition(tileOffset);
-		if (map.getSectorAtPosition(tpos, "no build") !is null)
-		{
-			return false;
-		}
-
 		//make a shower of gibs here
-
+		Vec2f tpos = this.getMap().getTileWorldPosition(tileOffset);
 		map.server_DestroyTile(tpos, 100.0f, this);
 		Vec2f vel = this.getVelocity();
 		this.setVelocity(vel * 0.8f); //damp

--- a/Entities/Items/Explosives/Explosion.as
+++ b/Entities/Items/Explosives/Explosion.as
@@ -260,7 +260,7 @@ void Explode(CBlob@ this, f32 radius, f32 damage)
 
 							if (canHit)
 							{
-								if (canExplosionDamage(map, tpos, tile))
+								if (canExplosionDamage(tile))
 								{
 									if (!map.isTileBedrock(tile))
 									{
@@ -369,7 +369,7 @@ void LinearExplosion(CBlob@ this, Vec2f _direction, f32 length, const f32 width,
 				}
 				else if (t != CMap::tile_empty && t != CMap::tile_ground_back)
 				{
-					if (canExplosionDamage(map, tpos, t))
+					if (canExplosionDamage(t))
 					{
 						if (!justhurt)
 							damaged = true;
@@ -479,19 +479,9 @@ void BombermanExplosion(CBlob@ this, f32 radius, f32 damage, f32 map_damage_radi
 
 }
 
-bool canExplosionDamage(CMap@ map, Vec2f tpos, TileType t)
+bool canExplosionDamage(TileType t)
 {
-	CBlob@ blob = map.getBlobAtPosition(tpos); // TODO: make platform get detected
-	bool hasValidFrontBlob = false;
-	bool isBackwall = (t == CMap::tile_castle_back || t == CMap::tile_castle_back_moss || t == CMap::tile_wood_back);
-	if (blob !is null)
-	{
-		string name = blob.getName();
-		hasValidFrontBlob = (name == "wooden_door" || name == "stone_door" || name == "trap_block" || name == "wooden_platform" || name == "bridge");
-	}
-	return map.getSectorAtPosition(tpos, "no build") is null &&
-	       (t != CMap::tile_ground_d0 && t != CMap::tile_stone_d0) && //don't _destroy_ ground, hit until its almost dead tho
-		   !(hasValidFrontBlob && isBackwall); // don't destroy backwall if there is a door or trap block
+	return t != CMap::tile_ground_d0 && t != CMap::tile_stone_d0;  //don't _destroy_ ground, hit until its almost dead tho
 }
 
 bool canExplosionDestroy(CMap@ map, Vec2f tpos, TileType t)

--- a/Entities/Items/Projectiles/BallistaBolt.as
+++ b/Entities/Items/Projectiles/BallistaBolt.as
@@ -259,10 +259,7 @@ void BallistaHitMap(CBlob@ this, const u32 offset, Vec2f hit_position, Vec2f vel
 	}
 	else if (!map.isTileGroundStuff(type))
 	{
-
-		if (map.getSectorAtPosition(hit_position, "no build") is null)
-			map.server_DestroyTile(hit_position, 1.0f, this);
-
+		map.server_DestroyTile(hit_position, 1.0f, this);
 		u8 blocks_pierced = this.get_u8("blocks_pierced");
 		const f32 speed = velocity.getLength();
 

--- a/Entities/Vehicles/Catapult/Rock.as
+++ b/Entities/Vehicles/Catapult/Rock.as
@@ -66,12 +66,7 @@ void onTick(CBlob@ this)
 	{
 		if (isServer)
 		{
-			if (map.getSectorAtPosition(pos, "no build") !is null)
-			{
-				return;
-			}
 			map.server_DestroyTile(pos, 2.0f, this);
-
 			// slightly damage the rock too
 			this.server_Hit(this, this.getPosition(), this.getVelocity(), 0.05f, Hitters::cata_stones, true);
 		}


### PR DESCRIPTION

## Description

Allow backwall to be damaged in `no build` zones and behind blobs.
 
Shops and doors protect the backwall behind them from any given instance of damage until destroyed. This can greatly impact the damage a well placed explosive or siege shot can do. For example, a keg in the middle of a tower will often do nothing besides destroy a couple of shops and/or doors. This is extremely frustrating as a player, especially considering how difficult it can be to actually land solid hits. Any significant damage often artificially requires two kegs minimum, since the first will clear the blobs out of the way. Since players can only carry one keg at a time, this leads to spam being the only consistent way to punch through buildings. Whether that be spamming from a shop on top of the enemy tower or tramp keg spam or siege spam, there is less precision play and agency from single players.

The flag room can permanently protect backwall from anything but fire. This leads to builders being able to hold a flag room with a single layer of block spam even under heavy fire from kegs or siege. This can greatly drag out a match where the losing team has practically nothing. It's miserable to play for the losing team and frustrating for the winning team (or toxic depending on how you view it). It contributes heavily to the problem of long running stalemates that we currently see often in pub matches, making it that much harder to get over the goal line.

Here is an example of a well placed keg on a dummy tower. Note, this tower doesn't even have that many doors, the problem worsens the more blobs there are, which tend to get spammed in pub matches.

Keg placement:

<img width="1047" height="942" alt="image" src="https://github.com/user-attachments/assets/d02ed5a8-0abf-428e-a76a-ed733aa090a3" />


Keg effect before changes:

<img width="873" height="855" alt="image" src="https://github.com/user-attachments/assets/6dc83030-c64a-41c3-8f6c-973f9f38bb51" />


Keg effect after changes:

<img width="1014" height="881" alt="image" src="https://github.com/user-attachments/assets/210b7bda-2ebc-4d57-afa2-f62c2f1b37be" />


This helps move the dial of power between builder and the combat classes a bit more back in the direction of the combat classes. In the game's current balance, the combat classes heavily struggle to do anything against even the most basic of builders without a builder immediately with them or an oppressive tower on their side.

Explosives will break the backwall behind a door often before breaking the door itself. While the door will prevent a tower from collapsing, the lack of backwall prevents support for building above. While a smaller detail, this does have an impact on the efficacy of direct attacks especially on taller towers and again slightly shifts the balance of power back to the combat classes.

<img width="484" height="393" alt="image" src="https://github.com/user-attachments/assets/ba58e261-7f37-439a-8778-7c3a89460e15" />


Note: Explosives will be blocked from hitting the next block over unless the blob is destroyed. Example with one bomb, which would normally hit a much larger radius:

<img width="528" height="638" alt="image" src="https://github.com/user-attachments/assets/0790f7c7-9ce5-4f63-b398-5547f398055e" />


<img width="497" height="556" alt="image" src="https://github.com/user-attachments/assets/a60c1acd-fad6-4ccf-a244-ecf4883758a4" />



These changes have been in place on the US captains mod for 3.5 years. They are well received and have improved gameplay over years of testing.

That said, they are not without fault. The biggest issue in my eyes is that it can sometimes be confusing/hard to see whether there is backwall under a blob, especially large opaque blobs like closed stone doors or especially tunnels. I suspect this was the original reason for the current implementation.

Despite this, I believe this relatively small change code wise has a large net positive effect on play.

P.S. This is also the cause of the "bug" of invincible backwall at the top of the map that is frequently exploited by sky towers, especially in SmallCTF. This PR fixes that, but my PR for the map ceiling changes also already addresses this by simply preventing building backwall that high.

P.S.S. I *believe* the change I made in `BallistaBolt.as` doesn't actually have any effect unless there are wood or stone tiles in a `no build` zone, which is impossible currently as far as I know. I wanted to make the change for consistency/cleanliness regardless.

Closes #568

## Steps to Test or Reproduce

For each of the following cases:
- Backwall in the flag room
- Backwall behind shops
- Backwall behind doors
- Backwall at the top of the map

Do each of the following:
- Use any explosive (bomb, keg, mine, bomb bolts)
- Launch a boulder out of a catapult
- Launch normal catapult rocks

The backwall behind the blobs or in the flag room will be destroyed instead of surviving.

