### PR TITLE
fix: inability to climb on some things correctly

### DIFF
--- a/Entities/Characters/MovementScripts/RunnerMovement.as
+++ b/Entities/Characters/MovementScripts/RunnerMovement.as
@@ -831,6 +831,8 @@ bool checkForSolidMapBlob(CMap@ map, Vec2f pos, CBlob@ blob = null)
 				Vec2f runnerPos = blob.getPosition();
 				Vec2f platPos = _tempBlob.getPosition();
 
+				angle = Maths::FMod(Maths::FMod(angle, 360.0f) + 360.0f, 360.0f);
+
 				if (angle == 90.0f && runnerPos.x > platPos.x && (blob.isKeyPressed(key_left) || blob.wasKeyPressed(key_left)))
 				{
 					// platform is facing right

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -306,7 +306,7 @@ class PNGLoader
 			case map_colors::platform_up:    autotile(offset); spawnBlob(map, "wooden_platform", offset, 255, true); break;
 			case map_colors::platform_right: autotile(offset); spawnBlob(map, "wooden_platform", offset, 255, true, Vec2f_zero,  90); break;
 			case map_colors::platform_down:  autotile(offset); spawnBlob(map, "wooden_platform", offset, 255, true, Vec2f_zero, 180); break;
-			case map_colors::platform_left:  autotile(offset); spawnBlob(map, "wooden_platform", offset, 255, true, Vec2f_zero, -90); break;
+			case map_colors::platform_left:  autotile(offset); spawnBlob(map, "wooden_platform", offset, 255, true, Vec2f_zero, 270); break;
 
 			// Doors
 			case map_colors::wooden_door_h_blue:   autotile(offset); spawnBlob(map, "wooden_door", offset,   0, true); break;


### PR DESCRIPTION
Fixes not being able to climb some platforms when loaded by map loaders. Additionally added some math in RunnerMovement.as to prevent negative angles from being an issue in the future, however, the fix should work with only the changes in BasePNGLoader.as.

## Steps to Test or Reproduce
1. Load a map with platforms facing to the left
2. Try to climb on the platforms
3. Cannot climb the platforms
