### PR TITLE
[changed] Tips use the player's keys rather than the default keys

### DIFF
--- a/Rules/CommonScripts/ChatCommands/MiscCommands.as
+++ b/Rules/CommonScripts/ChatCommands/MiscCommands.as
@@ -150,7 +150,9 @@ class TipCommand : ChatCommand
 
 		string text = getTranslatedString("Tip #{NUMBER}: {TIP}")
 			.replace("{NUMBER}", "" + (index + 1))
-			.replace("{TIP}", getTranslatedString(tips[index]));
+			.replace("{TIP}", getTranslatedString(tips[index]))
+			.replace("[SPACE]", "[" + getControls().getActionKeyKeyName(AK_ACTION3) + "]")
+			.replace("[C]", "[" + getControls().getActionKeyKeyName(AK_PICKUP) + "]");;
 
 		client_AddToChat(text, ConsoleColour::INFO);
 	}

--- a/Rules/CommonScripts/ShowTipOnDeath.as
+++ b/Rules/CommonScripts/ShowTipOnDeath.as
@@ -38,7 +38,10 @@ void SelectRandomTip()
 	}
 	else
 	{
-		tip = getTranslatedString("Tip: {TIP}").replace("{TIP}", getTranslatedString(tips[getGameTime() % tips.length]));
+		tip = getTranslatedString("Tip: {TIP}")
+			.replace("{TIP}", getTranslatedString(tips[getGameTime() % tips.length]))
+			.replace("[SPACE]", "[" + getControls().getActionKeyKeyName(AK_ACTION3) + "]")
+			.replace("[C]", "[" + getControls().getActionKeyKeyName(AK_PICKUP) + "]");
 	}
 }
 


### PR DESCRIPTION
## Description

For death tips that use default keys, such as tip 19 `Press [SPACE] to light a bomb, [C] or [SPACE] to throw it.`
it will now use the key names the player uses.

In my case it's `Press [RIGHT SHIFT] to light a bomb, [MOUSE RIGHT] or [RIGHT SHIFT] to throw it.`

The activate key and pickup/throw key are the only two keys mentioned in tips right now, so only two replace lines are used.

Verified in offline CTF and offline Sandbox.

## Additional

I know, there are more places that show default keys such as the _KAG cheat sheet_ image and the BasicHelps script.
I might get around to adjusting those, too, in the future.