### PR TITLE
[added] can travel tunnel by key

### DIFF
--- a/Entities/Industry/Tunnel/TunnelTravel.as
+++ b/Entities/Industry/Tunnel/TunnelTravel.as
@@ -99,6 +99,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (tunnel is null) return;
 
 		client_Travel(this, caller, tunnel);
+
+		CGridMenu@ menu = getGridMenuByName(getTranslatedString("Pick tunnel to travel"));
+		if (menu !is null)
+		{
+			menu.kill = true;
+		}
 	}
 }
 
@@ -187,7 +193,6 @@ void Callback_TravelTo(CBitStream@ params)
 		CBitStream params;
 		params.write_u16(to_id);
 		this.SendCommand(this.getCommandID("travel to"), params);
-
 	}
 	else
 	{
@@ -310,6 +315,9 @@ void BuildTunnelsMenu(CBlob@ this)
 		menu.AddKeyCallback(KEY_ESCAPE, "TunnelTravel.as", "Callback_TravelNone", params);
 		menu.SetDefaultCallback("TunnelTravel.as", "Callback_TravelNone", params);
 
+		array<EKEY_CODE> numKeys = { KEY_KEY_1, KEY_KEY_2, KEY_KEY_3, KEY_KEY_4, KEY_KEY_5, KEY_KEY_6, KEY_KEY_7, KEY_KEY_8, KEY_KEY_9, KEY_KEY_0 };
+		uint keybindCount = numKeys.length();
+
 		for (uint i = 0; i < tunnels.length; i++)
 		{
 			CBlob@ tunnel = tunnels[i];
@@ -324,6 +332,12 @@ void BuildTunnelsMenu(CBlob@ this)
 				params.write_u16(tunnel.getNetworkID());
 				int direction_index = getTravelDirectionIndex(this, tunnel);
 				menu.AddButton(getTravelIcon(this, tunnel, direction_index), getTranslatedString(getTravelDescription(this, tunnel, direction_index)), "TunnelTravel.as", "Callback_TravelTo", Vec2f(BUTTON_SIZE, BUTTON_SIZE), params);
+
+				// add keybind
+				if (i < keybindCount)
+				{
+					menu.AddKeyCallback(numKeys[i], "TunnelTravel.as", "Callback_TravelTo", params);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This lets you select a tunnel in the tunnel travel menu by num key, similar to how you can do it in shops.

The keys are 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, from left to right for both teams.
The originating tunnel that says "You are here" is omitted.

I didn't find a way to put a small number on the CGridButtons to quickly see the number to press to travel there. 
It would be nice. Otherwise let me know how to implement it or how to otherwise improve this.

Tested in offline, works.

## Test

Place at least 3 tunnels.
Open tunnel travel menu:
- Assuming you start from the middle tunnel, you can press 1 to go to the left tunnel or 3 to go to the right tunnel.
- Assuming you start from the left tunnel, you can press 2 to go to the middle tunnel or 3 to go to the right tunnel.
- Assuming you start from the right tunnel, you can press 1 to go to the left tunnel or 2 to go to the middle tunnel.

## Related PR

https://github.com/transhumandesign/kag-base/pull/2369