### PR TITLE
[changed] Bucket splashes from center when unattached and having almost no sideward velocity

### DIFF
--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -180,7 +180,10 @@ void DoSplash(CBlob@ this)
 	//extinguish fire
 
 	DepleteWaterCount(this);
-	Splash(this, splash_halfwidth, splash_halfheight, splash_offset, false);
+
+	f32 _splash_offset = this.isAttachedToPoint("PICKUP") ? splash_offset : 0.0f;
+	Splash(this, splash_halfwidth, splash_halfheight, _splash_offset, false);
+
 	SetFrame(this, this.get_u8("filled") > 0);
 }
 

--- a/Entities/Items/Bucket/Bucket.as
+++ b/Entities/Items/Bucket/Bucket.as
@@ -181,7 +181,8 @@ void DoSplash(CBlob@ this)
 
 	DepleteWaterCount(this);
 
-	f32 _splash_offset = this.isAttachedToPoint("PICKUP") ? splash_offset : 0.0f;
+	Vec2f oldvel = this.getOldVelocity();
+	f32 _splash_offset = (this.isAttachedToPoint("PICKUP") || oldvel.x > 1.0f) ? splash_offset : 0.0f;
 	Splash(this, splash_halfwidth, splash_halfheight, _splash_offset, false);
 
 	SetFrame(this, this.get_u8("filled") > 0);


### PR DESCRIPTION
## Description

I found it odd that bucket would splash into its facing direction even when it's just on the ground and getting destroyed or falling straight down. Now bucket will splash to the side only when **used in hand by a player** or when it has at least **some x velocity** (> 1.0f).

I could have made it so it would splash to the side only when **used in hand by a player** but I think there will be situations where a player wants to throw a bucket at a burning wall to extinguish it quickly so I didn't want to change that and therefore introduced a velocity check.

Tested in offline.

## Video showing previous behavior and change

https://github.com/user-attachments/assets/589d3504-1ab0-4209-861e-fbd06a5fe2de

