### PR TITLE
"restart_rules_after_game_time" little fix

### DIFF
--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -745,8 +745,11 @@ void onInit(CRules@ this)
 {
 	Reset(this);
 
-	const int restart_after = (!this.hasTag("tutorial") ? 30 : 5) * 30;
-	this.set_s32("restart_rules_after_game_time", restart_after);
+	// HACK: set short restart delay for tutorials
+	if (this.hasTag("tutorial")) {
+		const int restart_after = 5 * 30;
+		this.set_s32("restart_rules_after_game_time", restart_after);
+	}
 }
 
 // had to add it here for tutorial cause something didnt work in the tutorial script

--- a/Rules/CommonScripts/PostGameMapVotes.as
+++ b/Rules/CommonScripts/PostGameMapVotes.as
@@ -25,6 +25,12 @@ void onInit(CRules@ rules)
 	}
 
 	shouldCallOnRestart = true;
+
+	// set restart delay
+	if (!rules.hasTag("tutorial")) {
+		const int restart_after = 30 * 30;
+		rules.set_s32("restart_rules_after_game_time", restart_after);
+	}
 }
 
 // HACK: if we call this directly within onInit we get a command error because initialization

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -1004,8 +1004,11 @@ void onRestart(CRules@ this)
 void onInit(CRules@ this)
 {
 	Reset(this);
-	const int restart_after = (!this.hasTag("tutorial") ? 30 : 5) * 30;
-	this.set_s32("restart_rules_after_game_time", restart_after);
+	// HACK: set short restart delay for tutorials
+	if (this.hasTag("tutorial")) {
+		const int restart_after = 5 * 30;
+		this.set_s32("restart_rules_after_game_time", restart_after);
+	}
 
 	getNet().legacy_cmd = true;
 }


### PR DESCRIPTION
## Description
Fixes #2516

This change allows you to use the `RestartAfterShortPostGame.as` script without any problems and without subsequently rewriting the value of the “restart_rules_after_game_time” variable.

## Steps to Test or Reproduce
Add next code into hook **onRender** in `CTF_Interface.as` for example:
```
		GUI::SetFont("hud");
		GUI::DrawText("Game time: " + getGameTime(), Vec2f(320, 20), SColor(255, 255, 255, 255));
		GUI::DrawText("Game time (CMap): " + getMap().getTimeSinceStart(), Vec2f(320, 35), SColor(255, 255, 255, 255));
		GUI::DrawText("Rules restart after game: " + this.get_s32("restart_rules_after_game"), Vec2f(320, 50), SColor(255, 255, 255, 255));
		GUI::DrawText("Rules restart after game time: " + this.get_s32("restart_rules_after_game_time"), Vec2f(320, 65), SColor(255, 255, 255, 255));
```

Merge changes from that pull request and you can check, what value is assigned to the variable “restart_rules_after_game_time” when using the `RestartAfterShortPostGame.as` or `PostGameMapVotes.as` script.
1. When you using `RestartAfterShortPostGame.as`, it's should be set to 300 ticks (by default);
2. If you're using `PostGameMapVotes.as`, it's should be set to 900 ticks;
3. If you run the tutorials, the restart time should be set to 150 ticks.

