### PR TITLE
[dev] Removed unneeded FireAnim.as from some blob scripts

### DIFF
--- a/Entities/Industry/CTFShops/Quarry/Quarry.cfg
+++ b/Entities/Industry/CTFShops/Quarry/Quarry.cfg
@@ -2,7 +2,6 @@
 
 $sprite_factory                                   = generic_sprite
 @$sprite_scripts                                  = Stone.as;
-													FireAnim.as;
 													Quarry.as;
 $sprite_texture                                   = Quarry.png
 s32_sprite_frame_width                            = 40

--- a/Entities/Industry/CTFShops/Storage/Storage.cfg
+++ b/Entities/Industry/CTFShops/Storage/Storage.cfg
@@ -2,7 +2,6 @@
 
 $sprite_factory                                   = generic_sprite
 @$sprite_scripts                                  = Stone.as;
-													FireAnim.as;
 													Storage.as;
 $sprite_texture                                   = Storage.png
 s32_sprite_frame_width                            = 40

--- a/Entities/Industry/Hall/Hall.cfg
+++ b/Entities/Industry/Hall/Hall.cfg
@@ -7,7 +7,6 @@
 $sprite_factory                            = generic_sprite
 
 @$sprite_scripts                           = Stone.as;
-											 FireAnim.as;
 											 Hall.as;
 											 #TheresAMigrantInTheRoom.as;
 											 ResearchGUI.as;

--- a/Entities/Industry/Tunnel/Tunnel.cfg
+++ b/Entities/Industry/Tunnel/Tunnel.cfg
@@ -7,7 +7,6 @@
 $sprite_factory                            = generic_sprite
 
 @$sprite_scripts                           = Stone.as;
-											 FireAnim.as;
 											 Tunnel.as;
 $sprite_texture                            = WarTunnel.png
 s32_sprite_frame_width                     = 40

--- a/Entities/Natural/Farming/Grain.cfg
+++ b/Entities/Natural/Farming/Grain.cfg
@@ -6,7 +6,7 @@
 
 $sprite_factory                        = generic_sprite
 
-@$sprite_scripts                       = FireAnim.as;
+@$sprite_scripts                       =
 $sprite_texture                        = Grain.png
 s32_sprite_frame_width                 = 8
 s32_sprite_frame_height                = 8

--- a/Entities/Structures/Door/StoneDoor.cfg
+++ b/Entities/Structures/Door/StoneDoor.cfg
@@ -7,7 +7,6 @@
 $sprite_factory                            = generic_sprite
 
 @$sprite_scripts                           = Stone.as;
-											 FireAnim.as;
 $sprite_texture                            = 1x1StoneDoor.png
 s32_sprite_frame_width                     = 16
 s32_sprite_frame_height                    = 8

--- a/Entities/Vehicles/Boats/WarBoat/WarboatDoor.cfg
+++ b/Entities/Vehicles/Boats/WarBoat/WarboatDoor.cfg
@@ -7,7 +7,6 @@
 $sprite_factory                            = generic_sprite
 
 @$sprite_scripts                           = Wooden.as;
-											 FireAnim.as;
 $sprite_texture                            = WarboatDoor.png
 s32_sprite_frame_width                     = 16
 s32_sprite_frame_height                    = 16


### PR DESCRIPTION
## Description
This PR removes `FireAnim.as` from blob scripts that don't also have `IsFlammable.as`.
Those blob scripts are `Grain.cfg`, `Tunnel.cfg`, `Storage.cfg`, `Tunnel.cfg`, `StoneDoor.cfg`, `Hall.cfg`, `WarboatDoor.cfg`.
After the removal, shooting fire arrow at Grain will still cause a fire cross and set nearby things on fire.

## Context
- [#1649](https://github.com/transhumandesign/kag-base/pull/1649) removed `IsFlammable` from Grain but didn't remove `FireAnim.as`.
- [#857](https://github.com/transhumandesign/kag-base/pull/857) removed `IsFlammable.as` from Tunnel, Quarry and Storage, but didn't remove `FireAnim.as`.
