### PR TITLE
[fixed] Scenery now gets destroyed by unpacked or spawned in buildings

### DIFF
--- a/Entities/Characters/Builder/BuilderCommon.as
+++ b/Entities/Characters/Builder/BuilderCommon.as
@@ -136,7 +136,6 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, const u32 &in index)
 
 		// take inv here instead of in onDetach
 		server_TakeRequirements(inv, b.reqs);
-		DestroyScenary(tl, br);
 
 		CPlayer@ p = this.getPlayer();
 		if (p !is null)

--- a/Entities/Structures/Common/AddTilesBySector.as
+++ b/Entities/Structures/Common/AddTilesBySector.as
@@ -1,3 +1,5 @@
+#include "PlacementCommon.as";
+
 void AddTilesBySector(Vec2f ul, Vec2f lr, string sectorName, TileType tile, TileType omitTile = 255, bool hasWindow = false)
 {
 	if (isServer())
@@ -23,4 +25,6 @@ void AddTilesBySector(Vec2f ul, Vec2f lr, string sectorName, TileType tile, Tile
 			tpos.y = ul.y;
 		}
 	}
+
+	DestroyScenary(ul, lr);
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2464

This PR fixes that spawned in or unpacked buildings didn't destroy bushes.
Done by moving a `DestroyScenary()` call from `BuilderCommon.as` to `AddTilesBySector.as`.

## Testing
Move your character to a bush.
Type in `/spawn building`.
Notice the bush will still be there.
**After this PR, the bush wouldn't be there.**

Type in `/crate outpost` or buy a crate with outpost from vehicle shop.
Take the crate and move your character to a bush.
Unpack the crate inside the bush.
Notice the bush will still be there.
**After this PR, the bush wouldn't be there.**



