### PR TITLE
fix config load in CTF/TTH for mods

### DIFF
--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -13,14 +13,10 @@
 // no scripting required!
 void Config(CTFCore@ this)
 {
-	string configstr = "Rules/CTF/ctf_vars.cfg";
-
-	if (getRules().exists("ctfconfig"))
-	{
-		configstr = getRules().get_string("ctfconfig");
-	}
+	string configstr = "ctf_vars.cfg";
 
 	ConfigFile cfg = ConfigFile(configstr);
+	cfg.loadFile(configstr);
 
 	//how long to wait for everyone to spawn in?
 	s32 warmUpTimeSeconds = cfg.read_s32("warmup_time", 30);

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -9,11 +9,16 @@
 
 #include "CTF_PopulateSpawnList.as"
 
+string configstr = "ctf_vars.cfg";
+
 //edit the variables in the config file below to change the basics
 // no scripting required!
 void Config(CTFCore@ this)
 {
-	string configstr = "ctf_vars.cfg";
+	CRules@ rules = getRules();
+
+	if (rules.exists("ctfconfig")) 
+		configstr = getRules().get_string("ctfconfig");
 
 	ConfigFile cfg = ConfigFile(configstr);
 	cfg.loadFile(configstr);

--- a/Rules/CTF/Scripts/CTF.as
+++ b/Rules/CTF/Scripts/CTF.as
@@ -21,7 +21,6 @@ void Config(CTFCore@ this)
 		configstr = getRules().get_string("ctfconfig");
 
 	ConfigFile cfg = ConfigFile(configstr);
-	cfg.loadFile(configstr);
 
 	//how long to wait for everyone to spawn in?
 	s32 warmUpTimeSeconds = cfg.read_s32("warmup_time", 30);

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -26,7 +26,6 @@ void Config(WarCore@ this)
 		configstr = this.rules.get_string("warconfig");
 
 	ConfigFile cfg = ConfigFile(configstr);
-	cfg.loadFile(configstr);
 
 	//how long to wait for everyone to spawn in?
 	s32 warmUpTimeSeconds = cfg.read_s32("warmup_time", 30);

--- a/Rules/WAR/Scripts/WAR.as
+++ b/Rules/WAR/Scripts/WAR.as
@@ -19,12 +19,14 @@
 //simple config function - edit the variables in the config file
 void Config(WarCore@ this)
 {
-	string configstr = sv_test ? "Rules/WAR/war_vars_test.cfg" : "Rules/WAR/war_vars.cfg";
-	if (this.rules.exists("warconfig"))
-	{
+	CRules@ rules = getRules();
+
+	string configstr = sv_test ? "war_vars_test.cfg" : "war_vars.cfg";
+	if (rules.exists("warconfig"))
 		configstr = this.rules.get_string("warconfig");
-	}
+
 	ConfigFile cfg = ConfigFile(configstr);
+	cfg.loadFile(configstr);
 
 	//how long to wait for everyone to spawn in?
 	s32 warmUpTimeSeconds = cfg.read_s32("warmup_time", 30);


### PR DESCRIPTION
## Description
Vanilla code does not allow loading the configuration file for CTF/TTH from mods; this fix corrects that.

The change was made to resemble similar code from TDM.as.

## Steps to test or reproduce
Change any value in config file and try to load it from mod.