### PR TITLE
[fixed] Music/Ambient music will fade out when turning off game music in the settings

### DIFF
--- a/Entities/Meta/CTFMusic.as
+++ b/Entities/Meta/CTFMusic.as
@@ -40,7 +40,7 @@ void onTick(CBlob@ this)
 	if (mixer is null)
 		return;
 
-	if (s_soundon != 0 && s_musicvolume > 0.0f)
+	if (s_soundon != 0 && s_gamemusic && s_musicvolume > 0.0f)
 	{
 		if (!this.get_bool("initialized game"))
 		{
@@ -90,7 +90,7 @@ bool gameStarted = true;
 
 void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 {
-	if (mixer is null || !s_gamemusic)
+	if (mixer is null)
 		return;
 
 	if (mixer.isPlaying(world_battle))

--- a/Entities/Meta/CTFMusic.as
+++ b/Entities/Meta/CTFMusic.as
@@ -22,6 +22,10 @@ enum GameMusicTag
 	world_music_end,
 };
 
+u8 battle_timer = 0;
+u8 battle_delay = 5; // seconds
+bool fanfarePlayed = false;
+
 void onInit(CBlob@ this)
 {
 	CMixer@ mixer = getMixer();
@@ -84,10 +88,6 @@ void AddGameMusic(CBlob@ this, CMixer@ mixer)
 	mixer.AddTrack("Sounds/Music/KAGWorld1-14outro.ogg", world_outro);
 }
 
-u8 battle_timer = 0;
-u8 battle_delay = 5; // seconds
-bool gameStarted = true;
-
 void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 {
 	if (mixer is null)
@@ -111,14 +111,18 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 		return;
 	}
 
+	// pretend the fanfare played if the match started with muted music
+	if (blob !is null && blob.getTickSinceCreated() > 30)
+	{
+		fanfarePlayed = true;
+	}
+
 	CMap@ map = getMap();
 	if (map is null)
 		return;
 
 	if (rules.isWarmup())
 	{
-		gameStarted = false;
-
 		Vec2f pos; 
 		
 		// If the player is a spectating, base their location off of their camera.
@@ -150,12 +154,12 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 	}
 	else if (rules.isMatchRunning())
 	{
-		if (!gameStarted)
+		if (!fanfarePlayed)
 		{
 			Sound::Play("/fanfare_start.ogg");
+			fanfarePlayed = true; // only play this once
 		}
 
-		gameStarted = true;
 		if (!mixer.isPlaying(world_battle) || battle_timer == getTicksASecond() * 5) // hold onto battle music at least 5 seconds
 		{
 			Vec2f pos;

--- a/Entities/Meta/CTFMusic.as
+++ b/Entities/Meta/CTFMusic.as
@@ -22,10 +22,6 @@ enum GameMusicTag
 	world_music_end,
 };
 
-u8 battle_timer = 0;
-u8 battle_delay = 5; // seconds
-bool fanfarePlayed = false;
-
 void onInit(CBlob@ this)
 {
 	CMixer@ mixer = getMixer();
@@ -88,6 +84,10 @@ void AddGameMusic(CBlob@ this, CMixer@ mixer)
 	mixer.AddTrack("Sounds/Music/KAGWorld1-14outro.ogg", world_outro);
 }
 
+u8 battle_timer = 0;
+u8 battle_delay = 5; // seconds
+bool gameStarted = true;
+
 void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 {
 	if (mixer is null)
@@ -111,18 +111,14 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 		return;
 	}
 
-	// pretend the fanfare played if the match started with muted music
-	if (blob !is null && blob.getTickSinceCreated() > 30)
-	{
-		fanfarePlayed = true;
-	}
-
 	CMap@ map = getMap();
 	if (map is null)
 		return;
 
 	if (rules.isWarmup())
 	{
+		gameStarted = false;
+
 		Vec2f pos; 
 		
 		// If the player is a spectating, base their location off of their camera.
@@ -154,12 +150,12 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 	}
 	else if (rules.isMatchRunning())
 	{
-		if (!fanfarePlayed)
+		if (!gameStarted)
 		{
 			Sound::Play("/fanfare_start.ogg");
-			fanfarePlayed = true; // only play this once
 		}
 
+		gameStarted = true;
 		if (!mixer.isPlaying(world_battle) || battle_timer == getTicksASecond() * 5) // hold onto battle music at least 5 seconds
 		{
 			Vec2f pos;

--- a/Entities/Meta/ChallengeMusic.as
+++ b/Entities/Meta/ChallengeMusic.as
@@ -30,7 +30,7 @@ void onTick(CBlob@ this)
 	CMixer@ mixer = getMixer();
 	if (mixer is null) { return; } //prevents aids on server
 
-	if (s_soundon != 0 && s_musicvolume > 0.0f)
+	if (s_soundon != 0 && s_gamemusic && s_musicvolume > 0.0f)
 	{
 		if (!this.get_bool("initialized game"))
 		{
@@ -92,7 +92,7 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 	if (map is null) return;
 	Vec2f pos = blob.getPosition();
 
-	if (!s_gamemusic || rules.isWarmup())
+	if (rules.isWarmup())
 	{
 		if (timer % 48 != 0)
 			return;

--- a/Entities/Meta/TDMMusic.as
+++ b/Entities/Meta/TDMMusic.as
@@ -28,7 +28,7 @@ void onTick(CBlob@ this)
 	if (mixer is null)
 		return;
 
-	if (s_gamemusic && s_musicvolume > 0.0f)
+	if (s_soundon != 0 && s_gamemusic && s_musicvolume > 0.0f)
 	{
 		if (!this.get_bool("initialized game"))
 		{

--- a/Entities/Meta/WARMusic.as
+++ b/Entities/Meta/WARMusic.as
@@ -29,8 +29,6 @@ enum GameMusicTag
 };
 
 string base_blob_name = "hall";
-uint timer = 0;
-bool fanfarePlayed = false;
 
 void onInit(CBlob@ this)
 {
@@ -102,6 +100,9 @@ void AddGameMusic(CBlob@ this, CMixer@ mixer)
 	mixer.AddTrack("Sounds/Music/KAGWorldQuickOut.ogg", world_quick_out);
 }
 
+uint timer = 0;
+bool wasgame = false;
+
 void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 {
 	timer++;
@@ -121,12 +122,6 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 		return;
 
 	Vec2f pos = blob.getPosition();
-
-	// pretend the fanfare played if the match started with muted music
-	if (blob.getTickSinceCreated() > 30)
-	{
-		fanfarePlayed = true;
-	}
 
 	//calc ambience
 	if (timer % 30 == 0)
@@ -153,17 +148,18 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 
 	if (rules.isWarmup())
 	{
+		wasgame = false;
 		changeMusic(mixer, world_home);
 	}
 	//every beat, checks situation for appropriate music
 	else if (rules.isMatchRunning())
 	{
-		if (!fanfarePlayed)
+		if (!wasgame)
 		{
 			Sound::Play("/fanfare_start.ogg");
-			fanfarePlayed = true; // only play this once
 		}
 
+		wasgame = true;
 		if (playingMusic(mixer) == 0)
 		{
 			GameMusicTag chosen = world_calm;
@@ -195,6 +191,7 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 	}
 	else //end of game, fade out music
 	{
+		wasgame = false;
 		if (mixer.getPlayingCount() >= 0)
 		{
 			mixer.FadeOutAll(0.0f, 0.5f);

--- a/Entities/Meta/WARMusic.as
+++ b/Entities/Meta/WARMusic.as
@@ -55,7 +55,7 @@ void onTick(CBlob@ this)
 	if (mixer is null)
 		return;
 
-	if (s_soundon != 0 && s_musicvolume > 0.0f)
+	if (s_soundon != 0 && s_gamemusic && s_musicvolume > 0.0f)
 	{
 		if (!this.get_bool("initialized game"))
 		{
@@ -106,7 +106,7 @@ bool wasgame = false;
 void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 {
 	timer++;
-	if (mixer is null || !s_gamemusic)
+	if (mixer is null)
 		return;
 
 	CRules @rules = getRules();

--- a/Entities/Meta/WARMusic.as
+++ b/Entities/Meta/WARMusic.as
@@ -29,6 +29,8 @@ enum GameMusicTag
 };
 
 string base_blob_name = "hall";
+uint timer = 0;
+bool fanfarePlayed = false;
 
 void onInit(CBlob@ this)
 {
@@ -100,9 +102,6 @@ void AddGameMusic(CBlob@ this, CMixer@ mixer)
 	mixer.AddTrack("Sounds/Music/KAGWorldQuickOut.ogg", world_quick_out);
 }
 
-uint timer = 0;
-bool wasgame = false;
-
 void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 {
 	timer++;
@@ -122,6 +121,12 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 		return;
 
 	Vec2f pos = blob.getPosition();
+
+	// pretend the fanfare played if the match started with muted music
+	if (blob.getTickSinceCreated() > 30)
+	{
+		fanfarePlayed = true;
+	}
 
 	//calc ambience
 	if (timer % 30 == 0)
@@ -148,18 +153,17 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 
 	if (rules.isWarmup())
 	{
-		wasgame = false;
 		changeMusic(mixer, world_home);
 	}
 	//every beat, checks situation for appropriate music
 	else if (rules.isMatchRunning())
 	{
-		if (!wasgame)
+		if (!fanfarePlayed)
 		{
 			Sound::Play("/fanfare_start.ogg");
+			fanfarePlayed = true; // only play this once
 		}
 
-		wasgame = true;
 		if (playingMusic(mixer) == 0)
 		{
 			GameMusicTag chosen = world_calm;
@@ -191,7 +195,6 @@ void GameMusicLogic(CBlob@ this, CMixer@ mixer)
 	}
 	else //end of game, fade out music
 	{
-		wasgame = false;
 		if (mixer.getPlayingCount() >= 0)
 		{
 			mixer.FadeOutAll(0.0f, 0.5f);


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2458

Previously, it would just check if the music engine is active and volume is above 0, then would enter the function `GameMusicLogic()` and early out when checking `!s_gamemusic` so it didn't fade out the music and music would keep playing until reaching the end.

Now, when turning off game music in the settings, music and ambient music will fade out immediately since `s_gamemusic` is checked beforehand.

Tested with `WARMusic.as`, should work the same with the other scripts.
