### PR TITLE
[fixed] death tip doesn't show as spectator

### DIFF
--- a/Rules/CommonScripts/ShowTipOnDeath.as
+++ b/Rules/CommonScripts/ShowTipOnDeath.as
@@ -118,10 +118,8 @@ void onTick(CRules@ this)
 	{
 		been_alive = false;
 	}
-	else
-	{
-		can_show = been_alive && dead && timer > 0;
-	}
+
+	can_show = been_alive && dead && timer > 0;
 }
 
 void onRender(CRules@ this)


### PR DESCRIPTION
## Description

Fixes https://github.com/transhumandesign/kag-base/issues/2493

This fixes that a death tip could show forever when switching to spectator while dead.

Verified in dedicated server.