### PR TITLE
[changed] Respawn time is reset when changing team (CTF)

### DIFF
--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -286,24 +286,18 @@ shared class CTFSpawns : RespawnSystem
 
 	void AddPlayerToSpawn(CPlayer@ player)
 	{
-		s32 tickspawndelay = s32(CTF_core.spawnTime);
-
 		CTFPlayerInfo@ info = cast < CTFPlayerInfo@ > (core.getInfoFromPlayer(player));
 
 		if (info is null) { warn("CTF LOGIC: Couldn't get player info  ( in void AddPlayerToSpawn(CPlayer@ player) )"); return; }
 
-		//clamp it so old bad values don't get propagated
-		s32 old_spawn_time = Maths::Max(0, Maths::Min(info.can_spawn_time, tickspawndelay));
-
 		RemovePlayerFromSpawn(player);
 		if (player.getTeamNum() == core.rules.getSpectatorTeamNum())
 			return;
-
 		if (info.team < CTF_core.teams.length)
 		{
 			CTFTeamInfo@ team = cast < CTFTeamInfo@ > (CTF_core.teams[info.team]);
 
-			info.can_spawn_time = ((old_spawn_time > 30) ? old_spawn_time : tickspawndelay);
+			info.can_spawn_time = s32(CTF_core.spawnTime);
 
 			info.spawn_point = player.getSpawnPoint();
 			team.spawns.push_back(info);


### PR DESCRIPTION
## Description

Maybe fixes https://github.com/transhumandesign/kag-base/issues/1538 (I didn't test with spectator queue specifically)

When joining a team and it counts down the time until spawning + you
- change to spectator and then to a team again or 
- change to the other team directly

then the spawn time would keep going from where it left off.

This PR changes that to reset the time back to the usual 10 seconds whenever you change team.

Verified in dedicated server.

IMO it was odd that you could leave into spectator while the timer was at 2 seconds, and you come back after an hour and join a team and only have to wait 2 seconds.