### PR TITLE
[fix] duplicate arrow bolter bug

### DIFF
--- a/Entities/Structures/Components/Load/Bolter/Bolter.as
+++ b/Entities/Structures/Components/Load/Bolter/Bolter.as
@@ -33,25 +33,25 @@ class Bolter : Component
 				CBlob@ blob = blobs[i];
 				if (blob.getName() != "magazine" || !blob.getShape().isStatic()) continue;
 
-				CBlob@ ammo = blob.getInventory().getItem(0);
+				// get the next blob in inventory
+				CInventory@ inventory = blob.getInventory();
+				CBlob@ ammo;
+				for (u16 i = 0; i < inventory.getItemsCount(); i++)
+				{
+					CBlob@ next_ammo = inventory.getItem(i);
+					if (next_ammo.getQuantity() > 0) @ammo = next_ammo;
+				}
+
 				if (ammo is null) break;
 
 				const s8 arrow_type = arrowTypeNames.find(ammo.getName());
 				if (arrow_type == -1) break;
 
 				// decrement
-				const u8 quantity = ammo.getQuantity() - 1;
-				if (quantity > 0)
-				{
-					ammo.server_SetQuantity(quantity);
-				}
-				else
-				{
-					ammo.server_Die();
-				}
+				ammo.server_SetQuantity(ammo.getQuantity() - 1);
 
 				// calculate deviation
-				f32 deviation = (XORRandom(100) - 50) / 20.0f;
+				const f32 deviation = (XORRandom(100) - 50) / 20.0f;
 
 				// calculate velocity based on deviation
 				Vec2f velocity = offset;


### PR DESCRIPTION
## Description

Fixed a bug where 1 magazine could shoot the same arrow out of all attached bolters for the price of only 1 ammo.

This is a ported fix from ZF
https://github.com/Gingerbeard5773/Zombies_Reborn/issues/209

## Steps to Test or Reproduce

Attach two bolters to the same magazine and fire a bomb arrow out of it. With the fix, only one of the bolters will fire the arrow. 
