### PR TITLE
[fixed] Drill was making Steam Puff without dealing damage and detaching

### DIFF
--- a/Entities/Industry/Drill/Drill.as
+++ b/Entities/Industry/Drill/Drill.as
@@ -81,6 +81,8 @@ void onInit(CBlob@ this)
 
 	this.set_u32(last_drill_prop, 0);
 		this.Tag("ignore fall");
+
+	this.addCommandID("overheat client");
 }
 
 bool canBePutInInventory( CBlob@ this, CBlob@ inventoryBlob )
@@ -199,12 +201,11 @@ void onTick(CBlob@ this)
 
 		AimAtMouse(this, holder); // aim at our mouse pos
 
-		if (int(heat) >= heat_drop)
+		if (int(heat) >= heat_drop && isServer())
 		{
-			makeSteamPuff(this, 1.5f, 3, false);
 			this.server_Hit(holder, holder.getPosition(), Vec2f(), 0.25f, Hitters::burn, true);
 			this.server_DetachFrom(holder);
-			sprite.PlaySound("DrillOverheat.ogg");
+			this.SendCommand(this.getCommandID("overheat client"));
 		}
 
 		if (holder.getName() == required_class || sv_gamemode == "TDM")
@@ -431,6 +432,19 @@ void onTick(CBlob@ this)
 		else
 		{
 			this.getCurrentScript().runFlags &= ~Script::tick_not_sleeping;
+		}
+	}
+}
+
+void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
+{
+	if (cmd == this.getCommandID("overheat client") && isClient())
+	{
+		makeSteamPuff(this, 1.5f, 3, false);
+		CSprite@ sprite = this.getSprite();
+		if (sprite !is null)
+		{
+			sprite.PlaySound("DrillOverheat.ogg");
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2469

This PR fixes that Drill would sometimes make a steam puff from overheating without dealing burn damage and detaching the drill, while playing in an online server.

The code lines
```
this.server_Hit(holder, holder.getPosition(), Vec2f(), 0.25f, Hitters::burn, true);
this.server_DetachFrom(holder);
```
are now only run server-side for 1 tick, rather than on client-side for 1~3 ticks + server-side for 1 tick, saving some performance.

The code lines
```
makeSteamPuff(this, 1.5f, 3, false);
sprite.PlaySound("DrillOverheat.ogg");
```
are now run via command on client-side for one tick rather than the 1~3 ticks from before. Also, they will not run server-side, saving some performance.

Now, there should not be a steam puff without damage/detaching anymore.

I tested in dedicated server and it works.