### PR TITLE
Spectators heard lose fanfare on game over

### DIFF
--- a/Rules/CommonScripts/FanfareOnWin.as
+++ b/Rules/CommonScripts/FanfareOnWin.as
@@ -14,7 +14,7 @@ void onStateChange( CRules@ this, const u8 oldState )
 			{
 				Sound::Play("/FanfareWin.ogg");
 			}
-			else
+			else if (teamNum != this.getSpectatorTeamNum())
 			{
 				Sound::Play("/FanfareLose.ogg");
 			}


### PR DESCRIPTION
<!--
If your PR is a Work-In-Progress, please open it via the "Create draft pull request" button.
-->

## Description

Spectators heard lose fanfare on game over.
Now they can hear nothing like tie game.

## Steps to Test or Reproduce

1. Join game with 3 players (TDM is good)
2. Join Blue, Red team and Spectator
3. Make game over
4. Check the sound of spectator